### PR TITLE
feat: PC-12274 Add updatedAt to SLO Spec

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -48,6 +48,7 @@ type Spec struct {
 	AlertPolicies   []string       `json:"alertPolicies"`
 	Attachments     []Attachment   `json:"attachments,omitempty"`
 	CreatedAt       string         `json:"createdAt,omitempty"`
+	UpdatedAt       string         `json:"updatedAt,omitempty"`
 	Composite       *Composite     `json:"composite,omitempty"`
 	AnomalyConfig   *AnomalyConfig `json:"anomalyConfig,omitempty"`
 }


### PR DESCRIPTION
## Motivation

Expose new read only field `updatedAt` which allows to verify when a given SLO was updated.

## Release Notes

`updatedAt` field is now included in SLO Spec. It gives information about when was the last time given SLO was updated.