### PR TITLE
fix: reorder objective validation rules to produce more adequate composite objective validation messages [PC-12021]

### DIFF
--- a/internal/validation/rule_test.go
+++ b/internal/validation/rule_test.go
@@ -36,6 +36,50 @@ func TestSingleRule_WithErrorCode(t *testing.T) {
 	assert.Equal(t, "test", err.(*RuleError).Code)
 }
 
+func TestSingleRule_WithMessage(t *testing.T) {
+	for _, test := range []struct {
+		Error         string
+		Message       string
+		Details       string
+		ExpectedError string
+	}{
+		{
+			Error:         "this is error",
+			Message:       "",
+			Details:       "details",
+			ExpectedError: "this is error; details",
+		},
+		{
+			Error:         "this is error",
+			Message:       "this is message",
+			Details:       "",
+			ExpectedError: "this is message",
+		},
+		{
+			Error:         "",
+			Message:       "message",
+			Details:       "details",
+			ExpectedError: "message; details",
+		},
+	} {
+		r := NewSingleRule[int](func(v int) error {
+			if v < 0 {
+				return errors.Errorf(test.Error)
+			}
+			return nil
+		}).
+			WithErrorCode("test").
+			WithMessage(test.Message).
+			WithDetails(test.Details)
+
+		err := r.Validate(0)
+		assert.Nil(t, err)
+		err = r.Validate(-1)
+		assert.EqualError(t, err, test.ExpectedError)
+		assert.Equal(t, "test", err.(*RuleError).Code)
+	}
+}
+
 func TestSingleRule_WithDetails(t *testing.T) {
 	for _, test := range []struct {
 		Error         string

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -194,7 +194,7 @@ var oneOfBadOverTotalValidationRule = validation.NewSingleRule(func(v MetricSpec
 }).WithErrorCode(errCodeBadOverTotalDisabled)
 
 var exactlyOneMetricSpecTypeValidationRule = validation.NewSingleRule(func(v Spec) error {
-	if v.HasCompositeObjectives() {
+	if v.Indicator == nil {
 		return nil
 	}
 	if v.HasRawMetric() {

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -38,16 +38,21 @@ var sloValidationComposite = validation.New[SLO](
 	validation.For(validation.GetSelf[SLO]()).
 		Rules(
 			validation.NewSingleRule(func(s SLO) error {
-				for _, obj := range s.Spec.Objectives[0].Composite.Objectives {
-					isSameProject := obj.Project == s.Metadata.Project
-					isSameName := obj.Objective == s.Metadata.Name
+				for _, objective := range s.Spec.Objectives {
+					if objective.Composite == nil {
+						continue
+					}
+					for _, component := range objective.Composite.Objectives {
+						isSameProject := component.Project == s.Metadata.Project
+						isSameName := component.Objective == s.Metadata.Name
 
-					if isSameProject && isSameName {
-						return validation.NewPropertyError(
-							"slo",
-							s.Metadata.Name,
-							errors.Errorf("composite SLO cannot have itself as one of its objectives"),
-						)
+						if isSameProject && isSameName {
+							return validation.NewPropertyError(
+								"slo",
+								s.Metadata.Name,
+								errors.Errorf("composite SLO cannot have itself as one of its objectives"),
+							)
+						}
 					}
 				}
 

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -76,7 +76,7 @@ var sloValidationComposite = validation.New[SLO](
 			}).WithErrorCode(validation.ErrorCodeForbidden),
 		),
 
-	validation.For(func(s SLO) []CompositeObjective { return getCompositeObjectiveComponents(s) }).
+	validation.For(getCompositeObjectiveComponents).
 		Rules(
 			validation.NewSingleRule(func(c []CompositeObjective) error {
 				sloMap := make(map[string]bool)

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -370,7 +370,7 @@ var specValidationComposite = validation.New[Spec](
 	validation.ForEach(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Rules(validation.SliceLength[[]Objective](1, 1).
-			WithDetails("composite objective can be the only objective in the SLO")).
+			WithDetails("a composite objective can be the only objective in the SLO")).
 		IncludeForEach(validation.New[Objective](
 			validation.ForPointer(func(o Objective) *CompositeSpec { return o.Composite }).
 				WithName("composite").

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -226,7 +226,6 @@ var compositeObjectiveRule = validation.New[CompositeObjective](
 		Rules(validation.StringIsDNSSubdomain()),
 	validation.For(func(c CompositeObjective) float64 { return c.Weight }).
 		WithName("weight").
-		Required().
 		Rules(validation.GreaterThan(0.0)),
 	validation.For(func(c CompositeObjective) WhenDelayed { return c.WhenDelayed }).
 		WithName("whenDelayed").

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -19,10 +19,12 @@ var sloValidation = validation.New[SLO](
 		Include(metadataValidation),
 	validation.For(func(s SLO) Spec { return s.Spec }).
 		WithName("spec").
-		Include(specValidation).
-		StopOnError().
 		Include(specValidationNonComposite).
-		Include(specValidationComposite),
+		StopOnError().
+		Include(specValidationComposite).
+		StopOnError().
+		Include(specValidation).
+		StopOnError(),
 )
 
 var metadataValidation = validation.New[Metadata](
@@ -80,7 +82,8 @@ var sloValidationComposite = validation.New[SLO](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		Include(specMetricsValidation),
+		Include(specMetricsValidation).
+		StopOnError(),
 	validation.For(validation.GetSelf[Spec]()).
 		WithName("composite").
 		When(func(s Spec) bool { return s.Composite != nil }).
@@ -280,12 +283,6 @@ var indicatorValidation = validation.New[Indicator](
 )
 
 var objectiveValidation = validation.New[Objective](
-	validation.For(validation.GetSelf[Objective]()).
-		Rules(validation.MutuallyExclusive(true, map[string]func(o Objective) any{
-			"rawMetric":    func(o Objective) any { return o.RawMetric },
-			"countMetrics": func(o Objective) any { return o.CountMetrics },
-			"composite":    func(o Objective) any { return o.Composite },
-		})),
 	validation.For(validation.GetSelf[Objective]()).
 		Include(rawMetricObjectiveValidation),
 	validation.For(func(o Objective) ObjectiveBase { return o.ObjectiveBase }).

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -366,7 +366,7 @@ var specValidationComposite = validation.New[Spec](
 	validation.ForEach(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Rules(validation.SliceLength[[]Objective](1, 1).
-			WithDetails("this SLO contains a composite objective. No more objectives can be added to it")).
+			WithMessage("this SLO contains a composite objective. No more objectives can be added to it")).
 		IncludeForEach(validation.New[Objective](
 			validation.ForPointer(func(o Objective) *CompositeSpec { return o.Composite }).
 				WithName("composite").

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -124,13 +124,14 @@ var specValidation = validation.New[Spec](
 		WithName("objectives").
 		Rules(validation.SliceMinLength[[]Objective](1)).
 		StopOnError().
+		IncludeForEach(objectiveValidation).
+		When(func(s Spec) bool { return !s.HasCompositeObjectives() }).
 		Rules(validation.SliceUnique(func(v Objective) float64 {
 			if v.Value == nil {
 				return 0
 			}
 			return *v.Value
-		}, "objectives[*].value must be different for each objective")).
-		IncludeForEach(objectiveValidation),
+		}, "objectives[*].value must be different for each objective")),
 	validation.For(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Rules(
@@ -369,7 +370,7 @@ var specValidationComposite = validation.New[Spec](
 	validation.ForEach(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Rules(validation.SliceLength[[]Objective](1, 1).
-			WithDetails("there must be only 1 composite objective")).
+			WithDetails("composite objective can be the only objective in the SLO")).
 		IncludeForEach(validation.New[Objective](
 			validation.ForPointer(func(o Objective) *CompositeSpec { return o.Composite }).
 				WithName("composite").

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -370,7 +370,7 @@ var specValidationComposite = validation.New[Spec](
 	validation.ForEach(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Rules(validation.SliceLength[[]Objective](1, 1).
-			WithDetails("a composite objective can be the only objective in the SLO")).
+			WithDetails("this SLO contains a composite objective. No more objectives can be added to it")).
 		IncludeForEach(validation.New[Objective](
 			validation.ForPointer(func(o Objective) *CompositeSpec { return o.Composite }).
 				WithName("composite").

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -190,7 +190,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
 			Prop: "spec.objectives[0].composite.components.objectives[0].weight",
-			Code: validation.ErrorCodeRequired,
+			Code: validation.ErrorCodeGreaterThan,
 		})
 	})
 	t.Run("fails - weight is zero for second composite objective", func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
 			Prop: "spec.objectives[0].composite.components.objectives[1].weight",
-			Code: validation.ErrorCodeRequired,
+			Code: validation.ErrorCodeGreaterThan,
 		})
 	})
 	t.Run("fails - one of objectives is the composite SLO itself (cycle)", func(t *testing.T) {

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -45,6 +45,21 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			})
 		}
 	})
+	t.Run("fails - composite SLO has more than 1 objectives", func(t *testing.T) {
+		slo := validCompositeSLO()
+		anotherCompositeObjective := validCompositeObjective()
+		anotherCompositeObjective.Name = "another-composite-objective"
+		slo.Spec.Objectives = append(slo.Spec.Objectives, anotherCompositeObjective)
+		err := validate(slo)
+
+		testutils.AssertContainsErrors(t, slo, err, 1,
+			testutils.ExpectedError{
+				Prop:    "spec.objectives",
+				Code:    validation.ErrorCodeSliceLength,
+				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
+			},
+		)
+	})
 	t.Run("fails - raw objective type mixed with composite", func(t *testing.T) {
 		obj := Objective{
 			ObjectiveBase: ObjectiveBase{
@@ -67,7 +82,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; there must be only 1 composite objective",
+				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
 			},
 		)
 	})
@@ -96,7 +111,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; there must be only 1 composite objective",
+				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
 			},
 		)
 	})

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -56,7 +56,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
 			},
 		)
 	})
@@ -82,7 +82,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
 			},
 		)
 	})
@@ -111,7 +111,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
 			},
 		)
 	})

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -56,7 +56,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})
@@ -82,7 +82,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})
@@ -111,7 +111,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			testutils.ExpectedError{
 				Prop:    "spec.objectives",
 				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; a composite objective can be the only objective in the SLO",
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -54,10 +54,9 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: "spec.objectives",
-				Code: validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
-					"No more objectives can be added to it",
+				Prop:    "spec.objectives",
+				Code:    validation.ErrorCodeSliceLength,
+				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})
@@ -81,10 +80,9 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: "spec.objectives",
-				Code: validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
-					"No more objectives can be added to it",
+				Prop:    "spec.objectives",
+				Code:    validation.ErrorCodeSliceLength,
+				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})
@@ -111,10 +109,9 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: "spec.objectives",
-				Code: validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
-					"No more objectives can be added to it",
+				Prop:    "spec.objectives",
+				Code:    validation.ErrorCodeSliceLength,
+				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
 		)
 	})

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -54,9 +54,10 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    "spec.objectives",
-				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
+				Prop: "spec.objectives",
+				Code: validation.ErrorCodeSliceLength,
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
+					"No more objectives can be added to it",
 			},
 		)
 	})
@@ -80,9 +81,10 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    "spec.objectives",
-				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
+				Prop: "spec.objectives",
+				Code: validation.ErrorCodeSliceLength,
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
+					"No more objectives can be added to it",
 			},
 		)
 	})
@@ -109,9 +111,10 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    "spec.objectives",
-				Code:    validation.ErrorCodeSliceLength,
-				Message: "length must be between 1 and 1; this SLO contains a composite objective. No more objectives can be added to it",
+				Prop: "spec.objectives",
+				Code: validation.ErrorCodeSliceLength,
+				Message: "length must be between 1 and 1; this SLO contains a composite objective. " +
+					"No more objectives can be added to it",
 			},
 		)
 	})
@@ -131,9 +134,10 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			err := validate(slo)
 
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:    "spec.composite",
-				Code:    validation.ErrorCodeForbidden,
-				Message: "property is forbidden; composite section is forbidden when spec.objectives[0].composite is provided",
+				Prop: "spec.composite",
+				Code: validation.ErrorCodeForbidden,
+				Message: "property is forbidden; composite section is forbidden " +
+					"when spec.objectives[0].composite is provided",
 			})
 		}
 	})

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -663,12 +663,22 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 	})
 	t.Run("fails", func(t *testing.T) {
 		for name, test := range map[string]struct {
-			Indicator           Indicator
+			Indicator           *Indicator
 			ExpectedErrors      []testutils.ExpectedError
 			ExpectedErrorsCount int
 		}{
+			"no indicator": {
+				Indicator: nil,
+				ExpectedErrors: []testutils.ExpectedError{
+					{
+						Prop: "spec.indicator",
+						Code: validation.ErrorCodeRequired,
+					},
+				},
+				ExpectedErrorsCount: 1,
+			},
 			"empty indicator": {
-				Indicator: Indicator{},
+				Indicator: &Indicator{},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
 						Prop: "spec.indicator.metricSource.name",
@@ -678,7 +688,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				ExpectedErrorsCount: 1,
 			},
 			"empty metric source name": {
-				Indicator: Indicator{MetricSource: MetricSourceSpec{Name: "", Project: "default"}},
+				Indicator: &Indicator{MetricSource: MetricSourceSpec{Name: "", Project: "default"}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
 						Prop: "spec.indicator.metricSource.name",
@@ -688,7 +698,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				ExpectedErrorsCount: 1,
 			},
 			"invalid metric source": {
-				Indicator: Indicator{
+				Indicator: &Indicator{
 					MetricSource: MetricSourceSpec{
 						Name:    "MY NAME",
 						Project: "MY PROJECT",
@@ -714,7 +724,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				slo := validSLO()
-				slo.Spec.Indicator = &test.Indicator
+				slo.Spec.Indicator = test.Indicator
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, test.ExpectedErrorsCount, test.ExpectedErrors...)
 			})
@@ -1007,23 +1017,18 @@ func TestValidate_Spec(t *testing.T) {
 			GoodMetric:  validMetricSpec(v1alpha.Prometheus),
 		}
 		err := validate(slo)
-		testutils.AssertContainsErrors(t, slo, err, 2, testutils.ExpectedError{
-			Prop: "spec.objectives[0]",
-			Code: validation.ErrorCodeMutuallyExclusive,
-		}, testutils.ExpectedError{
-			Prop: "spec",
-			Code: errCodeExactlyOneMetricType,
-		})
+		testutils.AssertContainsErrors(t, slo, err, 1,
+			testutils.ExpectedError{
+				Prop: "spec",
+				Code: errCodeExactlyOneMetricType,
+			})
 	})
 	t.Run("exactly one metric type - both missing", func(t *testing.T) {
 		slo := validSLO()
 		slo.Spec.Objectives[0].RawMetric = nil
 		slo.Spec.Objectives[0].CountMetrics = nil
 		err := validate(slo)
-		testutils.AssertContainsErrors(t, slo, err, 2, testutils.ExpectedError{
-			Prop: "spec.objectives[0]",
-			Code: validation.ErrorCodeMutuallyExclusive,
-		}, testutils.ExpectedError{
+		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
 			Prop: "spec",
 			Code: errCodeExactlyOneMetricType,
 		})

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -1315,6 +1315,38 @@ func validSLO() SLO {
 	)
 }
 
+func validCompositeObjective() Objective {
+	return Objective{
+		ObjectiveBase: ObjectiveBase{
+			DisplayName: "Composite",
+			Value:       ptr(120.),
+			Name:        "composite-1",
+		},
+		BudgetTarget: ptr(0.9),
+		Composite: &CompositeSpec{
+			MaxDelay: "10m",
+			Components: Components{
+				Objectives: []CompositeObjective{
+					{
+						Project:     "project-alpha",
+						SLO:         "my-slo-alpha",
+						Objective:   "good",
+						Weight:      1.0,
+						WhenDelayed: WhenDelayedCountAsGood,
+					},
+					{
+						Project:     "project-beta",
+						SLO:         "my-slo-beta",
+						Objective:   "average",
+						Weight:      2.0,
+						WhenDelayed: WhenDelayedCountAsBad,
+					},
+				},
+			},
+		},
+	}
+}
+
 func validCompositeSLO() SLO {
 	return New(
 		Metadata{
@@ -1338,35 +1370,7 @@ func validCompositeSLO() SLO {
 			BudgetingMethod: BudgetingMethodOccurrences.String(),
 			Service:         "prometheus",
 			Objectives: []Objective{
-				{
-					ObjectiveBase: ObjectiveBase{
-						DisplayName: "Composite",
-						Value:       ptr(120.),
-						Name:        "composite-1",
-					},
-					BudgetTarget: ptr(0.9),
-					Composite: &CompositeSpec{
-						MaxDelay: "10m",
-						Components: Components{
-							Objectives: []CompositeObjective{
-								{
-									Project:     "project-alpha",
-									SLO:         "my-slo-alpha",
-									Objective:   "good",
-									Weight:      1.0,
-									WhenDelayed: WhenDelayedCountAsGood,
-								},
-								{
-									Project:     "project-beta",
-									SLO:         "my-slo-beta",
-									Objective:   "average",
-									Weight:      2.0,
-									WhenDelayed: WhenDelayedCountAsBad,
-								},
-							},
-						},
-					},
-				},
+				validCompositeObjective(),
 			},
 			TimeWindows: []TimeWindow{
 				{

--- a/sdk/test_data/client/simple_module/go.mod
+++ b/sdk/test_data/client/simple_module/go.mod
@@ -8,7 +8,7 @@ require github.com/nobl9/nobl9-go v0.73.0
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
-	github.com/aws/aws-sdk-go v1.51.6 // indirect
+	github.com/aws/aws-sdk-go v1.51.11 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect

--- a/sdk/test_data/client/simple_module/go.sum
+++ b/sdk/test_data/client/simple_module/go.sum
@@ -11,6 +11,7 @@ github.com/aws/aws-sdk-go v1.50.26/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3Tj
 github.com/aws/aws-sdk-go v1.50.28/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go v1.50.33/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go v1.51.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.51.11/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=


### PR DESCRIPTION
Validating if there's more than one composite objective in SLO should take precedence over objective uniqueness validation