### PR TITLE
Revert postUpgradeTasks from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,14 +39,8 @@
       "addLabels": ["javascript"],
     },
   ],
-  // Manager-specific configs:
   // This will run go mod tidy after each go.mod update.
   "postUpdateOptions": ["gomodTidy"],
-  "allowedPostUpgradeCommands": ["^make .*"],
-  "postUpgradeTasks": {
-    "commands": ["make generate/code"],
-    "executionMode": "update"
-  },
   // Custom version extraction from Makefile.
   "regexManagers": [
     {


### PR DESCRIPTION
It turns out these are only enabled for self hosted Renovate instances...