### PR TITLE
chore: Add option to change output format to compacted JSON in docgen

### DIFF
--- a/internal/cmd/docgen/main.go
+++ b/internal/cmd/docgen/main.go
@@ -80,6 +80,8 @@ func run(outputFilePath, outputFileFormat string, objectNames []string) {
 		enc = yaml.NewEncoder(out,
 			yaml.Indent(2),
 			yaml.UseLiteralStyleIfMultiline(true))
+	default:
+		panic("unsupported output format: " + outputFileFormat)
 	}
 	if err = enc.Encode(docs); err != nil {
 		panic(err)


### PR DESCRIPTION
## Motivation

Currently `docgen` only outputs yaml, which is slower to decode and weights more but it's easier to read by a human.
External tools however, would benefit more from having it in JSON than YAML.