### PR TITLE
feat: Add fields to Agent Status showing newest available agent versions [PC-11737]

### DIFF
--- a/manifest/v1alpha/agent/agent.go
+++ b/manifest/v1alpha/agent/agent.go
@@ -73,9 +73,11 @@ type Spec struct {
 
 // Status holds dynamic content which is not part of the static Agent definition.
 type Status struct {
-	AgentType      string `json:"agentType"`
-	AgentVersion   string `json:"agentVersion,omitempty"`
-	LastConnection string `json:"lastConnection,omitempty"`
+	AgentType                string `json:"agentType"`
+	AgentVersion             string `json:"agentVersion,omitempty"`
+	LastConnection           string `json:"lastConnection,omitempty"`
+	NewestStableAgentVersion string `json:"newestStableAgentVersion,omitempty"`
+	NewestBetaAgentVersion   string `json:"newestBetaAgentVersion,omitempty"`
 }
 
 func (spec Spec) GetType() (v1alpha.DataSourceType, error) {


### PR DESCRIPTION
## Motivation

We want to expose this information through the API, besides release notes and DockerHub/image repositories.

## Summary

Added two fields to `Agent` status struct (as this information is dynamic and not a part of `Agent` definition.)
