### PR TITLE
fix error API error handling

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -725,7 +725,7 @@ func getResponseServerError(resp *http.Response) error {
 		return fmt.Errorf("request finished with status code: %d", resp.StatusCode)
 	}
 	msg := bytes.TrimSpace(body)
-	if errors.As(errors.New(string(msg)), &ErrConcurrencyIssue) {
+	if string(msg) == ErrConcurrencyIssue.Error() {
 		return ErrConcurrencyIssue
 	}
 	return fmt.Errorf("request finished with status code: %d and message: %s", resp.StatusCode, msg)


### PR DESCRIPTION
Casting the API response body to ErrConcurrencyIssue causes any error to be of type ErrConcurrencyIssue and the actual error message to be ignored.