### PR TITLE
PC-10377: Turn on strict mode for objects decoding

### DIFF
--- a/manifest/v1alpha/parser.go
+++ b/manifest/v1alpha/parser.go
@@ -1,6 +1,7 @@
 package v1alpha
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -10,13 +11,17 @@ import (
 	"github.com/nobl9/nobl9-go/manifest"
 )
 
-type unmarshalFunc func(data []byte, v interface{}) error
+type unmarshalFunc func(v interface{}) error
 
 func ParseObject(data []byte, kind manifest.Kind, format manifest.ObjectFormat) (manifest.Object, error) {
 	var unmarshal unmarshalFunc
 	switch format {
 	case manifest.ObjectFormatJSON:
-		unmarshal = json.Unmarshal
+		unmarshal = func(v interface{}) error {
+			dec := json.NewDecoder(bytes.NewReader(data))
+			dec.DisallowUnknownFields()
+			return dec.Decode(v)
+		}
 	case manifest.ObjectFormatYAML:
 		// Workaround for https://github.com/goccy/go-yaml/issues/313.
 		// If the library changes its interpretation of empty pointer fields,
@@ -26,7 +31,9 @@ func ParseObject(data []byte, kind manifest.Kind, format manifest.ObjectFormat) 
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to convert YAML to JSON")
 		}
-		unmarshal = json.Unmarshal
+		unmarshal = func(v interface{}) error {
+			return yaml.UnmarshalWithOptions(data, v, yaml.Strict())
+		}
 	default:
 		return nil, errors.Errorf("unsupported format: %s", format)
 	}
@@ -38,31 +45,31 @@ func ParseObject(data []byte, kind manifest.Kind, format manifest.ObjectFormat) 
 	//exhaustive:enforce
 	switch kind {
 	case manifest.KindService:
-		object, err = genericParseObject[Service](data, unmarshal)
+		object, err = genericParseObject[Service](unmarshal)
 	case manifest.KindSLO:
-		object, err = genericParseObject[SLO](data, unmarshal)
+		object, err = genericParseObject[SLO](unmarshal)
 	case manifest.KindProject:
-		object, err = genericParseObject[Project](data, unmarshal)
+		object, err = genericParseObject[Project](unmarshal)
 	case manifest.KindAgent:
-		object, err = genericParseObject[Agent](data, unmarshal)
+		object, err = genericParseObject[Agent](unmarshal)
 	case manifest.KindDirect:
-		object, err = genericParseObject[Direct](data, unmarshal)
+		object, err = genericParseObject[Direct](unmarshal)
 	case manifest.KindAlert:
-		object, err = genericParseObject[Alert](data, unmarshal)
+		object, err = genericParseObject[Alert](unmarshal)
 	case manifest.KindAlertMethod:
-		object, err = genericParseObject[AlertMethod](data, unmarshal)
+		object, err = genericParseObject[AlertMethod](unmarshal)
 	case manifest.KindAlertPolicy:
-		object, err = genericParseObject[AlertPolicy](data, unmarshal)
+		object, err = genericParseObject[AlertPolicy](unmarshal)
 	case manifest.KindAlertSilence:
-		object, err = genericParseObject[AlertSilence](data, unmarshal)
+		object, err = genericParseObject[AlertSilence](unmarshal)
 	case manifest.KindRoleBinding:
-		object, err = genericParseObject[RoleBinding](data, unmarshal)
+		object, err = genericParseObject[RoleBinding](unmarshal)
 	case manifest.KindDataExport:
-		object, err = genericParseObject[DataExport](data, unmarshal)
+		object, err = genericParseObject[DataExport](unmarshal)
 	case manifest.KindAnnotation:
-		object, err = genericParseObject[Annotation](data, unmarshal)
+		object, err = genericParseObject[Annotation](unmarshal)
 	case manifest.KindUserGroup:
-		object, err = genericParseObject[UserGroup](data, unmarshal)
+		object, err = genericParseObject[UserGroup](unmarshal)
 	default:
 		return nil, fmt.Errorf("%s is %w", kind, manifest.ErrInvalidKind)
 	}
@@ -72,9 +79,9 @@ func ParseObject(data []byte, kind manifest.Kind, format manifest.ObjectFormat) 
 	return object, nil
 }
 
-func genericParseObject[T manifest.Object](data []byte, unmarshal unmarshalFunc) (T, error) {
+func genericParseObject[T manifest.Object](unmarshal unmarshalFunc) (T, error) {
 	var object T
-	if err := unmarshal(data, &object); err != nil {
+	if err := unmarshal(&object); err != nil {
 		return object, err
 	}
 	return object, nil

--- a/manifest/v1alpha/parser_test.go
+++ b/manifest/v1alpha/parser_test.go
@@ -34,6 +34,24 @@ func TestParseObject(t *testing.T) {
 	}
 }
 
+func TestParseObject_ErrorOnNonExistingKeys(t *testing.T) {
+	filename := "project_with_non_existing_keys"
+
+	t.Run("json", func(t *testing.T) {
+		jsonData, format := readParserTestFile(t, filename+".json")
+		_, err := ParseObject(jsonData, manifest.KindProject, format)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "horsepower")
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		yamlData, format := readParserTestFile(t, filename+".yaml")
+		_, err := ParseObject(yamlData, manifest.KindProject, format)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "horsepower")
+	})
+}
+
 func readParserTestFile(t *testing.T, filename string) ([]byte, manifest.ObjectFormat) {
 	t.Helper()
 	data, err := parserTestData.ReadFile(filepath.Join("test_data", "parser", filename))

--- a/manifest/v1alpha/test_data/parser/cloudwatch_agent.json
+++ b/manifest/v1alpha/test_data/parser/cloudwatch_agent.json
@@ -7,7 +7,7 @@
     "project": "default"
   },
   "spec": {
-    "cloudwatch": {},
+    "cloudWatch": {},
     "sourceOf": [
       "Metrics"
     ]

--- a/manifest/v1alpha/test_data/parser/cloudwatch_agent.yaml
+++ b/manifest/v1alpha/test_data/parser/cloudwatch_agent.yaml
@@ -5,6 +5,6 @@ metadata:
   displayName: cloudWatch-agent
   project: default
 spec:
-  cloudwatch: {}
+  cloudWatch: {}
   sourceOf:
     - Metrics

--- a/manifest/v1alpha/test_data/parser/project_with_non_existing_keys.json
+++ b/manifest/v1alpha/test_data/parser/project_with_non_existing_keys.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "n9/v1alpha",
+  "kind": "Project",
+  "metadata": {
+    "name": "cloudwatch-agent",
+    "horsepower": 100
+  },
+  "spec": {
+    "description": ""
+  }
+}

--- a/manifest/v1alpha/test_data/parser/project_with_non_existing_keys.yaml
+++ b/manifest/v1alpha/test_data/parser/project_with_non_existing_keys.yaml
@@ -1,0 +1,7 @@
+apiVersion: n9/v1alpha
+kind: Project
+metadata:
+  name: default
+  horsepower: 100
+spec:
+  description:

--- a/manifest/v1alpha/test_data/parser/redshift_agent.json
+++ b/manifest/v1alpha/test_data/parser/redshift_agent.json
@@ -7,7 +7,7 @@
     "project": "default"
   },
   "spec": {
-    "cloudwatch": {},
+    "redshift": {},
     "sourceOf": [
       "Metrics"
     ]

--- a/manifest/v1alpha/test_data/parser/redshift_agent.yaml
+++ b/manifest/v1alpha/test_data/parser/redshift_agent.yaml
@@ -5,6 +5,6 @@ metadata:
   displayName: redshift-agent
   project: default
 spec:
-  cloudwatch: {}
+  redshift: {}
   sourceOf:
     - Metrics

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -113,7 +113,7 @@ func TestClient_GetObjects_UserGroupsEndpoint(t *testing.T) {
 	responsePayload := []manifest.Object{
 		v1alpha.UserGroup{
 			APIVersion: v1alpha.APIVersion,
-			Kind:       manifest.KindService,
+			Kind:       manifest.KindUserGroup,
 			Metadata: v1alpha.UserGroupMetadata{
 				Name: "service1",
 			},


### PR DESCRIPTION
It's important for SDK users (that includes sloctl) to know when a field they're defining in their YAML/JSON definitions doesn't exist in an objects' struct definition. This PR turns on strict mode for decoding raw objects, so that it'd return an error when a field is not found in struct definition.