### PR TITLE
chore: Interpret git log grep pattern as literal string

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -55,7 +55,7 @@ while IFS= read -r line; do
 		continue
 	fi
 	commit_msg="${BASH_REMATCH[1]}"
-	commit_body=$(git log --grep "$commit_msg" -n1 --pretty="%b")
+	commit_body=$(git log -F --grep "$commit_msg" -n1 --pretty="%b")
 
 	add_notes() {
 		local notes="$1"


### PR DESCRIPTION
 ## Motivation

Commits which had special regex characters, like square braces, were causing the `git log --grep <pattern>` to fail.
We need to interpret these as literal strings, thus `-F` flag, which as per `man git log` says:
> -F, --fixed-strings
    Consider the limiting patterns to be fixed strings (don’t interpret pattern as a regular expression).