### PR TITLE
PC-10510: add resourceID and metricNamepsace validation for AzureMonitor SLOs

### DIFF
--- a/manifest/v1alpha/validator.go
+++ b/manifest/v1alpha/validator.go
@@ -666,12 +666,12 @@ func sloSpecStructLevelThousandEyesValidation(sl v.StructLevel, sloSpec SLOSpec)
 }
 
 func sloSpecStructLevelAzureMonitorValidation(sl v.StructLevel, sloSpec SLOSpec) {
-	if !haveAzureMonitorCountMetricSpecTheSameResource(sloSpec) {
+	if !haveAzureMonitorCountMetricSpecTheSameResourceIDAndMetricNamespace(sloSpec) {
 		sl.ReportError(
 			sloSpec.CountMetrics,
 			"objectives",
 			"Objectives",
-			"azureMonitorCountMetricsEqualResource",
+			"azureMonitorCountMetricsEqualResourceIDAndMetricNamespace",
 			"",
 		)
 	}
@@ -1402,9 +1402,9 @@ func areSumoLogicTimesliceValuesEqual(sloSpec SLOSpec) bool {
 	return true
 }
 
-// haveAzureMonitorCountMetricSpecTheSameResource checks if good/bad query has the same resourceID and metricNamespace
-// as total query
-func haveAzureMonitorCountMetricSpecTheSameResource(sloSpec SLOSpec) bool {
+// haveAzureMonitorCountMetricSpecTheSameResourceIDAndMetricNamespace checks if good/bad query has the same resourceID
+// and metricNamespace as total query
+func haveAzureMonitorCountMetricSpecTheSameResourceIDAndMetricNamespace(sloSpec SLOSpec) bool {
 	for _, objective := range sloSpec.Objectives {
 		if objective.CountMetrics == nil {
 			continue

--- a/manifest/v1alpha/validator_test.go
+++ b/manifest/v1alpha/validator_test.go
@@ -1168,7 +1168,7 @@ func TestAzureMonitorSloSpecValidation(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			isValid := haveAzureMonitorCountMetricSpecTheSameResource(tc.sloSpec)
+			isValid := haveAzureMonitorCountMetricSpecTheSameResourceIDAndMetricNamespace(tc.sloSpec)
 			assert.Equal(t, tc.isValid, isValid)
 		})
 	}


### PR DESCRIPTION
### Summary
This PR introduces a constraint on AzureMonitor SLO spec that defines additional validation rules for `resourceID` and `metricNamespace`. Those fields must be equal across good/bad total queries.