### PR TITLE
PC-5799 Add objective name to threshold base

### DIFF
--- a/slo.go
+++ b/slo.go
@@ -37,6 +37,7 @@ type MetricSourceSpec struct {
 type ThresholdBase struct {
 	DisplayName string  `json:"displayName"`
 	Value       float64 `json:"value"`
+	Name        string  `json:"name"`
 }
 
 // Threshold represents single threshold for SLO, for internal usage


### PR DESCRIPTION
Allow terraform-provider to enhance SLOs with objectives names.