### PR TITLE
fix: Revert "chore: Update dependency golangci/golangci-lint to v1.56.1 (#…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_ENUM_VERSION := v0.6.0
 # renovate datasource=github-releases depName=securego/gosec
 GOSEC_VERSION := v2.18.2
 # renovate datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION := v1.56.1
+GOLANGCI_LINT_VERSION := v1.56.0
 # renovate datasource=go depName=golang.org/x/vuln/cmd/govulncheck
 GOVULNCHECK_VERSION := v1.0.4
 # renovate datasource=go depName=golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
## Motivation

This reverts commit 361feaf4821777601e8ab6f983f7be6279a5f979.
It happened due to wrong GH settings.