### PR TITLE
PC-10133 Allow equal values in annotation's startTime and endTime

### DIFF
--- a/manifest/v1alpha/annotation/validation.go
+++ b/manifest/v1alpha/annotation/validation.go
@@ -37,20 +37,20 @@ var specValidation = validation.New[Spec](
 		Required().
 		Rules(validation.StringLength(0, 1000)),
 	validation.For(validation.GetSelf[Spec]()).
-		Rules(startTimeAfterEndTime),
+		Rules(endTimeNotBeforeStartTime),
 )
 
 func validate(p Annotation) *v1alpha.ObjectError {
 	return v1alpha.ValidateObject(annotationValidation, p)
 }
 
-const errorCodeStartTimeAfterEndTime validation.ErrorCode = "end_time_after_start_time"
+const errorCodeEndTimeNotBeforeStartTime validation.ErrorCode = "end_time_not_before_start_time"
 
-var startTimeAfterEndTime = validation.NewSingleRule(func(s Spec) error {
-	if s.StartTime.After(s.EndTime) {
+var endTimeNotBeforeStartTime = validation.NewSingleRule(func(s Spec) error {
+	if s.EndTime.Before(s.StartTime) {
 		return &validation.RuleError{
-			Message: fmt.Sprintf(`startTime '%s' must be before endTime '%s'`, s.StartTime, s.EndTime),
-			Code:    errorCodeStartTimeAfterEndTime,
+			Message: fmt.Sprintf(`endTime '%s' must be equal or after startTime '%s'`, s.EndTime, s.StartTime),
+			Code:    errorCodeEndTimeNotBeforeStartTime,
 		}
 	}
 

--- a/manifest/v1alpha/annotation/validation_test.go
+++ b/manifest/v1alpha/annotation/validation_test.go
@@ -117,7 +117,7 @@ func TestSpec_Time(t *testing.T) {
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
 			Prop: "spec",
-			Code: errorCodeStartTimeAfterEndTime,
+			Code: errorCodeEndTimeNotBeforeStartTime,
 		})
 	})
 }


### PR DESCRIPTION
Annotation Spec's startTime and endTime fields values can be equal. I misinterpreted condition on date comparison: 

![image](https://github.com/nobl9/nobl9-go/assets/83642555/288e17f5-1149-44c2-92bf-944ce64a494a)


Fixed code is also consistent with docs: 

![image](https://github.com/nobl9/nobl9-go/assets/83642555/0fc34b77-4508-4765-ab53-5cf22512d8c5)

https://docs.nobl9.com/yaml-guide/#alertpolicy