### PR TITLE
fix: PC-12544 Add validation for components list to be required (even if empty)

### DIFF
--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -415,7 +415,10 @@ var specValidationComposite = validation.New[Spec](
 							validation.DurationPrecision(time.Minute),
 							validation.GreaterThanOrEqualTo(time.Minute),
 						),
-					validation.ForSlice(func(c CompositeSpec) []CompositeObjective { return c.Objectives }).
+					validation.For(func(c CompositeSpec) []CompositeObjective { return c.Components.Objectives }).
+						WithName("components.objectives").
+						Required(),
+					validation.ForSlice(func(c CompositeSpec) []CompositeObjective { return c.Components.Objectives }).
 						WithName("components.objectives").
 						IncludeForEach(compositeObjectiveRule),
 				)),

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -286,4 +286,24 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			Message: "composite SLO cannot have duplicated SLOs as its objectives",
 		})
 	})
+	t.Run("fails - component list not provided", func(t *testing.T) {
+		slo := validCompositeSLO()
+		slo.Spec.Objectives[0].Composite.Objectives = nil
+
+		err := validate(slo)
+
+		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
+			Prop:    "spec.objectives[0].composite.components.objectives",
+			Code:    validation.ErrorCodeRequired,
+			Message: "property is required but was empty",
+		})
+	})
+	t.Run("passed - empty component list provided", func(t *testing.T) {
+		slo := validCompositeSLO()
+		slo.Spec.Objectives[0].Composite.Objectives = []CompositeObjective{}
+
+		err := validate(slo)
+
+		testutils.AssertNoError(t, slo, err)
+	})
 }


### PR DESCRIPTION
## Motivation

New SLO has elements at depth of 4:
```
objectives:
  composite:
    components:
      objectives:
```
A list of objectives can be empty.

It may be possible that a typo is made at the highest depth (`objectives`), which results in no error, but the list being empty (while the user expects the objectives to be there).

## Summary

Made the `components` list required, so that an empty array(YAML) / slice(Go) needs to be passed instead of omitted YAML property or nil slice.

## Related changes

None

## Testing

Added unit tests, sample YAML with the issue:
```yaml
- apiVersion: n9/v1alpha
  kind: SLO
  metadata:
    name: slo-test
    project: sample-project
  spec:
    alertPolicies: []
    budgetingMethod: Occurrences
    objectives:
    - displayName: Test
      name: objective-1
      composite:
        maxDelay: 20m
        objectives: # missing components parent`
          - project: splunk-direct
            slo: splunk-direct-counts-calendar
            objective: objective-1
            weight: 1
            whenDelayed: CountAsGood
          - project: splunk-direct
            slo: splunk-direct-raw-calendar
            objective: objective-3
            weight: 1
            whenDelayed: CountAsGood
          - project: thousandeyes
            slo: net-loss-rolling-timeslices
            objective: objective-1
            weight: 1
            whenDelayed: CountAsGood
      target: 0.9
    service: service
    timeWindows:
    - count: 1
      isRolling: true
      unit: Day
  status:
    updatedAt: "2022-01-21T11:22:14Z"
```

Correct YAML:
```yaml
- apiVersion: n9/v1alpha
  kind: SLO
  metadata:
    name: slo-test
    project: sample-project
  spec:
    alertPolicies: []
    budgetingMethod: Occurrences
    objectives:
    - displayName: Test
      name: objective-1
      composite:
        maxDelay: 20m
        components:
          objectives:
            - project: splunk-direct
              slo: splunk-direct-counts-calendar
              objective: objective-1
              weight: 1
              whenDelayed: CountAsGood
            - project: splunk-direct
              slo: splunk-direct-raw-calendar
              objective: objective-3
              weight: 1
              whenDelayed: CountAsGood
            - project: thousandeyes
              slo: net-loss-rolling-timeslices
              objective: objective-1
              weight: 1
              whenDelayed: CountAsGood
      target: 0.9
    service: service
    timeWindows:
    - count: 1
      isRolling: true
      unit: Day
  status:
    updatedAt: "2022-01-21T11:22:14Z"
```
