### PR TITLE
PC-12164 feat: Additional alert details

### DIFF
--- a/manifest/v1alpha/alert/alert.go
+++ b/manifest/v1alpha/alert/alert.go
@@ -36,18 +36,20 @@ type Metadata struct {
 
 // Spec represents content of Alert's Spec
 type Spec struct {
-	AlertPolicy         ObjectMetadata `json:"alertPolicy"`
-	SLO                 ObjectMetadata `json:"slo"`
-	Service             ObjectMetadata `json:"service"`
-	Objective           Objective      `json:"objective"`
-	Severity            string         `json:"severity"`
-	Status              string         `json:"status"`
-	TriggeredMetricTime string         `json:"triggeredMetricTime"`
-	TriggeredClockTime  string         `json:"triggeredClockTime"`
-	ResolvedClockTime   *string        `json:"resolvedClockTime,omitempty"`
-	ResolvedMetricTime  *string        `json:"resolvedMetricTime,omitempty"`
-	CoolDown            string         `json:"coolDown"`
-	Conditions          []Condition    `json:"conditions"`
+	AlertPolicy                 ObjectMetadata `json:"alertPolicy"`
+	SLO                         ObjectMetadata `json:"slo"`
+	Service                     ObjectMetadata `json:"service"`
+	Objective                   Objective      `json:"objective"`
+	Severity                    string         `json:"severity"`
+	Status                      string         `json:"status"`
+	TriggeredMetricTime         string         `json:"triggeredMetricTime"`
+	TriggeredClockTime          string         `json:"triggeredClockTime"`
+	ResolvedClockTime           *string        `json:"resolvedClockTime,omitempty"`
+	ResolvedMetricTime          *string        `json:"resolvedMetricTime,omitempty"`
+	CoolDown                    string         `json:"coolDown"`
+	Conditions                  []Condition    `json:"conditions"`
+	CoolDownStartedAtMetricTime *string        `json:"coolDownStartedAtMetricTime"`
+	ResolutionReason            *string        `json:"resolutionReason"`
 }
 
 type Objective struct {
@@ -64,11 +66,18 @@ type ObjectMetadata struct {
 }
 
 type Condition struct {
-	Measurement      string      `json:"measurement"`
-	Value            interface{} `json:"value"`
-	AlertingWindow   string      `json:"alertingWindow,omitempty"`
-	LastsForDuration string      `json:"lastsFor,omitempty"`
-	Operator         string      `json:"op,omitempty"`
+	Measurement      string           `json:"measurement"`
+	Value            interface{}      `json:"value"`
+	AlertingWindow   string           `json:"alertingWindow,omitempty"`
+	LastsForDuration string           `json:"lastsFor,omitempty"`
+	Operator         string           `json:"op,omitempty"`
+	Status           *ConditionStatus `json:"status,omitempty"`
+}
+
+type ConditionStatus struct {
+	StartedAtMetricTime string  `json:"startedAtMetricTime,omitempty"`
+	StoppedAtMetricTime *string `json:"stoppedAtMetricTIme,omitempty"`
+	LastsForMetAt       *string `json:"lastsForMetAt,omitempty"`
 }
 
 var validator = validation.New[Alert]()

--- a/manifest/v1alpha/alert/alert.go
+++ b/manifest/v1alpha/alert/alert.go
@@ -75,9 +75,9 @@ type Condition struct {
 }
 
 type ConditionStatus struct {
-	StartedAtMetricTime string  `json:"startedAtMetricTime,omitempty"`
-	StoppedAtMetricTime *string `json:"stoppedAtMetricTIme,omitempty"`
-	LastsForMetAt       *string `json:"lastsForMetAt,omitempty"`
+	FirstMetMetricTime   string  `json:"firstMetMetricTime,omitempty"`
+	LastMetMetricTime    *string `json:"lastMetMetricTime,omitempty"`
+	LastForMetMetricTime *string `json:"lastsForMetMetricTime,omitempty"`
 }
 
 var validator = validation.New[Alert]()

--- a/manifest/v1alpha/alert/alert.go
+++ b/manifest/v1alpha/alert/alert.go
@@ -48,8 +48,8 @@ type Spec struct {
 	ResolvedMetricTime          *string        `json:"resolvedMetricTime,omitempty"`
 	CoolDown                    string         `json:"coolDown"`
 	Conditions                  []Condition    `json:"conditions"`
-	CoolDownStartedAtMetricTime *string        `json:"coolDownStartedAtMetricTime"`
-	ResolutionReason            *string        `json:"resolutionReason"`
+	CoolDownStartedAtMetricTime *string        `json:"coolDownStartedAtMetricTime,omitempty"`
+	ResolutionReason            *string        `json:"resolutionReason,omitempty"`
 }
 
 type Objective struct {

--- a/manifest/v1alpha/alert/example.yaml
+++ b/manifest/v1alpha/alert/example.yaml
@@ -1,22 +1,52 @@
 apiVersion: n9/v1alpha
 kind: Alert
 metadata:
-  name: 6fbc76bc-ff8a-40a2-8ac6-65d7d7a2686e
-  project: alerting-test
+name: a706583a-153a-4d3f-8a12-2741cc09da9b
+project: azure-monitor-direct
+organization: alerting-test
 spec:
-  alertPolicy:
-    name: burn-rate-is-4x-immediately
-    project: alerting-test
-  service:
-    name: triggering-alerts-service
-    project: alerting-test
-  objective:
-    value: 99.0
-    name: ok
-    displayName: ok
-  severity: Medium
-  slo:
-    name: prometheus-rolling-timeslices-threshold
-    project: alerting-test
-  status: Triggered
-  triggeredClockTime: "2022-01-16T00:28:05Z
+alertPolicy:
+  displayName: Fast Burn
+  name: fast-burn
+  project: azure-monitor-direct
+conditions:
+- alertingWindow: 15m0s
+  measurement: averageBurnRate
+  op: gte
+  status:
+    firstMetMetricTime: "2024-04-16T16:45:00Z"
+    lastMetMetricTime: "2024-04-23T16:29:00Z"
+  value: 2
+- alertingWindow: 24h0m0s
+  measurement: averageBurnRate
+  op: gte
+  status:
+    firstMetMetricTime: "2024-04-17T16:30:00Z"
+    lastMetMetricTime: "2024-04-23T16:29:00Z"
+  value: 3
+- alertingWindow: 72h0m0s
+  measurement: averageBurnRate
+  op: gte
+  status:
+    firstMetMetricTime: "2024-04-19T16:30:00Z"
+    lastMetMetricTime: "2024-04-23T16:29:00Z"
+  value: 3
+coolDown: 5m0s
+coolDownStartedAtMetricTime: "2024-04-23T16:29:00Z"
+objective:
+  displayName: ""
+  name: objective-1
+  value: 1
+resolutionReason: AlertCanceledNewCalendarAlignedTimeWindow
+resolvedClockTime: "2024-04-23T16:36:10Z"
+resolvedMetricTime: "2024-04-23T16:30:00Z"
+service:
+  name: n9-web-app-direct
+  project: azure-monitor-direct
+severity: Medium
+slo:
+  name: azure-n9-web-app-availability-calendar-week-ts
+  project: azure-monitor-direct
+status: Canceled
+triggeredClockTime: "2024-04-19T16:36:08Z"
+triggeredMetricTime: "2024-04-19T16:30:00Z"


### PR DESCRIPTION
## Motivation

User can now find more details about why alert was triggered/resolved. Now alert returned via sloctl or API contains additional informations such as:
- when each condition was met for the first time
- when each condition lasts for was met
- when each condition was met for the last time
- when cooldown has started to be counted,
- what is the resolution reason (or cancelation).

## Summary

Return additional information from the API.

## Testing

Example response via sloctl for alert that was cancelled `sloctl get alert a706583a-153a-4d3f-8a12-2741cc09da9b -A`:

```yaml
- apiVersion: n9/v1alpha
  kind: Alert
  metadata:
    name: a706583a-153a-4d3f-8a12-2741cc09da9b
    project: azure-monitor-direct
  organization: nobl9-processing-and-alerting
  spec:
    alertPolicy:
      displayName: Fast Burn
      name: fast-burn
      project: azure-monitor-direct
    conditions:
    - alertingWindow: 15m0s
      measurement: averageBurnRate
      op: gte
      status:
        firstMetMetricTime: "2024-04-16T16:45:00Z"
        lastMetMetricTime: "2024-04-23T16:29:00Z"
      value: 2
    - alertingWindow: 24h0m0s
      measurement: averageBurnRate
      op: gte
      status:
        firstMetMetricTime: "2024-04-17T16:30:00Z"
        lastMetMetricTime: "2024-04-23T16:29:00Z"
      value: 3
    - alertingWindow: 72h0m0s
      measurement: averageBurnRate
      op: gte
      status:
        firstMetMetricTime: "2024-04-19T16:30:00Z"
        lastMetMetricTime: "2024-04-23T16:29:00Z"
      value: 3
    coolDown: 5m0s
    objective:
      displayName: ""
      name: objective-1
      value: 1
    resolutionReason: AlertCanceledNewCalendarAlignedTimeWindow
    resolvedClockTime: "2024-04-23T16:36:10Z"
    resolvedMetricTime: "2024-04-23T16:30:00Z"
    service:
      name: n9-web-app-direct
      project: azure-monitor-direct
    severity: Medium
    slo:
      name: azure-n9-web-app-availability-calendar-week-ts
      project: azure-monitor-direct
    status: Canceled
    triggeredClockTime: "2024-04-19T16:36:08Z"
    triggeredMetricTime: "2024-04-19T16:30:00Z"
```

## Release Notes

For alerts that have been detected recently, the API returns additional information such as:
- `Spec.Conditions[].Status.FirstMetMetricTime` - which point satisfied condition (so metric value met alert threshold) for the first time,
- `Spec.Conditions[].Status.LastsForMetMetricTime` - which point satisfied lasts for (even when lasts for is set to 0m),
- `Spec.Conditions[].Status.LastMetMetricTime` - which point satisfied condition for the last time (so metric value stopped meeting alert threshold),
- `Spec.CoolDownStartedAtMetricTime` - which point started cooldown (only for `Resolved` alerts), 
- `Spec.ResolutionReason` - resolution reason, most interesting is why alert was canceled.
