### PR TITLE
PC-10133 Completely assert errors

### DIFF
--- a/internal/testutils/assert.go
+++ b/internal/testutils/assert.go
@@ -109,13 +109,3 @@ func PrependPropertyPath(errs []ExpectedError, path string) []ExpectedError {
 	}
 	return errs
 }
-
-type errorMatch struct {
-	failedMessage         bool
-	failedContainsMessage bool
-	failedCode            bool
-}
-
-func (e errorMatch) matchedCompletely() bool {
-	return !e.failedMessage && !e.failedContainsMessage && !e.failedCode
-}


### PR DESCRIPTION
I encountered that errors asserting method does not require all errors expectations to be asserted. I'am proposing these changes, If we want to go with more strict and IMHO readable/expected assertion.