### PR TITLE
chore: Stabilize validation API - remove StopOnError and simplify internal logic

### DIFF
--- a/internal/testutils/assert.go
+++ b/internal/testutils/assert.go
@@ -66,8 +66,6 @@ func AssertContainsErrors(
 	for _, expected := range expectedErrors {
 		found := false
 		for _, actual := range objErr.Errors {
-			var failedMessage, failedContainsMessage, failedCode bool
-
 			var propErr *validation.PropertyError
 			require.ErrorAs(t, actual, &propErr)
 			if propErr.PropertyName != expected.Prop {
@@ -77,24 +75,25 @@ func AssertContainsErrors(
 				continue
 			}
 			for _, actualRuleErr := range propErr.Errors {
-				if expected.Message != "" && expected.Message != actualRuleErr.Message {
-					failedMessage = true
-					break
+				matchedCtr := 0
+				if expected.Message == "" || expected.Message == actualRuleErr.Message {
+					matchedCtr++
 				}
-				if expected.ContainsMessage != "" &&
-					!strings.Contains(actualRuleErr.Message, expected.ContainsMessage) {
-					failedContainsMessage = true
-					break
+				if expected.ContainsMessage == "" ||
+					strings.Contains(actualRuleErr.Message, expected.ContainsMessage) {
+					matchedCtr++
 				}
-				if expected.Code != "" &&
-					(expected.Code != actualRuleErr.Code && !validation.HasErrorCode(actualRuleErr, expected.Code)) {
-					failedCode = true
+				if expected.Code == "" ||
+					expected.Code == actualRuleErr.Code ||
+					validation.HasErrorCode(actualRuleErr, expected.Code) {
+					matchedCtr++
+				}
+				if matchedCtr == 3 {
+					found = true
 					break
 				}
 			}
-
-			if !failedMessage && !failedContainsMessage && !failedCode {
-				found = true
+			if found {
 				break
 			}
 		}

--- a/internal/validation/cascade_mode.go
+++ b/internal/validation/cascade_mode.go
@@ -1,0 +1,10 @@
+package validation
+
+type CascadeMode uint
+
+const (
+	// CascadeModeContinue will stop validation on first error.
+	CascadeModeContinue CascadeMode = iota
+	// CascadeModeAll will continue validation after first error.
+	CascadeModeAll
+)

--- a/internal/validation/cascade_mode.go
+++ b/internal/validation/cascade_mode.go
@@ -1,10 +1,11 @@
 package validation
 
+// CascadeMode defines how validation should behave when an error is encountered.
 type CascadeMode uint
 
 const (
-	// CascadeModeContinue will stop validation on first error.
+	// CascadeModeContinue will continue validation after first error.
 	CascadeModeContinue CascadeMode = iota
-	// CascadeModeAll will continue validation after first error.
-	CascadeModeAll
+	// CascadeModeStop will stop validation on first error encountered.
+	CascadeModeStop
 )

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -48,6 +49,27 @@ func (e PropertyErrors) HideValue() PropertyErrors {
 	return e
 }
 
+// Sort should be always called after Aggregate.
+func (e PropertyErrors) Sort() PropertyErrors {
+	if len(e) == 0 {
+		return e
+	}
+	sort.Slice(e, func(i, j int) bool {
+		e1, e2 := e[i], e[j]
+		if e1.PropertyName != e2.PropertyName {
+			return e1.PropertyName < e2.PropertyName
+		}
+		if e1.PropertyValue != e2.PropertyValue {
+			return e1.PropertyValue < e2.PropertyValue
+		}
+		if e1.IsKeyError != e2.IsKeyError {
+			return e1.IsKeyError
+		}
+		return e1.IsSliceElementError
+	})
+	return e
+}
+
 func (e PropertyErrors) Aggregate() PropertyErrors {
 	if len(e) == 0 {
 		return nil
@@ -79,9 +101,9 @@ type PropertyError struct {
 	PropertyValue string `json:"propertyValue"`
 	// IsKeyError is set to true if the error was created through map key validation.
 	// PropertyValue in this scenario will be the key value, equal to the last element of PropertyName path.
-	IsKeyError bool `json:"isKeyError"`
+	IsKeyError bool `json:"isKeyError,omitempty"`
 	// IsSliceElementError is set to true if the error was created through slice element validation.
-	IsSliceElementError bool         `json:"isSliceElementError"`
+	IsSliceElementError bool         `json:"isSliceElementError,omitempty"`
 	Errors              []*RuleError `json:"errors"`
 }
 

--- a/internal/validation/example_test.go
+++ b/internal/validation/example_test.go
@@ -631,11 +631,11 @@ func ExampleForSlice() {
 
 	// Output:
 	// Validation has failed for the following properties:
-	//   - 'students[1].index' with value '9182300123':
-	//     - length must be between 9 and 9
 	//   - 'students' with value '[{"index":"918230014"},{"index":"9182300123"},{"index":"918230014"}]':
 	//     - length must be less than or equal to 2
 	//     - elements are not unique, index 0 collides with index 2
+	//   - 'students[1].index' with value '9182300123':
+	//     - length must be between 9 and 9
 }
 
 // When dealing with maps there are three forms of iteration:
@@ -711,14 +711,14 @@ func ExampleForMap() {
 
 	// Output:
 	// Validation has failed for the following properties:
-	//   - 'students.9182300123.name' with value 'Eve':
-	//     - should be not equal to 'Eve'
 	//   - 'students' with value '{"9182300123":{"name":"Eve","age":0,"students":null,"university":{"name":"","address":""}},"91823001...':
 	//     - length must be less than or equal to 2
 	//   - 'students.918230013' with value '{"name":"Joan","age":0,"students":null,"university":{"name":"","address":""}}':
 	//     - Joan cannot be a teacher for student with index 918230013
 	//   - 'students.9182300123' with key '9182300123':
 	//     - length must be between 9 and 9
+	//   - 'students.9182300123.name' with value 'Eve':
+	//     - should be not equal to 'Eve'
 }
 
 // To only run property validation on condition, use [PropertyRules.When].
@@ -748,9 +748,10 @@ func ExamplePropertyRules_When() {
 	//     - should be not equal to 'Jerry'
 }
 
-// To fail validation immediately after certain [Rule] fails use [PropertyRules.StopOnError].
-// You need to call it directly AFTER you've called [PropertyRules.Rules].
-func ExamplePropertyRules_StopOnError() {
+// To customize how [Rule] are evaluated use [PropertyRules.CascadeMode].
+// Use [CascadeModeStop] to stop validation after the first error.
+// If you wish to revert to the default behavior, use [CascadeModeContinue].
+func ExamplePropertyRules_CascadeMode() {
 	alwaysFailingRule := validation.NewSingleRule(func(string) error {
 		return fmt.Errorf("always fails")
 	})
@@ -758,8 +759,8 @@ func ExamplePropertyRules_StopOnError() {
 	v := validation.New[Teacher](
 		validation.For(func(t Teacher) string { return t.Name }).
 			WithName("name").
+			CascadeMode(validation.CascadeModeStop).
 			Rules(validation.NotEqualTo("Jerry")).
-			StopOnError().
 			Rules(alwaysFailingRule),
 	).WithName("Teacher")
 
@@ -832,11 +833,11 @@ func ExampleValidator() {
 	// Validation for John has failed for the following properties:
 	//   - 'name' with value 'John':
 	//     - must be one of [Jake, George]
-	//   - 'students[1].index' with value '9182300123':
-	//     - length must be between 9 and 9
 	//   - 'students' with value '[{"index":"918230014"},{"index":"9182300123"},{"index":"918230014"}]':
 	//     - length must be less than or equal to 2
 	//     - elements are not unique, index 0 collides with index 2
+	//   - 'students[1].index' with value '9182300123':
+	//     - length must be between 9 and 9
 	//   - 'university.address':
 	//     - property is required but was empty
 }

--- a/internal/validation/example_test.go
+++ b/internal/validation/example_test.go
@@ -713,12 +713,12 @@ func ExampleForMap() {
 	// Validation has failed for the following properties:
 	//   - 'students' with value '{"9182300123":{"name":"Eve","age":0,"students":null,"university":{"name":"","address":""}},"91823001...':
 	//     - length must be less than or equal to 2
-	//   - 'students.918230013' with value '{"name":"Joan","age":0,"students":null,"university":{"name":"","address":""}}':
-	//     - Joan cannot be a teacher for student with index 918230013
 	//   - 'students.9182300123' with key '9182300123':
 	//     - length must be between 9 and 9
 	//   - 'students.9182300123.name' with value 'Eve':
 	//     - should be not equal to 'Eve'
+	//   - 'students.918230013' with value '{"name":"Joan","age":0,"students":null,"university":{"name":"","address":""}}':
+	//     - Joan cannot be a teacher for student with index 918230013
 }
 
 // To only run property validation on condition, use [PropertyRules.When].
@@ -748,7 +748,7 @@ func ExamplePropertyRules_When() {
 	//     - should be not equal to 'Jerry'
 }
 
-// To customize how [Rule] are evaluated use [PropertyRules.CascadeMode].
+// To customize how [Rule] are evaluated use [PropertyRules.Cascade].
 // Use [CascadeModeStop] to stop validation after the first error.
 // If you wish to revert to the default behavior, use [CascadeModeContinue].
 func ExamplePropertyRules_CascadeMode() {
@@ -759,7 +759,7 @@ func ExamplePropertyRules_CascadeMode() {
 	v := validation.New[Teacher](
 		validation.For(func(t Teacher) string { return t.Name }).
 			WithName("name").
-			CascadeMode(validation.CascadeModeStop).
+			Cascade(validation.CascadeModeStop).
 			Rules(validation.NotEqualTo("Jerry")).
 			Rules(alwaysFailingRule),
 	).WithName("Teacher")

--- a/internal/validation/example_test.go
+++ b/internal/validation/example_test.go
@@ -721,25 +721,17 @@ func ExampleForMap() {
 	//     - length must be between 9 and 9
 }
 
-// WARNING!
-// The below examples display the CURRENT state of flow management for rules.
-// It's far from ideal and will be CHANGED IN THE FUTURE.
-
-// To only proceed with further validation on condition, use [PropertyRules.When].
-// Similar to [PropertyRules.Rules] predicates provided through [PropertyRules.When]
-// are evaluated in the order they are provided.
-// If a predicate is not met, proceeding (as defined in code) validation rules are not evaluated.
+// To only run property validation on condition, use [PropertyRules.When].
+// Predicates set through [PropertyRules.When] are evaluated in the order they are provided.
+// If any predicate is not met, validation rules are not evaluated for the whole [PropertyRules].
+//
+// It's recommended to define [PropertyRules.When] before [PropertyRules.Rules] declaration.
 func ExamplePropertyRules_When() {
-	alwaysFailingRule := validation.NewSingleRule(func(string) error {
-		return fmt.Errorf("always fails")
-	})
-
 	v := validation.New[Teacher](
 		validation.For(func(t Teacher) string { return t.Name }).
 			WithName("name").
-			Rules(validation.NotEqualTo("Jerry")).
-			When(func(t Teacher) bool { return t.Name == "Tom" }).
-			Rules(alwaysFailingRule),
+			When(func(t Teacher) bool { return t.Name == "Jerry" }).
+			Rules(validation.NotEqualTo("Jerry")),
 	).WithName("Teacher")
 
 	for _, name := range []string{"Tom", "Jerry", "Mickey"} {
@@ -751,9 +743,6 @@ func ExamplePropertyRules_When() {
 	}
 
 	// Output:
-	// Validation for Teacher has failed for the following properties:
-	//   - 'name' with value 'Tom':
-	//     - always fails
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Jerry':
 	//     - should be not equal to 'Jerry'

--- a/internal/validation/example_test.go
+++ b/internal/validation/example_test.go
@@ -751,7 +751,7 @@ func ExamplePropertyRules_When() {
 // To customize how [Rule] are evaluated use [PropertyRules.Cascade].
 // Use [CascadeModeStop] to stop validation after the first error.
 // If you wish to revert to the default behavior, use [CascadeModeContinue].
-func ExamplePropertyRules_CascadeMode() {
+func ExamplePropertyRules_Cascade() {
 	alwaysFailingRule := validation.NewSingleRule(func(string) error {
 		return fmt.Errorf("always fails")
 	})

--- a/internal/validation/predicate.go
+++ b/internal/validation/predicate.go
@@ -1,0 +1,21 @@
+package validation
+
+type Predicate[S any] func(S) bool
+
+type predicateMatcher[S any] struct {
+	predicates []Predicate[S]
+}
+
+func (r predicateMatcher[S]) when(predicates ...Predicate[S]) predicateMatcher[S] {
+	r.predicates = append(r.predicates, predicates...)
+	return r
+}
+
+func (r predicateMatcher[S]) matchPredicates(st S) bool {
+	for _, predicate := range r.predicates {
+		if !predicate(st) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/validation/rule_test.go
+++ b/internal/validation/rule_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSingleRule(t *testing.T) {
-	r := NewSingleRule[int](func(v int) error {
+	r := NewSingleRule(func(v int) error {
 		if v < 0 {
 			return errors.Errorf("must be positive")
 		}
@@ -22,7 +22,7 @@ func TestSingleRule(t *testing.T) {
 }
 
 func TestSingleRule_WithErrorCode(t *testing.T) {
-	r := NewSingleRule[int](func(v int) error {
+	r := NewSingleRule(func(v int) error {
 		if v < 0 {
 			return errors.Errorf("must be positive")
 		}
@@ -62,7 +62,7 @@ func TestSingleRule_WithMessage(t *testing.T) {
 			ExpectedError: "message; details",
 		},
 	} {
-		r := NewSingleRule[int](func(v int) error {
+		r := NewSingleRule(func(v int) error {
 			if v < 0 {
 				return errors.Errorf(test.Error)
 			}
@@ -102,7 +102,7 @@ func TestSingleRule_WithDetails(t *testing.T) {
 			ExpectedError: "details",
 		},
 	} {
-		r := NewSingleRule[int](func(v int) error {
+		r := NewSingleRule(func(v int) error {
 			if v < 0 {
 				return errors.Errorf(test.Error)
 			}

--- a/internal/validation/rules.go
+++ b/internal/validation/rules.go
@@ -31,9 +31,6 @@ func Transform[T, N, S any](getter PropertyGetter[T, S], transform Transformer[T
 	return PropertyRules[N, S]{
 		transformGetter: func(s S) (transformed N, original any, err error) {
 			v := getter(s)
-			if err != nil {
-				return transformed, nil, err
-			}
 			if isEmptyFunc(v) {
 				return transformed, nil, emptyErr{}
 			}
@@ -153,7 +150,7 @@ func (r PropertyRules[T, S]) Include(rules ...Validator[T]) PropertyRules[T, S] 
 }
 
 func (r PropertyRules[T, S]) When(predicates ...Predicate[S]) PropertyRules[T, S] {
-	r.predicateMatcher = r.predicateMatcher.when(predicates...)
+	r.predicateMatcher = r.when(predicates...)
 	return r
 }
 
@@ -172,7 +169,7 @@ func (r PropertyRules[T, S]) HideValue() PropertyRules[T, S] {
 	return r
 }
 
-func (r PropertyRules[T, S]) CascadeMode(mode CascadeMode) PropertyRules[T, S] {
+func (r PropertyRules[T, S]) Cascade(mode CascadeMode) PropertyRules[T, S] {
 	r.mode = mode
 	return r
 }

--- a/internal/validation/rules.go
+++ b/internal/validation/rules.go
@@ -64,7 +64,6 @@ type PropertyRules[T, S any] struct {
 	getter          internalPropertyGetter[T, S]
 	transformGetter internalTransformPropertyGetter[T, S]
 	steps           []interface{}
-	predicates      []Predicate[S]
 	required        bool
 	omitEmpty       bool
 	hideValue       bool

--- a/internal/validation/rules_for_map.go
+++ b/internal/validation/rules_for_map.go
@@ -5,15 +5,24 @@ import "fmt"
 // ForMap creates a new [PropertyRulesForMap] instance for a map property
 // which value is extracted through [PropertyGetter] function.
 func ForMap[M ~map[K]V, K comparable, V, S any](getter PropertyGetter[M, S]) PropertyRulesForMap[M, K, V, S] {
-	return PropertyRulesForMap[M, K, V, S]{getter: getter}
+	return PropertyRulesForMap[M, K, V, S]{
+		mapRules:      For(getter),
+		forKeyRules:   For(GetSelf[K]()),
+		forValueRules: For(GetSelf[V]()),
+		forItemRules:  For(GetSelf[MapItem[K, V]]()),
+		getter:        getter,
+	}
 }
 
 // PropertyRulesForMap is responsible for validating a single property.
 type PropertyRulesForMap[M ~map[K]V, K comparable, V, S any] struct {
-	name       string
-	getter     PropertyGetter[M, S]
-	steps      []interface{}
-	predicates []Predicate[S]
+	mapRules      PropertyRules[M, S]
+	forKeyRules   PropertyRules[K, K]
+	forValueRules PropertyRules[V, V]
+	forItemRules  PropertyRules[MapItem[K, V], MapItem[K, V]]
+	getter        PropertyGetter[M, S]
+
+	predicateMatcher[S]
 }
 
 // MapItem is a tuple container for map's key and value pair.
@@ -25,157 +34,57 @@ type MapItem[K comparable, V any] struct {
 // Validate executes each of the rules sequentially and aggregates the encountered errors.
 // nolint: prealloc, gocognit
 func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) PropertyErrors {
-	var (
-		allErrors          PropertyErrors
-		mapErrors          []error
-		propValue          M
-		previousStepFailed bool
-	)
-	for _, predicate := range r.predicates {
-		if !predicate(st) {
-			return nil
+	if !r.matchPredicates(st) {
+		return nil
+	}
+	err := r.mapRules.Validate(st)
+	for k, v := range r.getter(st) {
+		forKeyErr := r.forKeyRules.Validate(k)
+		if forKeyErr != nil {
+			for _, e := range forKeyErr {
+				e.IsKeyError = true
+				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
+			}
+		}
+		forValueErr := r.forValueRules.Validate(v)
+		if forValueErr != nil {
+			for _, e := range forValueErr {
+				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
+			}
+		}
+		forItemErr := r.forItemRules.Validate(MapItem[K, V]{Key: k, Value: v})
+		if forItemErr != nil {
+			for _, e := range forItemErr {
+				e.PropertyValue = propertyValueString(v)
+				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
+			}
 		}
 	}
-	valueErrors := make(map[K]mapItemError)
-	keyErrors := make(map[K]mapItemError)
-loop:
-	for _, step := range r.steps {
-		switch stepValue := step.(type) {
-		case stopOnErrorStep:
-			if previousStepFailed {
-				break loop
-			}
-		case mapKeyRule[K], Rule[V], Rule[MapItem[K, V]]:
-			errorEncountered := false
-			m := r.getter(st)
-			for key := range m {
-				var (
-					err        error
-					isKeyError bool
-				)
-				switch stepValue := step.(type) {
-				case mapKeyRule[K]:
-					isKeyError = true
-					err = stepValue.Validate(key)
-				case Rule[V]:
-					err = stepValue.Validate(m[key])
-				case Rule[MapItem[K, V]]:
-					err = stepValue.Validate(MapItem[K, V]{Key: key, Value: m[key]})
-				}
-				if err == nil {
-					continue
-				}
-				errorEncountered = true
-				switch ev := err.(type) {
-				case *PropertyError:
-					allErrors = append(allErrors, ev.PrependPropertyName(MapElementName(r.name, key)))
-				default:
-					if isKeyError {
-						fErrs := keyErrors[key].Errors
-						keyErrors[key] = mapItemError{Errors: append(fErrs, err), PropValue: key}
-					} else {
-						fErrs := valueErrors[key].Errors
-						valueErrors[key] = mapItemError{Errors: append(fErrs, err), PropValue: m[key]}
-					}
-				}
-			}
-			previousStepFailed = errorEncountered
-		case Rule[M]:
-			propValue = r.getter(st)
-			err := stepValue.Validate(propValue)
-			if err != nil {
-				switch ev := err.(type) {
-				case *PropertyError:
-					allErrors = append(allErrors, ev.PrependPropertyName(r.name))
-				default:
-					mapErrors = append(mapErrors, err)
-				}
-			}
-			previousStepFailed = err != nil
-		case validatorI[K], validatorI[V], validatorI[MapItem[K, V]]:
-			errorEncountered := false
-			m := r.getter(st)
-			for key := range m {
-				var err *ValidatorError
-				switch stepValue := step.(type) {
-				case mapKeyValidator[K]:
-					err = stepValue.Validate(key)
-				case validatorI[V]:
-					err = stepValue.Validate(m[key])
-				case validatorI[MapItem[K, V]]:
-					err = stepValue.Validate(MapItem[K, V]{Key: key, Value: m[key]})
-				}
-				if err == nil {
-					continue
-				}
-				errorEncountered = true
-				for _, e := range err.Errors {
-					allErrors = append(allErrors, e.PrependPropertyName(MapElementName(r.name, key)))
-				}
-			}
-			previousStepFailed = errorEncountered
-		}
-	}
-	if len(mapErrors) > 0 {
-		allErrors = append(allErrors, NewPropertyError(r.name, propValue, mapErrors...))
-	}
-	for key, item := range valueErrors {
-		allErrors = append(allErrors, NewPropertyError(
-			MapElementName(r.name, key),
-			item.PropValue,
-			item.Errors...))
-	}
-	for key, item := range keyErrors {
-		propError := NewPropertyError(
-			MapElementName(r.name, key),
-			key,
-			item.Errors...)
-		propError.IsKeyError = true
-		allErrors = append(allErrors, propError)
-	}
-	if len(allErrors) > 0 {
-		return allErrors
-	}
-	return nil
-}
-
-type mapItemError struct {
-	PropValue interface{}
-	Errors    []error
+	return err.Aggregate()
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) WithName(name string) PropertyRulesForMap[M, K, V, S] {
-	r.name = name
+	r.mapRules.name = name
 	return r
 }
 
-// mapKeyRule wraps Rule for map keys in a custom type in order to discern between rules for keys and values.
-// Otherwise, if key and value have the same type both Rule[K] and Rule[V] would match.
-type mapKeyRule[K comparable] struct{ Rule[K] }
-
 func (r PropertyRulesForMap[M, K, V, S]) RulesForKeys(rules ...Rule[K]) PropertyRulesForMap[M, K, V, S] {
-	mapKeyRules := make([]mapKeyRule[K], 0, len(rules))
-	for _, rule := range rules {
-		mapKeyRules = append(mapKeyRules, mapKeyRule[K]{rule})
-	}
-	r.steps = appendSteps(r.steps, mapKeyRules)
+	r.forKeyRules = r.forKeyRules.Rules(rules...)
 	return r
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) RulesForValues(rules ...Rule[V]) PropertyRulesForMap[M, K, V, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.forValueRules = r.forValueRules.Rules(rules...)
 	return r
 }
 
-func (r PropertyRulesForMap[M, K, V, S]) RulesForItems(
-	rules ...Rule[MapItem[K, V]],
-) PropertyRulesForMap[M, K, V, S] {
-	r.steps = appendSteps(r.steps, rules)
+func (r PropertyRulesForMap[M, K, V, S]) RulesForItems(rules ...Rule[MapItem[K, V]]) PropertyRulesForMap[M, K, V, S] {
+	r.forItemRules = r.forItemRules.Rules(rules...)
 	return r
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) Rules(rules ...Rule[M]) PropertyRulesForMap[M, K, V, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.mapRules = r.mapRules.Rules(rules...)
 	return r
 }
 
@@ -184,34 +93,24 @@ func (r PropertyRulesForMap[M, K, V, S]) When(predicates ...Predicate[S]) Proper
 	return r
 }
 
-// mapKeyValidator wraps Validator for map keys in a custom type in order
-// to discern between validators for keys and values.
-// Otherwise, if key and value have the same type both Validator[K] and Validator[V] would match.
-type mapKeyValidator[K comparable] struct{ Validator[K] }
-
 func (r PropertyRulesForMap[M, K, V, S]) IncludeForKeys(validators ...Validator[K]) PropertyRulesForMap[M, K, V, S] {
-	mapKeyValidators := make([]mapKeyValidator[K], 0, len(validators))
-	for _, validator := range validators {
-		mapKeyValidators = append(mapKeyValidators, mapKeyValidator[K]{validator})
-	}
-	r.steps = appendSteps(r.steps, mapKeyValidators)
+	r.forKeyRules = r.forKeyRules.Include(validators...)
 	return r
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) IncludeForValues(rules ...Validator[V]) PropertyRulesForMap[M, K, V, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.forValueRules = r.forValueRules.Include(rules...)
 	return r
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) IncludeForItems(
 	rules ...Validator[MapItem[K, V]],
 ) PropertyRulesForMap[M, K, V, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.forItemRules = r.forItemRules.Include(rules...)
 	return r
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) StopOnError() PropertyRulesForMap[M, K, V, S] {
-	r.steps = append(r.steps, stopOnErrorStep(0))
 	return r
 }
 

--- a/internal/validation/rules_for_map.go
+++ b/internal/validation/rules_for_map.go
@@ -48,17 +48,11 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) PropertyErrors {
 				e.IsKeyError = true
 				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
 			}
-			if r.mode == CascadeModeStop {
-				break
-			}
 		}
 		forValueErr := r.forValueRules.Validate(v)
 		if forValueErr != nil {
 			for _, e := range forValueErr {
 				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
-			}
-			if r.mode == CascadeModeStop {
-				break
 			}
 		}
 		forItemErr := r.forItemRules.Validate(MapItem[K, V]{Key: k, Value: v})
@@ -69,12 +63,9 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) PropertyErrors {
 				e.PropertyValue = propertyValueString(v)
 				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
 			}
-			if r.mode == CascadeModeStop {
-				break
-			}
 		}
 	}
-	return err.Aggregate()
+	return err.Aggregate().Sort()
 }
 
 func (r PropertyRulesForMap[M, K, V, S]) WithName(name string) PropertyRulesForMap[M, K, V, S] {
@@ -124,12 +115,12 @@ func (r PropertyRulesForMap[M, K, V, S]) IncludeForItems(
 	return r
 }
 
-func (r PropertyRulesForMap[M, K, V, S]) CascadeMode(mode CascadeMode) PropertyRulesForMap[M, K, V, S] {
+func (r PropertyRulesForMap[M, K, V, S]) Cascade(mode CascadeMode) PropertyRulesForMap[M, K, V, S] {
 	r.mode = mode
-	r.mapRules = r.mapRules.CascadeMode(mode)
-	r.forKeyRules = r.forKeyRules.CascadeMode(mode)
-	r.forValueRules = r.forValueRules.CascadeMode(mode)
-	r.forItemRules = r.forItemRules.CascadeMode(mode)
+	r.mapRules = r.mapRules.Cascade(mode)
+	r.forKeyRules = r.forKeyRules.Cascade(mode)
+	r.forValueRules = r.forValueRules.Cascade(mode)
+	r.forItemRules = r.forItemRules.Cascade(mode)
 	return r
 }
 

--- a/internal/validation/rules_for_map.go
+++ b/internal/validation/rules_for_map.go
@@ -43,26 +43,20 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) PropertyErrors {
 	}
 	for k, v := range r.getter(st) {
 		forKeyErr := r.forKeyRules.Validate(k)
-		if forKeyErr != nil {
-			for _, e := range forKeyErr {
-				e.IsKeyError = true
-				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
-			}
+		for _, e := range forKeyErr {
+			e.IsKeyError = true
+			err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
 		}
 		forValueErr := r.forValueRules.Validate(v)
-		if forValueErr != nil {
-			for _, e := range forValueErr {
-				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
-			}
+		for _, e := range forValueErr {
+			err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
 		}
 		forItemErr := r.forItemRules.Validate(MapItem[K, V]{Key: k, Value: v})
-		if forItemErr != nil {
-			for _, e := range forItemErr {
-				// TODO: Figure out how to handle custom PropertyErrors.
-				// Custom errors' value for nested item will be overridden by the actual value.
-				e.PropertyValue = propertyValueString(v)
-				err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
-			}
+		for _, e := range forItemErr {
+			// TODO: Figure out how to handle custom PropertyErrors.
+			// Custom errors' value for nested item will be overridden by the actual value.
+			e.PropertyValue = propertyValueString(v)
+			err = append(err, e.PrependPropertyName(MapElementName(r.mapRules.name, k)))
 		}
 	}
 	return err.Aggregate().Sort()

--- a/internal/validation/rules_for_map_test.go
+++ b/internal/validation/rules_for_map_test.go
@@ -146,11 +146,13 @@ func TestPropertyRulesForMap(t *testing.T) {
 			{
 				PropertyName:  "test.path.key1.nested",
 				PropertyValue: "nestedKey",
+				IsKeyError:    true,
 				Errors:        []*RuleError{{Message: errNestedKey.Error()}},
 			},
 			{
 				PropertyName:  "test.path.key2.nested",
 				PropertyValue: "nestedKey",
+				IsKeyError:    true,
 				Errors:        []*RuleError{{Message: errNestedKey.Error()}},
 			},
 			{

--- a/internal/validation/rules_for_map_test.go
+++ b/internal/validation/rules_for_map_test.go
@@ -183,12 +183,12 @@ func TestPropertyRulesForMap(t *testing.T) {
 			},
 			{
 				PropertyName:  "test.path.key1.nested",
-				PropertyValue: "nestedItem",
+				PropertyValue: "value1",
 				Errors:        []*RuleError{{Message: errNestedItem.Error()}},
 			},
 			{
 				PropertyName:  "test.path.key2.nested",
-				PropertyValue: "nestedItem",
+				PropertyValue: "value2",
 				Errors:        []*RuleError{{Message: errNestedItem.Error()}},
 			},
 			{
@@ -199,18 +199,19 @@ func TestPropertyRulesForMap(t *testing.T) {
 		}, errs)
 	})
 
-	t.Run("stop on error", func(t *testing.T) {
+	t.Run("cascade mode stop", func(t *testing.T) {
 		expectedErr := errors.New("oh no!")
 		r := ForMap(func(m mockStruct) map[string]string { return map[string]string{"key": "value"} }).
 			WithName("test.path").
-			RulesForValues(NewSingleRule(func(v string) error { return expectedErr })).
-			StopOnError().
-			RulesForKeys(NewSingleRule(func(v string) error { return errors.New("no") }))
+			CascadeMode(CascadeModeStop).
+			RulesForValues(NewSingleRule(func(v string) error { return errors.New("no") })).
+			RulesForKeys(NewSingleRule(func(v string) error { return expectedErr }))
 		errs := r.Validate(mockStruct{})
 		require.Len(t, errs, 1)
 		assert.Equal(t, &PropertyError{
 			PropertyName:  "test.path.key",
-			PropertyValue: "value",
+			PropertyValue: "key",
+			IsKeyError:    true,
 			Errors:        []*RuleError{{Message: expectedErr.Error()}},
 		}, errs[0])
 	})
@@ -263,6 +264,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 			{
 				PropertyName:  "test.path.key.included_key",
 				PropertyValue: "key",
+				IsKeyError:    true,
 				Errors: []*RuleError{
 					{Message: errIncludedKey1.Error()},
 					{Message: errIncludedKey2.Error()},
@@ -278,7 +280,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 			},
 			{
 				PropertyName:  "test.path.key.included_item",
-				PropertyValue: `{"Key":"key","Value":1}`,
+				PropertyValue: "1",
 				Errors: []*RuleError{
 					{Message: errIncludedItem1.Error()},
 					{Message: errIncludedItem2.Error()},
@@ -335,6 +337,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 			{
 				PropertyName:  "test.path.key.included_key",
 				PropertyValue: "key",
+				IsKeyError:    true,
 				Errors: []*RuleError{
 					{Message: errIncludedKey1.Error()},
 					{Message: errIncludedKey2.Error()},
@@ -350,7 +353,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 			},
 			{
 				PropertyName:  "test.path.key.included_item",
-				PropertyValue: `{"Key":"key","Value":"1"}`,
+				PropertyValue: "1",
 				Errors: []*RuleError{
 					{Message: errIncludedItem1.Error()},
 					{Message: errIncludedItem2.Error()},

--- a/internal/validation/rules_for_slice.go
+++ b/internal/validation/rules_for_slice.go
@@ -1,146 +1,72 @@
 package validation
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // ForSlice creates a new [PropertyRulesForSlice] instance for a slice property
 // which value is extracted through [PropertyGetter] function.
 func ForSlice[T, S any](getter PropertyGetter[[]T, S]) PropertyRulesForSlice[T, S] {
-	return PropertyRulesForSlice[T, S]{getter: getter}
+	return PropertyRulesForSlice[T, S]{
+		sliceRules:   For(GetSelf[[]T]()),
+		forEachRules: For(GetSelf[T]()),
+		getter:       getter,
+	}
 }
 
 // PropertyRulesForSlice is responsible for validating a single property.
 type PropertyRulesForSlice[T, S any] struct {
-	name       string
-	getter     PropertyGetter[[]T, S]
-	steps      []interface{}
-	predicates []Predicate[S]
+	sliceRules   PropertyRules[[]T, []T]
+	forEachRules PropertyRules[T, T]
+	getter       PropertyGetter[[]T, S]
+
+	predicateMatcher[S]
 }
 
 // Validate executes each of the rules sequentially and aggregates the encountered errors.
-// nolint: prealloc, gocognit
 func (r PropertyRulesForSlice[T, S]) Validate(st S) PropertyErrors {
-	var (
-		allErrors          PropertyErrors
-		sliceErrors        []error
-		propValue          []T
-		previousStepFailed bool
-	)
-	for _, predicate := range r.predicates {
-		if !predicate(st) {
-			return nil
+	if !r.matchPredicates(st) {
+		return nil
+	}
+	v := r.getter(st)
+	err := r.sliceRules.Validate(v)
+	for i, element := range v {
+		forEachErr := r.forEachRules.Validate(element)
+		if forEachErr == nil {
+			continue
+		}
+		for _, e := range forEachErr {
+			e.IsSliceElementError = true
+			err = append(err, e.PrependPropertyName(SliceElementName(r.sliceRules.name, i)))
 		}
 	}
-	sliceElementErrors := make(map[int]sliceElementError)
-loop:
-	for _, step := range r.steps {
-		switch v := step.(type) {
-		case stopOnErrorStep:
-			if previousStepFailed {
-				break loop
-			}
-		case Predicate[S]:
-			if !v(st) {
-				break loop
-			}
-		// Same as Rule[S] as for GetSelf we'd get the same type on T and S.
-		case Rule[T]:
-			errorEncountered := false
-			for i, element := range r.getter(st) {
-				err := v.Validate(element)
-				if err == nil {
-					continue
-				}
-				errorEncountered = true
-				switch ev := err.(type) {
-				case *PropertyError:
-					ev.IsSliceElementError = true
-					allErrors = append(allErrors, ev.PrependPropertyName(SliceElementName(r.name, i)))
-				default:
-					fErrs := sliceElementErrors[i].Errors
-					sliceElementErrors[i] = sliceElementError{Errors: append(fErrs, err), PropValue: element}
-				}
-			}
-			previousStepFailed = errorEncountered
-		case Rule[[]T]:
-			propValue = r.getter(st)
-			err := v.Validate(propValue)
-			if err != nil {
-				switch ev := err.(type) {
-				case *PropertyError:
-					ev.IsSliceElementError = true
-					allErrors = append(allErrors, ev.PrependPropertyName(r.name))
-				default:
-					sliceErrors = append(sliceErrors, err)
-				}
-			}
-			previousStepFailed = err != nil
-		case validatorI[T]:
-			errorEncountered := false
-			for i, element := range r.getter(st) {
-				err := v.Validate(element)
-				if err == nil {
-					continue
-				}
-				errorEncountered = true
-				for _, e := range err.Errors {
-					e.IsSliceElementError = true
-					allErrors = append(allErrors, e.PrependPropertyName(SliceElementName(r.name, i)))
-				}
-			}
-			previousStepFailed = errorEncountered
-		}
-	}
-	if len(sliceErrors) > 0 {
-		allErrors = append(allErrors, NewPropertyError(r.name, propValue, sliceErrors...))
-	}
-	for i, element := range sliceElementErrors {
-		pErr := NewPropertyError(
-			SliceElementName(r.name, i),
-			element.PropValue,
-			element.Errors...)
-		pErr.IsSliceElementError = true
-		allErrors = append(allErrors, pErr)
-	}
-	if len(allErrors) > 0 {
-		return allErrors
-	}
-	return nil
-}
-
-type sliceElementError struct {
-	PropValue interface{}
-	Errors    []error
+	return err.Aggregate()
 }
 
 func (r PropertyRulesForSlice[T, S]) WithName(name string) PropertyRulesForSlice[T, S] {
-	r.name = name
+	r.sliceRules.name = name
 	return r
 }
 
 func (r PropertyRulesForSlice[T, S]) RulesForEach(rules ...Rule[T]) PropertyRulesForSlice[T, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.forEachRules = r.forEachRules.Rules(rules...)
 	return r
 }
 
 func (r PropertyRulesForSlice[T, S]) Rules(rules ...Rule[[]T]) PropertyRulesForSlice[T, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.sliceRules = r.sliceRules.Rules(rules...)
 	return r
 }
 
 func (r PropertyRulesForSlice[T, S]) When(predicates ...Predicate[S]) PropertyRulesForSlice[T, S] {
-	r.predicates = append(r.predicates, predicates...)
+	r.predicateMatcher = r.predicateMatcher.when(predicates...)
 	return r
 }
 
 func (r PropertyRulesForSlice[T, S]) IncludeForEach(rules ...Validator[T]) PropertyRulesForSlice[T, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.forEachRules = r.forEachRules.Include(rules...)
 	return r
 }
 
 func (r PropertyRulesForSlice[T, S]) StopOnError() PropertyRulesForSlice[T, S] {
-	r.steps = append(r.steps, stopOnErrorStep(0))
 	return r
 }
 

--- a/internal/validation/rules_for_slice.go
+++ b/internal/validation/rules_for_slice.go
@@ -41,9 +41,6 @@ func (r PropertyRulesForSlice[T, S]) Validate(st S) PropertyErrors {
 			e.IsSliceElementError = true
 			err = append(err, e.PrependPropertyName(SliceElementName(r.sliceRules.name, i)))
 		}
-		if r.mode == CascadeModeStop {
-			break
-		}
 	}
 	return err.Aggregate()
 }
@@ -64,7 +61,7 @@ func (r PropertyRulesForSlice[T, S]) Rules(rules ...Rule[[]T]) PropertyRulesForS
 }
 
 func (r PropertyRulesForSlice[T, S]) When(predicates ...Predicate[S]) PropertyRulesForSlice[T, S] {
-	r.predicateMatcher = r.predicateMatcher.when(predicates...)
+	r.predicateMatcher = r.when(predicates...)
 	return r
 }
 
@@ -73,10 +70,10 @@ func (r PropertyRulesForSlice[T, S]) IncludeForEach(rules ...Validator[T]) Prope
 	return r
 }
 
-func (r PropertyRulesForSlice[T, S]) CascadeMode(mode CascadeMode) PropertyRulesForSlice[T, S] {
+func (r PropertyRulesForSlice[T, S]) Cascade(mode CascadeMode) PropertyRulesForSlice[T, S] {
 	r.mode = mode
-	r.sliceRules = r.sliceRules.CascadeMode(mode)
-	r.forEachRules = r.forEachRules.CascadeMode(mode)
+	r.sliceRules = r.sliceRules.Cascade(mode)
+	r.forEachRules = r.forEachRules.Cascade(mode)
 	return r
 }
 

--- a/internal/validation/rules_for_slice.go
+++ b/internal/validation/rules_for_slice.go
@@ -58,9 +58,6 @@ loop:
 					ev.IsSliceElementError = true
 					allErrors = append(allErrors, ev.PrependPropertyName(SliceElementName(r.name, i)))
 				default:
-					if sliceElementErrors == nil {
-						sliceElementErrors = make(map[int]sliceElementError)
-					}
 					fErrs := sliceElementErrors[i].Errors
 					sliceElementErrors[i] = sliceElementError{Errors: append(fErrs, err), PropValue: element}
 				}

--- a/internal/validation/rules_for_slice_test.go
+++ b/internal/validation/rules_for_slice_test.go
@@ -74,10 +74,9 @@ func TestPropertyRulesForEach(t *testing.T) {
 				Errors:        []*RuleError{{Message: err3.Error()}},
 			},
 			{
-				PropertyName:        "test.path.nested",
-				PropertyValue:       "nestedValue",
-				IsSliceElementError: true,
-				Errors:              []*RuleError{{Message: err4.Error()}},
+				PropertyName:  "test.path.nested",
+				PropertyValue: "nestedValue",
+				Errors:        []*RuleError{{Message: err4.Error()}},
 			},
 			{
 				PropertyName:        "test.path[0]",

--- a/internal/validation/rules_for_slice_test.go
+++ b/internal/validation/rules_for_slice_test.go
@@ -109,7 +109,7 @@ func TestPropertyRulesForEach(t *testing.T) {
 		expectedErr := errors.New("oh no!")
 		r := ForSlice(func(m mockStruct) []string { return []string{"value"} }).
 			WithName("test.path").
-			CascadeMode(CascadeModeStop).
+			Cascade(CascadeModeStop).
 			RulesForEach(NewSingleRule(func(v string) error { return expectedErr })).
 			RulesForEach(NewSingleRule(func(v string) error { return errors.New("no") }))
 		errs := r.Validate(mockStruct{})
@@ -129,7 +129,7 @@ func TestPropertyRulesForEach(t *testing.T) {
 		r := ForSlice(func(m mockStruct) []string { return m.Fields }).
 			WithName("test.path").
 			RulesForEach(NewSingleRule(func(v string) error { return err1 })).
-			IncludeForEach(New[string](
+			IncludeForEach(New(
 				For(func(s string) string { return "nested" }).
 					WithName("included").
 					Rules(
@@ -161,7 +161,7 @@ func TestPropertyRulesForEach(t *testing.T) {
 	t.Run("include nested for slice", func(t *testing.T) {
 		forEachErr := errors.New("oh no!")
 		includedErr := errors.New("oh no!")
-		inc := New[[]string](
+		inc := New(
 			ForSlice(GetSelf[[]string]()).
 				RulesForEach(NewSingleRule(func(v string) error {
 					if v == "value1" {

--- a/internal/validation/rules_for_slice_test.go
+++ b/internal/validation/rules_for_slice_test.go
@@ -105,12 +105,12 @@ func TestPropertyRulesForEach(t *testing.T) {
 		}, errs)
 	})
 
-	t.Run("stop on error", func(t *testing.T) {
+	t.Run("cascade mode stop", func(t *testing.T) {
 		expectedErr := errors.New("oh no!")
 		r := ForSlice(func(m mockStruct) []string { return []string{"value"} }).
 			WithName("test.path").
+			CascadeMode(CascadeModeStop).
 			RulesForEach(NewSingleRule(func(v string) error { return expectedErr })).
-			StopOnError().
 			RulesForEach(NewSingleRule(func(v string) error { return errors.New("no") }))
 		errs := r.Validate(mockStruct{})
 		require.Len(t, errs, 1)

--- a/internal/validation/rules_test.go
+++ b/internal/validation/rules_test.go
@@ -80,12 +80,12 @@ func TestPropertyRules(t *testing.T) {
 		}, errs)
 	})
 
-	t.Run("stop on error", func(t *testing.T) {
+	t.Run("cascade mode stop", func(t *testing.T) {
 		expectedErr := errors.New("oh no!")
 		r := For(func(m mockStruct) string { return "value" }).
 			WithName("test.path").
+			CascadeMode(CascadeModeStop).
 			Rules(NewSingleRule(func(v string) error { return expectedErr })).
-			StopOnError().
 			Rules(NewSingleRule(func(v string) error { return errors.New("no") }))
 		errs := r.Validate(mockStruct{})
 		require.Len(t, errs, 1)

--- a/internal/validation/rules_test.go
+++ b/internal/validation/rules_test.go
@@ -84,7 +84,7 @@ func TestPropertyRules(t *testing.T) {
 		expectedErr := errors.New("oh no!")
 		r := For(func(m mockStruct) string { return "value" }).
 			WithName("test.path").
-			CascadeMode(CascadeModeStop).
+			Cascade(CascadeModeStop).
 			Rules(NewSingleRule(func(v string) error { return expectedErr })).
 			Rules(NewSingleRule(func(v string) error { return errors.New("no") }))
 		errs := r.Validate(mockStruct{})
@@ -103,7 +103,7 @@ func TestPropertyRules(t *testing.T) {
 		r := For(func(m mockStruct) mockStruct { return m }).
 			WithName("test.path").
 			Rules(NewSingleRule(func(v mockStruct) error { return err1 })).
-			Include(New[mockStruct](
+			Include(New(
 				For(func(s mockStruct) string { return "value" }).
 					WithName("included").
 					Rules(NewSingleRule(func(v string) error { return err2 })).

--- a/internal/validation/string.go
+++ b/internal/validation/string.go
@@ -48,7 +48,7 @@ func StringDenyRegexp(re *regexp.Regexp, examples ...string) SingleRule[string] 
 var dns1123SubdomainRegexp = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 
 func StringIsDNSSubdomain() RuleSet[string] {
-	return NewRuleSet[string](
+	return NewRuleSet(
 		StringLength(1, 63),
 		StringMatchRegexp(dns1123SubdomainRegexp, "my-name", "123-abc").
 			WithDetails("a DNS-1123 compliant name must consist of lower case alphanumeric characters or '-',"+
@@ -158,7 +158,7 @@ func prettyStringListBuilder[T any](b *strings.Builder, values []T, surroundInSi
 		if surroundInSingleQuotes {
 			b.WriteString("'")
 		}
-		b.WriteString(fmt.Sprint(values[i]))
+		fmt.Fprint(b, values[i])
 		if surroundInSingleQuotes {
 			b.WriteString("'")
 		}

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestValidator(t *testing.T) {
 	t.Run("no errors", func(t *testing.T) {
-		r := New[mockValidatorStruct](
-			For[string](func(m mockValidatorStruct) string { return "test" }).
+		r := New(
+			For(func(m mockValidatorStruct) string { return "test" }).
 				WithName("test").
 				Rules(NewSingleRule(func(v string) error { return nil })),
 		)
@@ -22,7 +22,7 @@ func TestValidator(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		err1 := errors.New("1")
 		err2 := errors.New("2")
-		r := New[mockValidatorStruct](
+		r := New(
 			For(func(m mockValidatorStruct) string { return "test" }).
 				WithName("test").
 				Rules(NewSingleRule(func(v string) error { return nil })),
@@ -52,8 +52,8 @@ func TestValidator(t *testing.T) {
 
 func TestValidatorWhen(t *testing.T) {
 	t.Run("when condition is not met, don't validate", func(t *testing.T) {
-		r := New[mockValidatorStruct](
-			For[string](func(m mockValidatorStruct) string { return "test" }).
+		r := New(
+			For(func(m mockValidatorStruct) string { return "test" }).
 				WithName("test").
 				Rules(NewSingleRule(func(v string) error { return errors.New("test") })),
 		).
@@ -63,8 +63,8 @@ func TestValidatorWhen(t *testing.T) {
 		assert.Nil(t, errs)
 	})
 	t.Run("when condition is met, validate", func(t *testing.T) {
-		r := New[mockValidatorStruct](
-			For[string](func(m mockValidatorStruct) string { return "test" }).
+		r := New(
+			For(func(m mockValidatorStruct) string { return "test" }).
 				WithName("test").
 				Rules(NewSingleRule(func(v string) error { return errors.New("test") })),
 		).
@@ -83,8 +83,8 @@ func TestValidatorWhen(t *testing.T) {
 }
 
 func TestValidatorWithName(t *testing.T) {
-	r := New[mockValidatorStruct](
-		For[string](func(m mockValidatorStruct) string { return "test" }).
+	r := New(
+		For(func(m mockValidatorStruct) string { return "test" }).
 			WithName("test").
 			Rules(NewSingleRule(func(v string) error { return errors.New("test") })),
 	).WithName("validator")

--- a/manifest/v1alpha/agent/validation.go
+++ b/manifest/v1alpha/agent/validation.go
@@ -25,7 +25,7 @@ var agentValidation = validation.New[Agent](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(exactlyOneDataSourceTypeValidationRule).
 		Rules(
 			historicalDataRetrievalValidationRule,

--- a/manifest/v1alpha/agent/validation.go
+++ b/manifest/v1alpha/agent/validation.go
@@ -25,8 +25,8 @@ var agentValidation = validation.New[Agent](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
+		CascadeMode(validation.CascadeModeStop).
 		Rules(exactlyOneDataSourceTypeValidationRule).
-		StopOnError().
 		Rules(
 			historicalDataRetrievalValidationRule,
 			queryDelayGreaterThanOrEqualToDefaultValidationRule),

--- a/manifest/v1alpha/alertmethod/validation.go
+++ b/manifest/v1alpha/alertmethod/validation.go
@@ -132,8 +132,8 @@ var webhookValidation = validation.New[WebhookAlertMethod](
 		Rules(validation.NewSingleRule(validateTemplateFields)),
 	validation.ForSlice(func(w WebhookAlertMethod) []WebhookHeader { return w.Headers }).
 		WithName("headers").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.SliceMaxLength[[]WebhookHeader](maxWebhookHeaders)).
-		StopOnError().
 		IncludeForEach(webhookHeaderValidation),
 )
 
@@ -158,6 +158,7 @@ var discordValidation = validation.New[DiscordAlertMethod](
 	validation.For(func(s DiscordAlertMethod) string { return s.URL }).
 		WithName("url").
 		HideValue().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(
 			validation.NewSingleRule(func(v string) error {
 				if strings.HasSuffix(strings.ToLower(v), "/slack") || strings.HasSuffix(strings.ToLower(v), "/github") {
@@ -165,7 +166,6 @@ var discordValidation = validation.New[DiscordAlertMethod](
 				}
 				return nil
 			})).
-		StopOnError().
 		Include(optionalUrlValidation()),
 )
 
@@ -202,8 +202,8 @@ var jiraValidation = validation.New[JiraAlertMethod](
 	validation.Transform(func(j JiraAlertMethod) string { return j.URL }, url.Parse).
 		WithName("url").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.URL()).
-		StopOnError().
 		Rules(
 			validation.NewSingleRule(func(u *url.URL) error {
 				if u.Scheme != "https" {
@@ -224,8 +224,8 @@ var teamsValidation = validation.New[TeamsAlertMethod](
 	validation.Transform(func(t TeamsAlertMethod) string { return t.URL }, url.Parse).
 		WithName("url").
 		HideValue().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.URL()).
-		StopOnError().
 		Rules(
 			validation.NewSingleRule(func(u *url.URL) error {
 				if u.Scheme != "https" {

--- a/manifest/v1alpha/alertmethod/validation.go
+++ b/manifest/v1alpha/alertmethod/validation.go
@@ -132,7 +132,7 @@ var webhookValidation = validation.New[WebhookAlertMethod](
 		Rules(validation.NewSingleRule(validateTemplateFields)),
 	validation.ForSlice(func(w WebhookAlertMethod) []WebhookHeader { return w.Headers }).
 		WithName("headers").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceMaxLength[[]WebhookHeader](maxWebhookHeaders)).
 		IncludeForEach(webhookHeaderValidation),
 )
@@ -158,7 +158,7 @@ var discordValidation = validation.New[DiscordAlertMethod](
 	validation.For(func(s DiscordAlertMethod) string { return s.URL }).
 		WithName("url").
 		HideValue().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(
 			validation.NewSingleRule(func(v string) error {
 				if strings.HasSuffix(strings.ToLower(v), "/slack") || strings.HasSuffix(strings.ToLower(v), "/github") {
@@ -202,7 +202,7 @@ var jiraValidation = validation.New[JiraAlertMethod](
 	validation.Transform(func(j JiraAlertMethod) string { return j.URL }, url.Parse).
 		WithName("url").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.URL()).
 		Rules(
 			validation.NewSingleRule(func(u *url.URL) error {
@@ -224,7 +224,7 @@ var teamsValidation = validation.New[TeamsAlertMethod](
 	validation.Transform(func(t TeamsAlertMethod) string { return t.URL }, url.Parse).
 		WithName("url").
 		HideValue().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.URL()).
 		Rules(
 			validation.NewSingleRule(func(u *url.URL) error {

--- a/manifest/v1alpha/alertpolicy/validation.go
+++ b/manifest/v1alpha/alertpolicy/validation.go
@@ -43,7 +43,7 @@ var specValidation = validation.New[Spec](
 		Rules(validation.GreaterThanOrEqualTo(time.Minute*5)),
 	validation.ForSlice(func(s Spec) []AlertCondition { return s.Conditions }).
 		WithName("conditions").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceMinLength[[]AlertCondition](1)).
 		IncludeForEach(conditionValidation),
 	validation.ForSlice(func(s Spec) []AlertMethodRef { return s.AlertMethods }).

--- a/manifest/v1alpha/alertpolicy/validation.go
+++ b/manifest/v1alpha/alertpolicy/validation.go
@@ -43,8 +43,8 @@ var specValidation = validation.New[Spec](
 		Rules(validation.GreaterThanOrEqualTo(time.Minute*5)),
 	validation.ForSlice(func(s Spec) []AlertCondition { return s.Conditions }).
 		WithName("conditions").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.SliceMinLength[[]AlertCondition](1)).
-		StopOnError().
 		IncludeForEach(conditionValidation),
 	validation.ForSlice(func(s Spec) []AlertMethodRef { return s.AlertMethods }).
 		WithName("alertMethods").

--- a/manifest/v1alpha/alertsilence/validation.go
+++ b/manifest/v1alpha/alertsilence/validation.go
@@ -11,8 +11,8 @@ import (
 
 var alertSilenceValidation = validation.New[AlertSilence](
 	validation.For(validation.GetSelf[AlertSilence]()).
+		CascadeMode(validation.CascadeModeStop).
 		Include(metadataValidation).
-		StopOnError().
 		Rules(alertPolicyProjectConsistencyRule),
 	validation.For(func(s AlertSilence) Spec { return s.Spec }).
 		WithName("spec").
@@ -37,13 +37,13 @@ var specValidation = validation.New[Spec](
 		Include(alertPolicySourceValidation),
 	validation.For(func(s Spec) Period { return s.Period }).
 		WithName("period").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(
 			validation.MutuallyExclusive(true, map[string]func(p Period) any{
 				"duration": func(p Period) any { return p.Duration },
 				"endTime":  func(p Period) any { return p.EndTime },
 			}),
 		).
-		StopOnError().
 		Include(
 			validation.New[Period](
 				validation.Transform(func(p Period) string { return p.Duration }, time.ParseDuration).

--- a/manifest/v1alpha/alertsilence/validation.go
+++ b/manifest/v1alpha/alertsilence/validation.go
@@ -11,7 +11,7 @@ import (
 
 var alertSilenceValidation = validation.New[AlertSilence](
 	validation.For(validation.GetSelf[AlertSilence]()).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Include(metadataValidation).
 		Rules(alertPolicyProjectConsistencyRule),
 	validation.For(func(s AlertSilence) Spec { return s.Spec }).
@@ -37,7 +37,7 @@ var specValidation = validation.New[Spec](
 		Include(alertPolicySourceValidation),
 	validation.For(func(s Spec) Period { return s.Period }).
 		WithName("period").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(
 			validation.MutuallyExclusive(true, map[string]func(p Period) any{
 				"duration": func(p Period) any { return p.Duration },

--- a/manifest/v1alpha/budgetadjustment/validation.go
+++ b/manifest/v1alpha/budgetadjustment/validation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 )
 
-var budgetAdjustmentValidation = validation.New[BudgetAdjustment](
+var budgetAdjustmentValidation = validation.New(
 	validation.For(func(b BudgetAdjustment) Metadata { return b.Metadata }).
 		Include(metadataValidation),
 	validation.For(func(b BudgetAdjustment) Spec { return b.Spec }).
@@ -18,12 +18,12 @@ var budgetAdjustmentValidation = validation.New[BudgetAdjustment](
 		Include(specValidation),
 )
 
-var metadataValidation = validation.New[Metadata](
+var metadataValidation = validation.New(
 	validationV1Alpha.FieldRuleMetadataName(func(m Metadata) string { return m.Name }),
 	validationV1Alpha.FieldRuleMetadataDisplayName(func(m Metadata) string { return m.DisplayName }),
 )
 
-var specValidation = validation.New[Spec](
+var specValidation = validation.New(
 	validation.For(func(s Spec) string { return s.Description }).
 		WithName("description").
 		Rules(validation.StringDescription()),
@@ -41,14 +41,14 @@ var specValidation = validation.New[Spec](
 		Include(filtersValidationRule),
 )
 
-var filtersValidationRule = validation.New[Filters](
+var filtersValidationRule = validation.New(
 	validation.ForSlice(func(f Filters) []SLORef { return f.SLOs }).
 		WithName("slos").
 		Rules(validation.SliceMinLength[[]SLORef](1)).
 		IncludeForEach(sloValidationRule),
 )
 
-var sloValidationRule = validation.New[SLORef](
+var sloValidationRule = validation.New(
 	validation.For(func(s SLORef) string { return s.Project }).
 		WithName("project").
 		Required().

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -24,7 +24,7 @@ var directValidation = validation.New[Direct](
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
 		Rules(exactlyOneDataSourceTypeValidationRule).
-		StopOnError().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(
 			historicalDataRetrievalValidationRule,
 			queryDelayGreaterThanOrEqualToDefaultValidationRule),
@@ -344,9 +344,9 @@ const errorCodeHTTPSSchemeRequired = "https_scheme_required"
 func urlPropertyRules[S any](getter validation.PropertyGetter[string, S]) validation.PropertyRules[*url.URL, S] {
 	return validation.Transform(getter, url.Parse).
 		WithName("url").
+		CascadeMode(validation.CascadeModeStop).
 		Required().
 		Rules(validation.URL()).
-		StopOnError().
 		Rules(validation.NewSingleRule(func(u *url.URL) error {
 			if u.Scheme != "https" {
 				return errors.New("requires https scheme")

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -24,7 +24,7 @@ var directValidation = validation.New[Direct](
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
 		Rules(exactlyOneDataSourceTypeValidationRule).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(
 			historicalDataRetrievalValidationRule,
 			queryDelayGreaterThanOrEqualToDefaultValidationRule),
@@ -344,7 +344,7 @@ const errorCodeHTTPSSchemeRequired = "https_scheme_required"
 func urlPropertyRules[S any](getter validation.PropertyGetter[string, S]) validation.PropertyRules[*url.URL, S] {
 	return validation.Transform(getter, url.Parse).
 		WithName("url").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Required().
 		Rules(validation.URL()).
 		Rules(validation.NewSingleRule(func(u *url.URL) error {

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -23,8 +23,8 @@ var directValidation = validation.New[Direct](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		Rules(exactlyOneDataSourceTypeValidationRule).
 		Cascade(validation.CascadeModeStop).
+		Rules(exactlyOneDataSourceTypeValidationRule).
 		Rules(
 			historicalDataRetrievalValidationRule,
 			queryDelayGreaterThanOrEqualToDefaultValidationRule),

--- a/manifest/v1alpha/slo/metrics_azure_monitor.go
+++ b/manifest/v1alpha/slo/metrics_azure_monitor.go
@@ -76,9 +76,9 @@ var azureMonitorMetricDataTypeValidation = validation.New[AzureMonitorMetric](
 		Rules(validation.OneOf(supportedAzureMonitorAggregations...)),
 	validation.ForSlice(func(a AzureMonitorMetric) []AzureMonitorMetricDimension { return a.Dimensions }).
 		WithName("dimensions").
-		IncludeForEach(azureMonitorMetricDimensionValidation).
 		// We don't want to check names uniqueness if they're empty.
-		StopOnError().
+		CascadeMode(validation.CascadeModeStop).
+		IncludeForEach(azureMonitorMetricDimensionValidation).
 		Rules(validation.SliceUnique(func(d AzureMonitorMetricDimension) string {
 			if d.Name == nil {
 				return ""

--- a/manifest/v1alpha/slo/metrics_azure_monitor.go
+++ b/manifest/v1alpha/slo/metrics_azure_monitor.go
@@ -76,8 +76,6 @@ var azureMonitorMetricDataTypeValidation = validation.New[AzureMonitorMetric](
 		Rules(validation.OneOf(supportedAzureMonitorAggregations...)),
 	validation.ForSlice(func(a AzureMonitorMetric) []AzureMonitorMetricDimension { return a.Dimensions }).
 		WithName("dimensions").
-		// We don't want to check names uniqueness if they're empty.
-		CascadeMode(validation.CascadeModeStop).
 		IncludeForEach(azureMonitorMetricDimensionValidation).
 		Rules(validation.SliceUnique(func(d AzureMonitorMetricDimension) string {
 			if d.Name == nil {

--- a/manifest/v1alpha/slo/metrics_azure_monitor_test.go
+++ b/manifest/v1alpha/slo/metrics_azure_monitor_test.go
@@ -525,7 +525,7 @@ func TestAzureMonitorDimension(t *testing.T) {
 			},
 		}
 		err := validate(slo)
-		testutils.AssertContainsErrors(t, slo, err, 8,
+		testutils.AssertContainsErrors(t, slo, err, 9,
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[0].name",
 				Code: validation.ErrorCodeRequired,

--- a/manifest/v1alpha/slo/metrics_cloudwatch.go
+++ b/manifest/v1alpha/slo/metrics_cloudwatch.go
@@ -48,6 +48,7 @@ type CloudWatchMetricDimension struct {
 
 var cloudWatchValidation = validation.New[CloudWatchMetric](
 	validation.For(validation.GetSelf[CloudWatchMetric]()).
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.NewSingleRule(func(c CloudWatchMetric) error {
 			var configOptions int
 			if c.IsStandardConfiguration() {
@@ -66,7 +67,6 @@ var cloudWatchValidation = validation.New[CloudWatchMetric](
 			}
 			return nil
 		}).WithErrorCode(validation.ErrorCodeOneOf)).
-		StopOnError().
 		Include(
 			cloudWatchStandardConfigValidation,
 			cloudWatchSQLConfigValidation,
@@ -103,29 +103,28 @@ var cloudWatchStandardConfigValidation = validation.New[CloudWatchMetric](
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.Namespace }).
 		WithName("namespace").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringMatchRegexp(cloudWatchNamespaceRegexp)),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.MetricName }).
 		WithName("metricName").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringMaxLength(255)),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.Stat }).
 		WithName("stat").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringMatchRegexp(cloudWatchStatRegexp, cloudWatchExampleValidStats...)),
 	validation.ForSlice(func(c CloudWatchMetric) []CloudWatchMetricDimension { return c.Dimensions }).
 		WithName("dimensions").
-		Rules(validation.SliceMaxLength[[]CloudWatchMetricDimension](10)).
 		// If the slice is too long, don't proceed with validation.
-		StopOnError().
-		IncludeForEach(cloudwatchMetricDimensionValidation).
-		StopOnError().
 		// We don't want to check names uniqueness if for example names are empty.
+		CascadeMode(validation.CascadeModeStop).
+		Rules(validation.SliceMaxLength[[]CloudWatchMetricDimension](10)).
+		IncludeForEach(cloudwatchMetricDimensionValidation).
 		Rules(validation.SliceUnique(func(c CloudWatchMetricDimension) string {
 			if c.Name == nil {
 				return ""
@@ -134,8 +133,8 @@ var cloudWatchStandardConfigValidation = validation.New[CloudWatchMetric](
 		}).WithDetails("dimension 'name' must be unique for all dimensions")),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.AccountID }).
 		WithName("accountId").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringMatchRegexp(cloudWatchAccountIDRegexp, "123456789012")),
 ).When(func(c CloudWatchMetric) bool { return c.IsStandardConfiguration() })
 

--- a/manifest/v1alpha/slo/metrics_cloudwatch.go
+++ b/manifest/v1alpha/slo/metrics_cloudwatch.go
@@ -48,7 +48,7 @@ type CloudWatchMetricDimension struct {
 
 var cloudWatchValidation = validation.New[CloudWatchMetric](
 	validation.For(validation.GetSelf[CloudWatchMetric]()).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.NewSingleRule(func(c CloudWatchMetric) error {
 			var configOptions int
 			if c.IsStandardConfiguration() {
@@ -103,26 +103,26 @@ var cloudWatchStandardConfigValidation = validation.New[CloudWatchMetric](
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.Namespace }).
 		WithName("namespace").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringMatchRegexp(cloudWatchNamespaceRegexp)),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.MetricName }).
 		WithName("metricName").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringMaxLength(255)),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.Stat }).
 		WithName("stat").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringMatchRegexp(cloudWatchStatRegexp, cloudWatchExampleValidStats...)),
 	validation.ForSlice(func(c CloudWatchMetric) []CloudWatchMetricDimension { return c.Dimensions }).
 		WithName("dimensions").
 		// If the slice is too long, don't proceed with validation.
 		// We don't want to check names uniqueness if for example names are empty.
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceMaxLength[[]CloudWatchMetricDimension](10)).
 		IncludeForEach(cloudwatchMetricDimensionValidation).
 		Rules(validation.SliceUnique(func(c CloudWatchMetricDimension) string {
@@ -133,7 +133,7 @@ var cloudWatchStandardConfigValidation = validation.New[CloudWatchMetric](
 		}).WithDetails("dimension 'name' must be unique for all dimensions")),
 	validation.ForPointer(func(c CloudWatchMetric) *string { return c.AccountID }).
 		WithName("accountId").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringMatchRegexp(cloudWatchAccountIDRegexp, "123456789012")),
 ).When(func(c CloudWatchMetric) bool { return c.IsStandardConfiguration() })

--- a/manifest/v1alpha/slo/metrics_cloudwatch_test.go
+++ b/manifest/v1alpha/slo/metrics_cloudwatch_test.go
@@ -304,10 +304,26 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 			Code: validation.ErrorCodeSliceMaxLength,
 		})
 	})
-	t.Run("invalid fields", func(t *testing.T) {
+	t.Run("required fields", func(t *testing.T) {
 		slo := validRawMetricSLO(v1alpha.CloudWatch)
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch.Dimensions = []CloudWatchMetricDimension{
 			{},
+		}
+		err := validate(slo)
+		testutils.AssertContainsErrors(t, slo, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name",
+				Code: validation.ErrorCodeRequired,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value",
+				Code: validation.ErrorCodeRequired,
+			},
+		)
+	})
+	t.Run("invalid fields", func(t *testing.T) {
+		slo := validRawMetricSLO(v1alpha.CloudWatch)
+		slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch.Dimensions = []CloudWatchMetricDimension{
 			{
 				Name:  ptr(""),
 				Value: ptr(""),
@@ -322,37 +338,29 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 			},
 		}
 		err := validate(slo)
-		testutils.AssertContainsErrors(t, slo, err, 8,
+		testutils.AssertContainsErrors(t, slo, err, 6,
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name",
-				Code: validation.ErrorCodeRequired,
+				Code: validation.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value",
-				Code: validation.ErrorCodeRequired,
+				Code: validation.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].name",
-				Code: validation.ErrorCodeStringNotEmpty,
+				Code: validation.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].value",
-				Code: validation.ErrorCodeStringNotEmpty,
+				Code: validation.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
 				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].name",
-				Code: validation.ErrorCodeStringMaxLength,
-			},
-			testutils.ExpectedError{
-				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].value",
-				Code: validation.ErrorCodeStringMaxLength,
-			},
-			testutils.ExpectedError{
-				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[3].name",
 				Code: validation.ErrorCodeStringASCII,
 			},
 			testutils.ExpectedError{
-				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[3].value",
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].value",
 				Code: validation.ErrorCodeStringASCII,
 			},
 		)

--- a/manifest/v1alpha/slo/metrics_elasticsearch.go
+++ b/manifest/v1alpha/slo/metrics_elasticsearch.go
@@ -16,7 +16,7 @@ var elasticsearchValidation = validation.New[ElasticsearchMetric](
 	validation.ForPointer(func(e ElasticsearchMetric) *string { return e.Query }).
 		WithName("query").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringContains("{{.BeginTime}}", "{{.EndTime}}")),
 )

--- a/manifest/v1alpha/slo/metrics_elasticsearch.go
+++ b/manifest/v1alpha/slo/metrics_elasticsearch.go
@@ -16,7 +16,7 @@ var elasticsearchValidation = validation.New[ElasticsearchMetric](
 	validation.ForPointer(func(e ElasticsearchMetric) *string { return e.Query }).
 		WithName("query").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringContains("{{.BeginTime}}", "{{.EndTime}}")),
 )

--- a/manifest/v1alpha/slo/metrics_graphite.go
+++ b/manifest/v1alpha/slo/metrics_graphite.go
@@ -15,7 +15,7 @@ var graphiteValidation = validation.New[GraphiteMetric](
 	validation.ForPointer(func(g GraphiteMetric) *string { return g.MetricPath }).
 		WithName("metricPath").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(
 			// Graphite allows the use of wildcards in metric paths, but we decided not to support it for our MVP.

--- a/manifest/v1alpha/slo/metrics_graphite.go
+++ b/manifest/v1alpha/slo/metrics_graphite.go
@@ -15,8 +15,8 @@ var graphiteValidation = validation.New[GraphiteMetric](
 	validation.ForPointer(func(g GraphiteMetric) *string { return g.MetricPath }).
 		WithName("metricPath").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(
 			// Graphite allows the use of wildcards in metric paths, but we decided not to support it for our MVP.
 			// https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards

--- a/manifest/v1alpha/slo/metrics_influxdb.go
+++ b/manifest/v1alpha/slo/metrics_influxdb.go
@@ -15,7 +15,7 @@ var influxdbValidation = validation.New[InfluxDBMetric](
 	validation.ForPointer(func(i InfluxDBMetric) *string { return i.Query }).
 		WithName("query").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(
 			validation.StringMatchRegexp(regexp.MustCompile(`\s*bucket\s*:\s*".+"\s*`)).

--- a/manifest/v1alpha/slo/metrics_influxdb.go
+++ b/manifest/v1alpha/slo/metrics_influxdb.go
@@ -15,8 +15,8 @@ var influxdbValidation = validation.New[InfluxDBMetric](
 	validation.ForPointer(func(i InfluxDBMetric) *string { return i.Query }).
 		WithName("query").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(
 			validation.StringMatchRegexp(regexp.MustCompile(`\s*bucket\s*:\s*".+"\s*`)).
 				WithDetails("must contain a bucket name"),

--- a/manifest/v1alpha/slo/metrics_instana.go
+++ b/manifest/v1alpha/slo/metrics_instana.go
@@ -58,6 +58,7 @@ var instanaCountMetricsLevelValidation = validation.New[CountMetricsSpec](
 
 var instanaValidation = validation.ForPointer(func(m MetricSpec) *InstanaMetric { return m.Instana }).
 	WithName("instana").
+	CascadeMode(validation.CascadeModeStop).
 	Rules(validation.NewSingleRule[InstanaMetric](func(v InstanaMetric) error {
 		if v.Application != nil && v.Infrastructure != nil {
 			return errors.New("cannot use both 'instana.application' and 'instana.infrastructure'")
@@ -77,8 +78,7 @@ var instanaValidation = validation.ForPointer(func(m MetricSpec) *InstanaMetric 
 			}
 		}
 		return nil
-	})).
-	StopOnError()
+	}))
 
 var instanaCountMetricsValidation = validation.New[MetricSpec](
 	instanaValidation.

--- a/manifest/v1alpha/slo/metrics_instana.go
+++ b/manifest/v1alpha/slo/metrics_instana.go
@@ -58,7 +58,7 @@ var instanaCountMetricsLevelValidation = validation.New[CountMetricsSpec](
 
 var instanaValidation = validation.ForPointer(func(m MetricSpec) *InstanaMetric { return m.Instana }).
 	WithName("instana").
-	CascadeMode(validation.CascadeModeStop).
+	Cascade(validation.CascadeModeStop).
 	Rules(validation.NewSingleRule[InstanaMetric](func(v InstanaMetric) error {
 		if v.Application != nil && v.Infrastructure != nil {
 			return errors.New("cannot use both 'instana.application' and 'instana.infrastructure'")

--- a/manifest/v1alpha/slo/metrics_newrelic.go
+++ b/manifest/v1alpha/slo/metrics_newrelic.go
@@ -15,8 +15,8 @@ var newRelicValidation = validation.New[NewRelicMetric](
 	validation.ForPointer(func(n NewRelicMetric) *string { return n.NRQL }).
 		WithName("nrql").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(validation.StringDenyRegexp(regexp.MustCompile(`(?i)[\n\s](since|until)([\n\s]|$)`)).
 			WithDetails("query must not contain 'since' or 'until' keywords (case insensitive)")),
 )

--- a/manifest/v1alpha/slo/metrics_newrelic.go
+++ b/manifest/v1alpha/slo/metrics_newrelic.go
@@ -15,7 +15,7 @@ var newRelicValidation = validation.New[NewRelicMetric](
 	validation.ForPointer(func(n NewRelicMetric) *string { return n.NRQL }).
 		WithName("nrql").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(validation.StringDenyRegexp(regexp.MustCompile(`(?i)[\n\s](since|until)([\n\s]|$)`)).
 			WithDetails("query must not contain 'since' or 'until' keywords (case insensitive)")),

--- a/manifest/v1alpha/slo/metrics_splunk.go
+++ b/manifest/v1alpha/slo/metrics_splunk.go
@@ -15,7 +15,7 @@ var splunkValidation = validation.New[SplunkMetric](
 	validation.ForPointer(func(s SplunkMetric) *string { return s.Query }).
 		WithName("query").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
 		Rules(
 			validation.StringContains("n9time", "n9value"),

--- a/manifest/v1alpha/slo/metrics_splunk.go
+++ b/manifest/v1alpha/slo/metrics_splunk.go
@@ -15,8 +15,8 @@ var splunkValidation = validation.New[SplunkMetric](
 	validation.ForPointer(func(s SplunkMetric) *string { return s.Query }).
 		WithName("query").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.StringNotEmpty()).
-		StopOnError().
 		Rules(
 			validation.StringContains("n9time", "n9value"),
 			validation.StringMatchRegexp(

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -20,7 +20,7 @@ const (
 
 var specMetricsValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.NewSingleRule(func(s Spec) error {
 			if !s.HasCompositeObjectives() {
 				if s.HasRawMetric() == s.HasCountMetrics() {

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -20,6 +20,7 @@ const (
 
 var specMetricsValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.NewSingleRule(func(s Spec) error {
 			if !s.HasCompositeObjectives() {
 				if s.HasRawMetric() == s.HasCountMetrics() {
@@ -28,9 +29,7 @@ var specMetricsValidation = validation.New[Spec](
 			}
 			return nil
 		}).WithErrorCode(errCodeExactlyOneMetricType)).
-		StopOnError().
 		Rules(exactlyOneMetricSpecTypeValidationRule).
-		StopOnError().
 		// Each objective should have exactly two count metrics.
 		Rules(validation.NewSingleRule(func(s Spec) error {
 			for i, objective := range s.Objectives {
@@ -49,7 +48,6 @@ var specMetricsValidation = validation.New[Spec](
 			}
 			return nil
 		})).
-		StopOnError().
 		Rules(timeSliceTargetsValidationRule),
 )
 

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -19,7 +19,7 @@ var sloValidation = validation.New[SLO](
 		Include(metadataValidation),
 	validation.For(func(s SLO) Spec { return s.Spec }).
 		WithName("spec").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Include(specValidationNonComposite).
 		Include(specValidationComposite).
 		Include(specValidation),
@@ -104,7 +104,7 @@ var sloValidationComposite = validation.New[SLO](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Include(specMetricsValidation),
 	validation.For(validation.GetSelf[Spec]()).
 		WithName("composite").
@@ -129,7 +129,7 @@ var specValidation = validation.New[Spec](
 		RulesForEach(validation.StringIsDNSSubdomain()),
 	validation.ForSlice(func(s Spec) []Attachment { return s.Attachments }).
 		WithName("attachments").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceLength[[]Attachment](0, 20)).
 		IncludeForEach(attachmentValidation),
 	validation.ForPointer(func(s Spec) *Composite { return s.Composite }).
@@ -140,13 +140,13 @@ var specValidation = validation.New[Spec](
 		Include(anomalyConfigValidation),
 	validation.ForSlice(func(s Spec) []TimeWindow { return s.TimeWindows }).
 		WithName("timeWindows").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceLength[[]TimeWindow](1, 1)).
 		IncludeForEach(timeWindowsValidation).
 		RulesForEach(timeWindowValidationRule()),
 	validation.ForSlice(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Rules(validation.SliceMinLength[[]Objective](1)).
 		IncludeForEach(objectiveValidation).
 		When(func(s Spec) bool { return !s.HasCompositeObjectives() }).
@@ -264,7 +264,7 @@ var anomalyConfigValidation = validation.New[AnomalyConfig](
 		Include(validation.New[AnomalyConfigNoData](
 			validation.ForSlice(func(a AnomalyConfigNoData) []AnomalyConfigAlertMethod { return a.AlertMethods }).
 				WithName("alertMethods").
-				CascadeMode(validation.CascadeModeStop).
+				Cascade(validation.CascadeModeStop).
 				Rules(validation.SliceMinLength[[]AnomalyConfigAlertMethod](1)).
 				Rules(validation.SliceUnique(validation.SelfHashFunc[AnomalyConfigAlertMethod]())).
 				IncludeForEach(validation.New[AnomalyConfigAlertMethod](

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -19,12 +19,10 @@ var sloValidation = validation.New[SLO](
 		Include(metadataValidation),
 	validation.For(func(s SLO) Spec { return s.Spec }).
 		WithName("spec").
+		CascadeMode(validation.CascadeModeStop).
 		Include(specValidationNonComposite).
-		StopOnError().
 		Include(specValidationComposite).
-		StopOnError().
-		Include(specValidation).
-		StopOnError(),
+		Include(specValidation),
 )
 
 var metadataValidation = validation.New[Metadata](
@@ -106,8 +104,8 @@ var sloValidationComposite = validation.New[SLO](
 
 var specValidation = validation.New[Spec](
 	validation.For(validation.GetSelf[Spec]()).
-		Include(specMetricsValidation).
-		StopOnError(),
+		CascadeMode(validation.CascadeModeStop).
+		Include(specMetricsValidation),
 	validation.For(validation.GetSelf[Spec]()).
 		WithName("composite").
 		When(func(s Spec) bool { return s.Composite != nil }).
@@ -131,8 +129,8 @@ var specValidation = validation.New[Spec](
 		RulesForEach(validation.StringIsDNSSubdomain()),
 	validation.ForSlice(func(s Spec) []Attachment { return s.Attachments }).
 		WithName("attachments").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.SliceLength[[]Attachment](0, 20)).
-		StopOnError().
 		IncludeForEach(attachmentValidation),
 	validation.ForPointer(func(s Spec) *Composite { return s.Composite }).
 		WithName("composite").
@@ -142,15 +140,14 @@ var specValidation = validation.New[Spec](
 		Include(anomalyConfigValidation),
 	validation.ForSlice(func(s Spec) []TimeWindow { return s.TimeWindows }).
 		WithName("timeWindows").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.SliceLength[[]TimeWindow](1, 1)).
-		StopOnError().
 		IncludeForEach(timeWindowsValidation).
-		StopOnError().
 		RulesForEach(timeWindowValidationRule()),
 	validation.ForSlice(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
+		CascadeMode(validation.CascadeModeStop).
 		Rules(validation.SliceMinLength[[]Objective](1)).
-		StopOnError().
 		IncludeForEach(objectiveValidation).
 		When(func(s Spec) bool { return !s.HasCompositeObjectives() }).
 		Rules(validation.SliceUnique(func(v Objective) float64 {
@@ -267,10 +264,9 @@ var anomalyConfigValidation = validation.New[AnomalyConfig](
 		Include(validation.New[AnomalyConfigNoData](
 			validation.ForSlice(func(a AnomalyConfigNoData) []AnomalyConfigAlertMethod { return a.AlertMethods }).
 				WithName("alertMethods").
+				CascadeMode(validation.CascadeModeStop).
 				Rules(validation.SliceMinLength[[]AnomalyConfigAlertMethod](1)).
-				StopOnError().
 				Rules(validation.SliceUnique(validation.SelfHashFunc[AnomalyConfigAlertMethod]())).
-				StopOnError().
 				IncludeForEach(validation.New[AnomalyConfigAlertMethod](
 					validation.For(func(a AnomalyConfigAlertMethod) string { return a.Name }).
 						WithName("name").

--- a/sdk/models/replay.go
+++ b/sdk/models/replay.go
@@ -72,8 +72,8 @@ var replayValidation = validation.New[Replay](
 	validation.For(func(r Replay) ReplayDuration { return r.Duration }).
 		WithName("duration").
 		Required().
+		CascadeMode(validation.CascadeModeStop).
 		Include(replayDurationValidation).
-		StopOnError().
 		Rules(replayDurationValidationRule()),
 )
 

--- a/sdk/models/replay.go
+++ b/sdk/models/replay.go
@@ -72,7 +72,7 @@ var replayValidation = validation.New[Replay](
 	validation.For(func(r Replay) ReplayDuration { return r.Duration }).
 		WithName("duration").
 		Required().
-		CascadeMode(validation.CascadeModeStop).
+		Cascade(validation.CascadeModeStop).
 		Include(replayDurationValidation).
 		Rules(replayDurationValidationRule()),
 )


### PR DESCRIPTION
## Motivation

In order for validation pkg to mature into it's own library we have to cleanup the current hacks and non-ideal solutions.

## Summary

- Removed hacky `StopOnError` construct
- Simplified maps and slices validators' logic
- Added `CascadeMode` similar to https://docs.fluentvalidation.net/en/latest/cascade.html
