### PR TITLE
chore: Ignore commit suffix

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -23,9 +23,10 @@ extract_header() {
 	local header_name="$2"
 	awk "
     /^\s?$/ {next}
+    /^--+/ {rn=0};
+    /^Signed-off-by|Co-authored-by/ {rn=0};
     /^## $header_name/ {rn=1}
     rn && !/^##/ && !/^--+/ {print};
-    /^--+/ {rn=0};
     /^##/ && !/^## $header_name/ {rn=0}" <<<"$commit"
 }
 


### PR DESCRIPTION
Ignore `signed-off-by` and `co-authored-by` suffixes from commit messages while generating release notes.

Made evident by:
![image](https://github.com/nobl9/nobl9-go/assets/48822818/bbcb1f22-3ea9-42de-86ec-854da457edc2)
