### PR TITLE
feat: PC-12274 PC-12009 Move updatedAt to status, add createdBy to spec

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -48,7 +48,7 @@ type Spec struct {
 	AlertPolicies   []string       `json:"alertPolicies"`
 	Attachments     []Attachment   `json:"attachments,omitempty"`
 	CreatedAt       string         `json:"createdAt,omitempty"`
-	UpdatedAt       string         `json:"updatedAt,omitempty"`
+	CreatedBy       string         `json:"createdBy,omitempty"`
 	Composite       *Composite     `json:"composite,omitempty"`
 	AnomalyConfig   *AnomalyConfig `json:"anomalyConfig,omitempty"`
 }
@@ -147,6 +147,7 @@ type AnomalyConfigAlertMethod struct {
 // Status holds dynamic fields returned when the Service is fetched from Nobl9 platform.
 // Status is not part of the static object definition.
 type Status struct {
+	UpdatedAt    string        `json:"updatedAt,omitempty"`
 	ReplayStatus *ReplayStatus `json:"timeTravel,omitempty"`
 }
 


### PR DESCRIPTION
## Summray

Expose new read only field `CreatedBy` which allows to identify user who created a given SLO.
Move `UpdatedAt` to Status.

## Release Notes

`UpdatedAt` field is included in SLO Status. It gives information about when was the last time given SLO was updated.
`CreatedBy` field is included in SLO Spec. It gives information about user ID who initially created a given SLO.
