### PR TITLE
PC-9893: Change `time_to_burn_entire_budget` measurement operator for alerting

### DIFF
--- a/manifest/v1alpha/validator.go
+++ b/manifest/v1alpha/validator.go
@@ -2225,8 +2225,8 @@ func alertPolicyConditionOperatorLimitsValidation(sl v.StructLevel) {
 			sl.ReportError(condition, "op", "Operator", "valueOperatorBurnRateGreaterThanEqualRequired", "")
 		}
 	case MeasurementTimeToBurnEntireBudget.String():
-		if condition.Operator != LessThan.String() {
-			sl.ReportError(condition, "op", "Operator", "valueOperatorForTimeToBurnEntireBudgetLessThanRequired", "")
+		if condition.Operator != LessThanEqual.String() {
+			sl.ReportError(condition, "op", "Operator", "valueOperatorForTimeToBurnEntireBudgetLessThanEqualRequired", "")
 		}
 	}
 }

--- a/manifest/v1alpha/validator_test.go
+++ b/manifest/v1alpha/validator_test.go
@@ -974,7 +974,7 @@ func TestAlertConditionOpSupport(t *testing.T) {
 			Measurement:      MeasurementTimeToBurnEntireBudget.String(),
 			LastsForDuration: "10m",
 			Value:            "30m",
-		}: {"lt"},
+		}: {"lte"},
 		{
 			Measurement:      MeasurementTimeToBurnBudget.String(),
 			LastsForDuration: "10m",


### PR DESCRIPTION
## TLDR
This PR changed operator for `time_to_burn_entire_budget` measurement.

## Motivation
Reason `lte` is better suited than `lt` is that with thte maximum possible exhaustion we're going to be predicting the burn of Total Error Budget Allowance. 