### PR TITLE
PC-11208: Remove dive from structs

### DIFF
--- a/manifest/v1alpha/alert_method.go
+++ b/manifest/v1alpha/alert_method.go
@@ -44,7 +44,7 @@ type PublicAlertMethodStatus struct {
 // AlertMethodSpec represents content of AlertMethod's Spec.
 type AlertMethodSpec struct {
 	Description string                 `json:"description" validate:"description" example:"Sends notification"`
-	Webhook     *WebhookAlertMethod    `json:"webhook,omitempty" validate:"omitempty,dive"`
+	Webhook     *WebhookAlertMethod    `json:"webhook,omitempty" validate:"omitempty"`
 	PagerDuty   *PagerDutyAlertMethod  `json:"pagerduty,omitempty"`
 	Slack       *SlackAlertMethod      `json:"slack,omitempty"`
 	Discord     *DiscordAlertMethod    `json:"discord,omitempty"`

--- a/manifest/v1alpha/alert_silence.go
+++ b/manifest/v1alpha/alert_silence.go
@@ -31,8 +31,8 @@ type AlertSilenceMetadata struct {
 type AlertSilenceSpec struct {
 	Description string                        `json:"description" validate:"description"`
 	Slo         string                        `json:"slo" validate:"required"`
-	AlertPolicy AlertSilenceAlertPolicySource `json:"alertPolicy" validate:"required,dive"`
-	Period      AlertSilencePeriod            `json:"period" validate:"required,dive"`
+	AlertPolicy AlertSilenceAlertPolicySource `json:"alertPolicy" validate:"required"`
+	Period      AlertSilencePeriod            `json:"period" validate:"required"`
 }
 
 func (a AlertSilenceSpec) GetParsedDuration() (time.Duration, error) {


### PR DESCRIPTION
A change in behaviour was introduced in go-validator: https://github.com/go-playground/validator/issues/1181 that causes a panic when dive is used on structs. Dive doesn't really have any meaning here, so we can just remove it.