### PR TITLE
chore: PC-12175 Make honeycomb public in SDK

### DIFF
--- a/manifest/v1alpha/slo/metrics_honeycomb.go
+++ b/manifest/v1alpha/slo/metrics_honeycomb.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nobl9/nobl9-go/internal/validation"
 )
 
-// HoneycombMetric represents metric from Honeycomb. To access this integration, contact support@nobl9.com.
+// HoneycombMetric represents metric from Honeycomb.
 type HoneycombMetric struct {
 	Calculation string `json:"calculation"`
 	Attribute   string `json:"attribute,omitempty"`


### PR DESCRIPTION
## Summary

Honeycomb integration became GA in the platform's 1.69 release, hence comment about beta state of the integration removal in this PR.