### PR TITLE
chore: Update README.md logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
    <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github.com/nobl9/n9/assets/84388336/2895fcab-a386-498f-b7c4-14a70c66093d">
       <source media="(prefers-color-scheme: light)" srcset="https://github.com/nobl9/n9/assets/84388336/b21abc8b-8b05-448b-a8bc-5576c72e81b5">
-      <img alt="N9" src="https://github.com/nobl9/n9/assets/84388336/b21abc8b-8b05-448b-a8bc-5576c72e81b5" width="500" />
+      <img alt="N9" src="https://github.com/nobl9/nobl9-go/assets/48822818/4b0288bf-28ec-4435-af42-1d8918c81a47" width="500" />
    </picture>
 </h1>
 


### PR DESCRIPTION
The previous logo was referencing the wrong asset.