### PR TITLE
fix: PC-12276 Prevent alert policies with alertingWindow 0m

### DIFF
--- a/manifest/v1alpha/alertpolicy/validation_test.go
+++ b/manifest/v1alpha/alertpolicy/validation_test.go
@@ -472,6 +472,15 @@ func TestValidate_Spec_Condition_AlertingWindow(t *testing.T) {
 			expectedCode:    validation.ErrorCodeGreaterThanOrEqualTo,
 			expectedMessage: `should be greater than or equal to '5m0s'`,
 		},
+		"fails, zero value": {
+			values: []string{
+				"0ms",
+				"0s",
+				"0m",
+			},
+			expectedCode:    validation.ErrorCodeTransform,
+			expectedMessage: `should be greater than or equal to '5m0s'`,
+		},
 	}
 	for name, testCase := range failTests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

Prevent an edge case where users are allowed to define `alertingWindow` duration equal to `0m` as the minimal duration is defined as `5m`.

## Summary

* Added validation for the edge case.

## Testing

- Added unit tests
