### PR TITLE
PC-7440: Add parameter allowing to filter system/user annotations for get request

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -51,6 +51,7 @@ const (
 	QueryKeyDryRun            = "dry_run"
 	QueryKeyTextSearch        = "text_search"
 	QueryKeySystemAnnotations = "system_annotations"
+	QueryKeyUserAnnotations   = "user_annotations"
 )
 
 // ProjectsWildcard is used in HeaderProject when requesting for all projects.


### PR DESCRIPTION
Summary
--
Allow to filter system annotations in GET request. By default system annotations are not returned with API.