### PR TITLE
PC-8951 optimize mem usage by IsDNS1123Label func

### DIFF
--- a/manifest/v1alpha/validator.go
+++ b/manifest/v1alpha/validator.go
@@ -217,6 +217,7 @@ const (
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
 // IsDNS1123Label tests for a string that conforms to the definition of a label in DNS (RFC 1123).
+// nolint:lll
 // Source: https://github.com/kubernetes/kubernetes/blob/fdb2cb4c8832da1499069bda918c014762d8ac05/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
 func IsDNS1123Label(value string) []string {
 	var errs []string


### PR DESCRIPTION
### Self-check
- [x] Have I checked if my changes affect performance or resources usage?

### Motivation

The `IsDNS1123Label` function in v1alpha/validator package compiled the regexp for every call. Now compiling the regexp for validation DNS label is static.

### Summary

before:
![Screenshot from 2023-07-13 10-48-30](https://github.com/nobl9/n9/assets/100848248/9228c4fa-5423-4c80-8d94-bd3d78e04d19)

after:
![image](https://github.com/nobl9/n9/assets/100848248/beb6a9cc-0c26-4af3-9229-d935995238ac)


