### PR TITLE
PC-7859: Additional flags for alerting

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -335,19 +335,20 @@ func (c *Client) GetObjectWithParams(
 		}
 		response.Objects = content
 
-		if _, exists := resp.Header[HeaderTruncatedLimitMax]; exists {
-			if truncatedValue := resp.Header.Get(HeaderTruncatedLimitMax); truncatedValue != "" {
-				truncatedMax, err := strconv.Atoi(truncatedValue)
-				if err != nil {
-					return response, fmt.Errorf(
-						"'%s' header value: '%s' is not a valid integer",
-						HeaderTruncatedLimitMax,
-						truncatedValue,
-					)
-				}
-				response.TruncatedMax = truncatedMax
-			}
+		if _, exists := resp.Header[HeaderTruncatedLimitMax]; !exists {
+			return response, nil
 		}
+
+		truncatedValue := resp.Header.Get(HeaderTruncatedLimitMax)
+		truncatedMax, err := strconv.Atoi(truncatedValue)
+		if err != nil {
+			return response, fmt.Errorf(
+				"'%s' header value: '%s' is not a valid integer",
+				HeaderTruncatedLimitMax,
+				truncatedValue,
+			)
+		}
+		response.TruncatedMax = truncatedMax
 		return response, nil
 	case resp.StatusCode == http.StatusBadRequest,
 		resp.StatusCode == http.StatusUnprocessableEntity,


### PR DESCRIPTION
## JIRA PC-7859
### Summary
- Introduced possibility to decide what sdk flags can be passed wit `getObject()`.
- Additional sdk flags required for alerting.
- New response header to let know that response was truncated to some max limit.

Required by this change https://github.com/nobl9/n9/pull/10312