### PR TITLE
PC-5926: Add AlertSilence object

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -67,10 +67,11 @@ type M2MAppCredentials struct {
 
 // List of available objects in API.
 const (
-	ObjectSLO         Object = "SLO"
-	ObjectService     Object = "Service"
-	ObjectAgent       Object = "Agent"
-	ObjectAlertPolicy Object = "AlertPolicy"
+	ObjectSLO          Object = "SLO"
+	ObjectService      Object = "Service"
+	ObjectAgent        Object = "Agent"
+	ObjectAlertPolicy  Object = "AlertPolicy"
+	ObjectAlertSilence Object = "AlertSilence"
 	// ObjectAlert represents object used only to return list of Alerts. Applying and deleting alerts is disabled.
 	ObjectAlert Object = "Alert"
 	// ObjectProject represents object used only to return list of Projects.
@@ -97,6 +98,7 @@ func getAllObjects() []Object {
 		ObjectProject,
 		ObjectMetricSource,
 		ObjectAlertPolicy,
+		ObjectAlertSilence,
 		ObjectAlert,
 		// @todo: Backward compatibility. Support for kind Integration should be removed with PC-1805.
 		ObjectIntegration,
@@ -112,12 +114,13 @@ func getAllObjects() []Object {
 
 func ObjectName(apiObject string) Object {
 	objects := map[string]Object{
-		"slo":         ObjectSLO,
-		"service":     ObjectService,
-		"agent":       ObjectAgent,
-		"alertpolicy": ObjectAlertPolicy,
-		"alert":       ObjectAlert,
-		"project":     ObjectProject,
+		"slo":          ObjectSLO,
+		"service":      ObjectService,
+		"agent":        ObjectAgent,
+		"alertpolicy":  ObjectAlertPolicy,
+		"alertsilence": ObjectAlertSilence,
+		"alert":        ObjectAlert,
+		"project":      ObjectProject,
 		// @todo: Backward compatibility. Support for kind Integration should be removed with PC-1805.
 		"integration": ObjectIntegration,
 		"alertmethod": ObjectAlertMethod,


### PR DESCRIPTION
Summary
---
File `sdk.go` was moved from n9 to nobl9-go. This is the only change regarding `AlertSilence` which I'm going to make in this repository. Rest of implementation (v1alpha model) will be done in N9 repository.

**Please note:** It seems that not all code was moved from N9 to Nobl9-go repo and it's not ready to switch to use it (for example missing validation rules, missing Annotation model etc.)