### PR TITLE
Update renovate automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,7 @@
   // Manager-specific configs:
   // This will run go mod tidy after each go.mod update.
   "postUpdateOptions": ["gomodTidy"],
+  "allowedPostUpgradeCommands": ["^make .*"],
   "postUpgradeTasks": {
     "commands": ["make generate/code"],
     "executionMode": "update"


### PR DESCRIPTION
## Motivation

`postUpgradeTasks` won't run at all unless `allowedPostUpgradeCommands` has at least one regex defined which matches the `commands` option for `postUpgradeTasks`.