### PR TITLE
chore: Update Go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/nobl9-go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/sdk/test_data/client/simple_module/go.mod
+++ b/sdk/test_data/client/simple_module/go.mod
@@ -1,8 +1,6 @@
 module simple_module
 
-go 1.21
-
-toolchain go1.21.4
+go 1.22
 
 require github.com/nobl9/nobl9-go v0.73.0
 


### PR DESCRIPTION
## Motivation

Update Go to the newest major version which solves some recently reported govulncheck problems too.