### PR TITLE
fix: Correct Logic Monitor validation

### DIFF
--- a/manifest/v1alpha/slo/metrics_logic_monitor.go
+++ b/manifest/v1alpha/slo/metrics_logic_monitor.go
@@ -16,13 +16,13 @@ var logicMonitorValidation = validation.New[LogicMonitorMetric](
 		Required().
 		Rules(validation.StringContains("device_metrics")),
 	validation.For(func(e LogicMonitorMetric) int { return e.DeviceDataSourceInstanceID }).
-		WithName("deviceDataSourceInstanceID").
+		WithName("deviceDataSourceInstanceId").
 		Required().
-		Rules(validation.GreaterThanOrEqualTo[int](0)),
+		Rules(validation.GreaterThanOrEqualTo(0)),
 	validation.For(func(e LogicMonitorMetric) int { return e.GraphID }).
-		WithName("graphID").
+		WithName("graphId").
 		Required().
-		Rules(validation.GreaterThanOrEqualTo[int](0)),
+		Rules(validation.GreaterThanOrEqualTo(0)),
 	validation.For(func(e LogicMonitorMetric) string { return e.Line }).
 		WithName("line").
 		Required().

--- a/manifest/v1alpha/slo/metrics_logic_monitor_test.go
+++ b/manifest/v1alpha/slo/metrics_logic_monitor_test.go
@@ -26,11 +26,11 @@ func TestLogicMonitor(t *testing.T) {
 				Code: validation.ErrorCodeStringContains,
 			},
 			testutils.ExpectedError{
-				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.deviceDataSourceInstanceID",
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.deviceDataSourceInstanceId",
 				Code: validation.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.graphID",
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.graphId",
 				Code: validation.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{


### PR DESCRIPTION
Corrects invalid field names for Logic Monitor:

- `deviceDataSourceInstanceID` --> `deviceDataSourceInstanceId`
- `groupID` --> `groupId`