### PR TITLE
PC-10574: Move manifest funcs to object level

### DIFF
--- a/manifest/object.go
+++ b/manifest/object.go
@@ -19,6 +19,10 @@ type Object interface {
 	GetName() string
 	// Validate performs static validation of the Object.
 	Validate() error
+	// GetManifestSource returns the source of the Object's manifest.
+	GetManifestSource() string
+	// SetManifestSource sets the source of the Object's manifest.
+	SetManifestSource(src string) Object
 }
 
 // ProjectScopedObject an Object which is tied to a specific KindProject.

--- a/manifest/object_test.go
+++ b/manifest/object_test.go
@@ -154,19 +154,17 @@ type customObject struct {
 	validationError error
 }
 
-func (c customObject) GetVersion() string { return "" }
-
-func (c customObject) GetKind() Kind { return c.kind }
-
-func (c customObject) GetName() string { return c.name }
-
-func (c customObject) Validate() error { return c.validationError }
+func (c customObject) GetVersion() string              { return "" }
+func (c customObject) GetKind() Kind                   { return c.kind }
+func (c customObject) GetName() string                 { return c.name }
+func (c customObject) Validate() error                 { return c.validationError }
+func (c customObject) GetManifestSource() string       { return "" }
+func (c customObject) SetManifestSource(string) Object { return c }
 
 type customProjectScopedObject struct {
 	customObject
 	project string
 }
 
-func (c customProjectScopedObject) GetProject() string { return c.project }
-
+func (c customProjectScopedObject) GetProject() string               { return c.project }
 func (c customProjectScopedObject) SetProject(project string) Object { c.project = project; return c }

--- a/manifest/v1alpha/agent_object.go
+++ b/manifest/v1alpha/agent_object.go
@@ -25,6 +25,15 @@ func (a Agent) Validate() error {
 	return validator.Check(a)
 }
 
+func (a Agent) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a Agent) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a Agent) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a Agent) GetOrganization() string {
 
 func (a Agent) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a Agent) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a Agent) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/alert_method_object.go
+++ b/manifest/v1alpha/alert_method_object.go
@@ -25,6 +25,15 @@ func (a AlertMethod) Validate() error {
 	return validator.Check(a)
 }
 
+func (a AlertMethod) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a AlertMethod) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a AlertMethod) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a AlertMethod) GetOrganization() string {
 
 func (a AlertMethod) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a AlertMethod) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a AlertMethod) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/alert_object.go
+++ b/manifest/v1alpha/alert_object.go
@@ -25,6 +25,15 @@ func (a Alert) Validate() error {
 	return validator.Check(a)
 }
 
+func (a Alert) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a Alert) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a Alert) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a Alert) GetOrganization() string {
 
 func (a Alert) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a Alert) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a Alert) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/alert_policy_object.go
+++ b/manifest/v1alpha/alert_policy_object.go
@@ -25,6 +25,15 @@ func (a AlertPolicy) Validate() error {
 	return validator.Check(a)
 }
 
+func (a AlertPolicy) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a AlertPolicy) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a AlertPolicy) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a AlertPolicy) GetOrganization() string {
 
 func (a AlertPolicy) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a AlertPolicy) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a AlertPolicy) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/alert_silence_object.go
+++ b/manifest/v1alpha/alert_silence_object.go
@@ -25,6 +25,15 @@ func (a AlertSilence) Validate() error {
 	return validator.Check(a)
 }
 
+func (a AlertSilence) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a AlertSilence) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a AlertSilence) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a AlertSilence) GetOrganization() string {
 
 func (a AlertSilence) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a AlertSilence) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a AlertSilence) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/annotation_object.go
+++ b/manifest/v1alpha/annotation_object.go
@@ -25,6 +25,15 @@ func (a Annotation) Validate() error {
 	return validator.Check(a)
 }
 
+func (a Annotation) GetManifestSource() string {
+	return a.ManifestSource
+}
+
+func (a Annotation) SetManifestSource(src string) manifest.Object {
+	a.ManifestSource = src
+	return a
+}
+
 func (a Annotation) GetProject() string {
 	return a.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (a Annotation) GetOrganization() string {
 
 func (a Annotation) SetOrganization(org string) manifest.Object {
 	a.Organization = org
-	return a
-}
-
-func (a Annotation) GetManifestSource() string {
-	return a.ManifestSource
-}
-
-func (a Annotation) SetManifestSource(src string) manifest.Object {
-	a.ManifestSource = src
 	return a
 }

--- a/manifest/v1alpha/data_export_object.go
+++ b/manifest/v1alpha/data_export_object.go
@@ -25,6 +25,15 @@ func (d DataExport) Validate() error {
 	return validator.Check(d)
 }
 
+func (d DataExport) GetManifestSource() string {
+	return d.ManifestSource
+}
+
+func (d DataExport) SetManifestSource(src string) manifest.Object {
+	d.ManifestSource = src
+	return d
+}
+
 func (d DataExport) GetProject() string {
 	return d.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (d DataExport) GetOrganization() string {
 
 func (d DataExport) SetOrganization(org string) manifest.Object {
 	d.Organization = org
-	return d
-}
-
-func (d DataExport) GetManifestSource() string {
-	return d.ManifestSource
-}
-
-func (d DataExport) SetManifestSource(src string) manifest.Object {
-	d.ManifestSource = src
 	return d
 }

--- a/manifest/v1alpha/direct.go
+++ b/manifest/v1alpha/direct.go
@@ -30,6 +30,8 @@ type PublicDirect struct {
 	Metadata   DirectMetadata   `json:"metadata"`
 	Spec       PublicDirectSpec `json:"spec"`
 	Status     *DirectStatus    `json:"status,omitempty"`
+
+	ManifestSource string `json:"manifestSrc,omitempty"`
 }
 
 type DirectMetadata struct {

--- a/manifest/v1alpha/direct_object.go
+++ b/manifest/v1alpha/direct_object.go
@@ -25,6 +25,15 @@ func (d Direct) Validate() error {
 	return validator.Check(d)
 }
 
+func (d Direct) GetManifestSource() string {
+	return d.ManifestSource
+}
+
+func (d Direct) SetManifestSource(src string) manifest.Object {
+	d.ManifestSource = src
+	return d
+}
+
 func (d Direct) GetProject() string {
 	return d.Metadata.Project
 }
@@ -40,15 +49,6 @@ func (d Direct) GetOrganization() string {
 
 func (d Direct) SetOrganization(org string) manifest.Object {
 	d.Organization = org
-	return d
-}
-
-func (d Direct) GetManifestSource() string {
-	return d.ManifestSource
-}
-
-func (d Direct) SetManifestSource(src string) manifest.Object {
-	d.ManifestSource = src
 	return d
 }
 
@@ -70,6 +70,15 @@ func (p PublicDirect) GetName() string {
 
 func (p PublicDirect) Validate() error {
 	return validator.Check(p)
+}
+
+func (p PublicDirect) GetManifestSource() string {
+	return p.ManifestSource
+}
+
+func (p PublicDirect) SetManifestSource(src string) manifest.Object {
+	p.ManifestSource = src
+	return p
 }
 
 func (p PublicDirect) GetProject() string {

--- a/manifest/v1alpha/errors.go
+++ b/manifest/v1alpha/errors.go
@@ -14,13 +14,11 @@ import (
 func NewObjectError(object manifest.Object, errs []error) error {
 	oErr := &ObjectError{
 		Object: ObjectMetadata{
-			Kind: object.GetKind(),
-			Name: object.GetName(),
+			Kind:   object.GetKind(),
+			Name:   object.GetName(),
+			Source: object.GetManifestSource(),
 		},
 		Errors: errs,
-	}
-	if v, ok := object.(ObjectContext); ok {
-		oErr.Object.Source = v.GetManifestSource()
 	}
 	if v, ok := object.(manifest.ProjectScopedObject); ok {
 		oErr.Object.IsProjectScoped = true

--- a/manifest/v1alpha/objects.go
+++ b/manifest/v1alpha/objects.go
@@ -13,6 +13,4 @@ const APIVersion = "n9/v1alpha"
 type ObjectContext interface {
 	GetOrganization() string
 	SetOrganization(org string) manifest.Object
-	GetManifestSource() string
-	SetManifestSource(src string) manifest.Object
 }

--- a/manifest/v1alpha/project/project_object.go
+++ b/manifest/v1alpha/project/project_object.go
@@ -4,7 +4,12 @@ package project
 
 import (
 	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 )
+
+// Ensure interfaces are implemented.
+var _ manifest.Object = Project{}
+var _ v1alpha.ObjectContext = Project{}
 
 func (p Project) GetVersion() string {
 	return p.APIVersion
@@ -22,20 +27,20 @@ func (p Project) Validate() error {
 	return validate(p)
 }
 
-func (p Project) GetOrganization() string {
-	return p.Organization
-}
-
-func (p Project) SetOrganization(org string) manifest.Object {
-	p.Organization = org
-	return p
-}
-
 func (p Project) GetManifestSource() string {
 	return p.ManifestSource
 }
 
 func (p Project) SetManifestSource(src string) manifest.Object {
 	p.ManifestSource = src
+	return p
+}
+
+func (p Project) GetOrganization() string {
+	return p.Organization
+}
+
+func (p Project) SetOrganization(org string) manifest.Object {
+	p.Organization = org
 	return p
 }

--- a/manifest/v1alpha/role_binding_object.go
+++ b/manifest/v1alpha/role_binding_object.go
@@ -24,20 +24,20 @@ func (r RoleBinding) Validate() error {
 	return validator.Check(r)
 }
 
-func (r RoleBinding) GetOrganization() string {
-	return r.Organization
-}
-
-func (r RoleBinding) SetOrganization(org string) manifest.Object {
-	r.Organization = org
-	return r
-}
-
 func (r RoleBinding) GetManifestSource() string {
 	return r.ManifestSource
 }
 
 func (r RoleBinding) SetManifestSource(src string) manifest.Object {
 	r.ManifestSource = src
+	return r
+}
+
+func (r RoleBinding) GetOrganization() string {
+	return r.Organization
+}
+
+func (r RoleBinding) SetOrganization(org string) manifest.Object {
+	r.Organization = org
 	return r
 }

--- a/manifest/v1alpha/service/service_object.go
+++ b/manifest/v1alpha/service/service_object.go
@@ -2,11 +2,15 @@
 
 package service
 
-import "github.com/nobl9/nobl9-go/manifest"
+import (
+	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
+)
 
 // Ensure interfaces are implemented.
 var _ manifest.Object = Service{}
 var _ manifest.ProjectScopedObject = Service{}
+var _ v1alpha.ObjectContext = Service{}
 
 func (s Service) GetVersion() string {
 	return s.APIVersion
@@ -24,6 +28,15 @@ func (s Service) Validate() error {
 	return validate(s)
 }
 
+func (s Service) GetManifestSource() string {
+	return s.ManifestSource
+}
+
+func (s Service) SetManifestSource(src string) manifest.Object {
+	s.ManifestSource = src
+	return s
+}
+
 func (s Service) GetProject() string {
 	return s.Metadata.Project
 }
@@ -39,14 +52,5 @@ func (s Service) GetOrganization() string {
 
 func (s Service) SetOrganization(org string) manifest.Object {
 	s.Organization = org
-	return s
-}
-
-func (s Service) GetManifestSource() string {
-	return s.ManifestSource
-}
-
-func (s Service) SetManifestSource(src string) manifest.Object {
-	s.ManifestSource = src
 	return s
 }

--- a/manifest/v1alpha/slo_object.go
+++ b/manifest/v1alpha/slo_object.go
@@ -25,6 +25,15 @@ func (s SLO) Validate() error {
 	return validator.Check(s)
 }
 
+func (s SLO) GetManifestSource() string {
+	return s.ManifestSource
+}
+
+func (s SLO) SetManifestSource(src string) manifest.Object {
+	s.ManifestSource = src
+	return s
+}
+
 func (s SLO) GetProject() string {
 	return s.Metadata.Project
 }
@@ -40,14 +49,5 @@ func (s SLO) GetOrganization() string {
 
 func (s SLO) SetOrganization(org string) manifest.Object {
 	s.Organization = org
-	return s
-}
-
-func (s SLO) GetManifestSource() string {
-	return s.ManifestSource
-}
-
-func (s SLO) SetManifestSource(src string) manifest.Object {
-	s.ManifestSource = src
 	return s
 }

--- a/manifest/v1alpha/user_groups_object.go
+++ b/manifest/v1alpha/user_groups_object.go
@@ -24,20 +24,20 @@ func (u UserGroup) Validate() error {
 	return validator.Check(u)
 }
 
-func (u UserGroup) GetOrganization() string {
-	return u.Organization
-}
-
-func (u UserGroup) SetOrganization(org string) manifest.Object {
-	u.Organization = org
-	return u
-}
-
 func (u UserGroup) GetManifestSource() string {
 	return u.ManifestSource
 }
 
 func (u UserGroup) SetManifestSource(src string) manifest.Object {
 	u.ManifestSource = src
+	return u
+}
+
+func (u UserGroup) GetOrganization() string {
+	return u.Organization
+}
+
+func (u UserGroup) SetOrganization(org string) manifest.Object {
+	u.Organization = org
 	return u
 }

--- a/scripts/generate-object-impl.tpl
+++ b/scripts/generate-object-impl.tpl
@@ -31,6 +31,15 @@ func ({{ .Receiver }} {{ .Name }}) GetName() string {
 func ({{ .Receiver }} {{ .Name }}) Validate() error {
   return validator.Check({{ .Receiver }})
 }
+
+func ({{ .Receiver }} {{ .Name }}) GetManifestSource() string {
+  return {{ .Receiver }}.ManifestSource
+}
+
+func ({{ .Receiver }} {{ .Name }}) SetManifestSource(src string) manifest.Object {
+{{ .Receiver }}.ManifestSource = src
+  return {{ .Receiver }}
+}
 {{- end }}
 
 {{- if .GenerateProjectScopedObject }}
@@ -53,15 +62,6 @@ func ({{ .Receiver }} {{ .Name }}) GetOrganization() string {
 
 func ({{ .Receiver }} {{ .Name }}) SetOrganization(org string) manifest.Object {
   {{ .Receiver }}.Organization = org
-  return {{ .Receiver }}
-}
-
-func ({{ .Receiver }} {{ .Name }}) GetManifestSource() string {
-  return {{ .Receiver }}.ManifestSource
-}
-
-func ({{ .Receiver }} {{ .Name }}) SetManifestSource(src string) manifest.Object {
-  {{ .Receiver }}.ManifestSource = src
   return {{ .Receiver }}
 }
 {{- end }}

--- a/sdk/parser.go
+++ b/sdk/parser.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nobl9/nobl9-go/manifest"
-	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	v1alphaParser "github.com/nobl9/nobl9-go/manifest/v1alpha/parser"
 )
 
@@ -64,13 +63,8 @@ func processRawDefinitions(rds rawDefinitions) ([]manifest.Object, error) {
 
 // annotateWithManifestSource annotates manifest.Object with the manifest definition source.
 func annotateWithManifestSource(object manifest.Object, source string) manifest.Object {
-	switch object.GetVersion() {
-	case "n9/v1alpha":
-		if v, ok := object.(v1alpha.ObjectContext); ok {
-			if v.GetManifestSource() == "" && source != "" {
-				object = v.SetManifestSource(source)
-			}
-		}
+	if object.GetManifestSource() == "" && source != "" {
+		object = object.SetManifestSource(source)
 	}
 	return object
 }


### PR DESCRIPTION
Manifest source is something we'll want to keep throughout all object versions, and as such it should be moved to `manifest` level.