### PR TITLE
feat: add createdAt and createdBy to project

### DIFF
--- a/manifest/v1alpha/project/project.go
+++ b/manifest/v1alpha/project/project.go
@@ -44,6 +44,8 @@ type Metadata struct {
 
 // Spec holds detailed specification of the Project.
 type Spec struct {
+	CreatedAt string `json:"createdAt,omitempty"`
+	CreatedBy string `json:"createdBy,omitempty"`
 	// Description allows for a more detailed description of the Project.
 	Description string `json:"description" validate:"description" example:"Bleeding edge web app"`
 }


### PR DESCRIPTION
## Motivation

Right now there is no info for the project about when it was created and who created it. We are developing some internal APIs to manage nobl9, and would love to get this info added. 

## Summary
I have added relevant fields to the `Project` struct, the core controller needs to populate these fields, but since it isn't open-source, I can't do that myself.
@nieomylnieja  Let me know your thoughts 😄 

## Release Notes

Added `createdAt` and `createdBy` fields to v1alpha Project.
These fields are not yet populated by the API, follow our [release notes](https://docs.nobl9.com/application-release-notes) to get informed when the API support ships.