### PR TITLE
chore: Add no config file

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,4 +43,5 @@ jobs:
           NOBL9_SDK_CLIENT_SECRET: ${{ secrets.clientSecret }}
           NOBL9_SDK_OKTA_ORG_URL: ${{ inputs.oktaOrgUrl }}
           NOBL9_SDK_OKTA_AUTH_SERVER: ${{ inputs.oktaAuthServer }}
+          NOBL9_SDK_NO_CONFIG_FILE: true
         run: make test/e2e


### PR DESCRIPTION
In CI we don't want to create a config file to store the access token, thus we need to pass additional env to SDK config.