### PR TITLE
fix: Decode to json.Number instead of float

### DIFF
--- a/internal/examples/client.go
+++ b/internal/examples/client.go
@@ -1,13 +1,12 @@
 package examples
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 
-	"github.com/goccy/go-yaml"
-
+	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/sdk"
 )
 
@@ -21,11 +20,9 @@ func GetOfflineEchoClient() *sdk.Client {
 		if err != nil {
 			panic(err)
 		}
-		data, err := yaml.Marshal(objects[0])
-		if err != nil {
+		if err = sdk.PrintObject(objects[0], os.Stdout, manifest.ObjectFormatYAML); err != nil {
 			panic(err)
 		}
-		fmt.Println(string(data))
 	}))
 	// Create sdk.Client:
 	u, _ := url.Parse(srv.URL)

--- a/manifest/v1alpha/parser/parser.go
+++ b/manifest/v1alpha/parser/parser.go
@@ -100,6 +100,7 @@ func getUnmarshalFunc(data []byte, format manifest.ObjectFormat) (unmarshalFunc,
 	case manifest.ObjectFormatJSON:
 		unmarshal = func(v interface{}) error {
 			dec := json.NewDecoder(bytes.NewReader(data))
+			dec.UseNumber()
 			if UseStrictDecodingMode {
 				dec.DisallowUnknownFields()
 			}

--- a/sdk/printer.go
+++ b/sdk/printer.go
@@ -1,0 +1,42 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/nobl9/nobl9-go/manifest"
+)
+
+// PrintObjects prints objects to the given [io.Writer] in specified [manifest.ObjectFormat].
+func PrintObjects(objects []manifest.Object, out io.Writer, format manifest.ObjectFormat) error {
+	return printObjects(objects, out, format)
+}
+
+// PrintObject prints a single object to the given [io.Writer] in specified [manifest.ObjectFormat].
+func PrintObject(object manifest.Object, out io.Writer, format manifest.ObjectFormat) error {
+	return printObjects(object, out, format)
+}
+
+func printObjects(objects any, out io.Writer, format manifest.ObjectFormat) error {
+	switch format {
+	case manifest.ObjectFormatJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(objects)
+	case manifest.ObjectFormatYAML:
+		enc := yaml.NewEncoder(out, yaml.CustomMarshaler(yamlNumberMarshaler))
+		return enc.Encode(objects)
+	default:
+		return fmt.Errorf("unsupported format: %s", format)
+	}
+}
+
+// yamlNumberMarshaler is a custom marshaler for [json.Number].
+// It is used to avoid converting int to float64 when converting JSON to YAML for generic
+// [manifest.Object] representations, like [v1alpha.GenericObject].
+func yamlNumberMarshaler(number json.Number) ([]byte, error) {
+	return []byte(number.String()), nil
+}

--- a/sdk/printer_test.go
+++ b/sdk/printer_test.go
@@ -1,0 +1,105 @@
+package sdk
+
+import (
+	"bytes"
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
+	v1alphaProject "github.com/nobl9/nobl9-go/manifest/v1alpha/project"
+)
+
+//go:embed test_data/printer/expected_objects.json
+var expectedObjectsJSON string
+
+//go:embed test_data/printer/expected_objects.yaml
+var expectedObjectsYAML string
+
+func TestPrintObjects(t *testing.T) {
+	objects := []manifest.Object{
+		v1alpha.GenericObject{
+			"apiVersion": "v1alpha",
+			"kind":       "Project",
+			"metadata": map[string]interface{}{
+				"name":  "test-int",
+				"value": 1,
+			},
+		},
+		v1alpha.GenericObject{
+			"apiVersion": "v1alpha",
+			"kind":       "Project",
+			"metadata": map[string]interface{}{
+				"name":  "test-float",
+				"value": 2.89,
+			},
+		},
+		v1alphaProject.New(
+			v1alphaProject.Metadata{
+				Name: "test-project",
+			},
+			v1alphaProject.Spec{},
+		),
+	}
+
+	t.Run("JSON format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObjects(objects, buf, manifest.ObjectFormatJSON)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedObjectsJSON, buf.String())
+	})
+
+	t.Run("YAML format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObjects(objects, buf, manifest.ObjectFormatYAML)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedObjectsYAML, buf.String())
+	})
+
+	t.Run("Unsupported format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObjects(objects, buf, manifest.ObjectFormat(-1))
+		assert.Error(t, err)
+		assert.Equal(t, "unsupported format: ObjectFormat(-1)", err.Error())
+	})
+}
+
+//go:embed test_data/printer/expected_object.json
+var expectedObjectJSON string
+
+//go:embed test_data/printer/expected_object.yaml
+var expectedObjectYAML string
+
+func TestPrintObject(t *testing.T) {
+	object := v1alpha.GenericObject{
+		"apiVersion": "v1alpha",
+		"kind":       "Project",
+		"metadata": map[string]interface{}{
+			"name":  "test-int",
+			"value": 1,
+		},
+	}
+
+	t.Run("JSON format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObject(object, buf, manifest.ObjectFormatJSON)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedObjectJSON, buf.String())
+	})
+
+	t.Run("YAML format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObject(object, buf, manifest.ObjectFormatYAML)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedObjectYAML, buf.String())
+	})
+
+	t.Run("Unsupported format", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		err := PrintObject(object, buf, manifest.ObjectFormat(-1))
+		assert.Error(t, err)
+		assert.Equal(t, "unsupported format: ObjectFormat(-1)", err.Error())
+	})
+}

--- a/sdk/test_data/printer/expected_object.json
+++ b/sdk/test_data/printer/expected_object.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "v1alpha",
+  "kind": "Project",
+  "metadata": {
+    "name": "test-int",
+    "value": 1
+  }
+}

--- a/sdk/test_data/printer/expected_object.yaml
+++ b/sdk/test_data/printer/expected_object.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: test-int
+  value: 1

--- a/sdk/test_data/printer/expected_objects.json
+++ b/sdk/test_data/printer/expected_objects.json
@@ -1,0 +1,28 @@
+[
+  {
+    "apiVersion": "v1alpha",
+    "kind": "Project",
+    "metadata": {
+      "name": "test-int",
+      "value": 1
+    }
+  },
+  {
+    "apiVersion": "v1alpha",
+    "kind": "Project",
+    "metadata": {
+      "name": "test-float",
+      "value": 2.89
+    }
+  },
+  {
+    "apiVersion": "n9/v1alpha",
+    "kind": "Project",
+    "metadata": {
+      "name": "test-project"
+    },
+    "spec": {
+      "description": ""
+    }
+  }
+]

--- a/sdk/test_data/printer/expected_objects.yaml
+++ b/sdk/test_data/printer/expected_objects.yaml
@@ -1,0 +1,16 @@
+- apiVersion: v1alpha
+  kind: Project
+  metadata:
+    name: test-int
+    value: 1
+- apiVersion: v1alpha
+  kind: Project
+  metadata:
+    name: test-float
+    value: 2.89
+- apiVersion: n9/v1alpha
+  kind: Project
+  metadata:
+    name: test-project
+  spec:
+    description: ""


### PR DESCRIPTION
## Motivation

When working with generic object representation, like `v1alpha.GenericObject` it was impossible to properly handle the data retaining integer and float distinction as Golang's `encoding/json` always converts JSON numbers to floats.

The solution is retain the original number format through `json.Number` and user custom YAML encoding for the `json.Number` type.

## Release Notes

When reading JSON encoded `manifest.Object`, the numbers are now retained in `json.Number` format instead of being converted to floats.
Added `PrintObjects` and `PrintObject` which handle `json.Number` correctly when encoding to YAML format. 