### PR TITLE
chore: Correct Alert Method type names

### DIFF
--- a/manifest/v1alpha/alert_methods.go
+++ b/manifest/v1alpha/alert_methods.go
@@ -1,8 +1,8 @@
 package v1alpha
 
-//go:generate ../../bin/go-enum  --values --noprefix
+//go:generate ../../bin/go-enum  --values
 
-// DataSourceType represents the specific type of alert method.
+// AlertMethodType represents the specific type of alert method.
 //
 /* ENUM(
 Webhook = 1

--- a/manifest/v1alpha/alert_methods_enum.go
+++ b/manifest/v1alpha/alert_methods_enum.go
@@ -13,24 +13,24 @@ import (
 )
 
 const (
-	// Webhook is a AlertMethodType of type Webhook.
-	Webhook AlertMethodType = iota + 1
-	// PagerDuty is a AlertMethodType of type PagerDuty.
-	PagerDuty
-	// Slack is a AlertMethodType of type Slack.
-	Slack
-	// Discord is a AlertMethodType of type Discord.
-	Discord
-	// Opsgenie is a AlertMethodType of type Opsgenie.
-	Opsgenie
-	// ServiceNow is a AlertMethodType of type ServiceNow.
-	ServiceNow
-	// Jira is a AlertMethodType of type Jira.
-	Jira
-	// Teams is a AlertMethodType of type Teams.
-	Teams
-	// Email is a AlertMethodType of type Email.
-	Email
+	// AlertMethodTypeWebhook is a AlertMethodType of type Webhook.
+	AlertMethodTypeWebhook AlertMethodType = iota + 1
+	// AlertMethodTypePagerDuty is a AlertMethodType of type PagerDuty.
+	AlertMethodTypePagerDuty
+	// AlertMethodTypeSlack is a AlertMethodType of type Slack.
+	AlertMethodTypeSlack
+	// AlertMethodTypeDiscord is a AlertMethodType of type Discord.
+	AlertMethodTypeDiscord
+	// AlertMethodTypeOpsgenie is a AlertMethodType of type Opsgenie.
+	AlertMethodTypeOpsgenie
+	// AlertMethodTypeServiceNow is a AlertMethodType of type ServiceNow.
+	AlertMethodTypeServiceNow
+	// AlertMethodTypeJira is a AlertMethodType of type Jira.
+	AlertMethodTypeJira
+	// AlertMethodTypeTeams is a AlertMethodType of type Teams.
+	AlertMethodTypeTeams
+	// AlertMethodTypeEmail is a AlertMethodType of type Email.
+	AlertMethodTypeEmail
 )
 
 var ErrInvalidAlertMethodType = errors.New("not a valid AlertMethodType")
@@ -40,28 +40,28 @@ const _AlertMethodTypeName = "WebhookPagerDutySlackDiscordOpsgenieServiceNowJira
 // AlertMethodTypeValues returns a list of the values for AlertMethodType
 func AlertMethodTypeValues() []AlertMethodType {
 	return []AlertMethodType{
-		Webhook,
-		PagerDuty,
-		Slack,
-		Discord,
-		Opsgenie,
-		ServiceNow,
-		Jira,
-		Teams,
-		Email,
+		AlertMethodTypeWebhook,
+		AlertMethodTypePagerDuty,
+		AlertMethodTypeSlack,
+		AlertMethodTypeDiscord,
+		AlertMethodTypeOpsgenie,
+		AlertMethodTypeServiceNow,
+		AlertMethodTypeJira,
+		AlertMethodTypeTeams,
+		AlertMethodTypeEmail,
 	}
 }
 
 var _AlertMethodTypeMap = map[AlertMethodType]string{
-	Webhook:    _AlertMethodTypeName[0:7],
-	PagerDuty:  _AlertMethodTypeName[7:16],
-	Slack:      _AlertMethodTypeName[16:21],
-	Discord:    _AlertMethodTypeName[21:28],
-	Opsgenie:   _AlertMethodTypeName[28:36],
-	ServiceNow: _AlertMethodTypeName[36:46],
-	Jira:       _AlertMethodTypeName[46:50],
-	Teams:      _AlertMethodTypeName[50:55],
-	Email:      _AlertMethodTypeName[55:60],
+	AlertMethodTypeWebhook:    _AlertMethodTypeName[0:7],
+	AlertMethodTypePagerDuty:  _AlertMethodTypeName[7:16],
+	AlertMethodTypeSlack:      _AlertMethodTypeName[16:21],
+	AlertMethodTypeDiscord:    _AlertMethodTypeName[21:28],
+	AlertMethodTypeOpsgenie:   _AlertMethodTypeName[28:36],
+	AlertMethodTypeServiceNow: _AlertMethodTypeName[36:46],
+	AlertMethodTypeJira:       _AlertMethodTypeName[46:50],
+	AlertMethodTypeTeams:      _AlertMethodTypeName[50:55],
+	AlertMethodTypeEmail:      _AlertMethodTypeName[55:60],
 }
 
 // String implements the Stringer interface.
@@ -80,15 +80,15 @@ func (x AlertMethodType) IsValid() bool {
 }
 
 var _AlertMethodTypeValue = map[string]AlertMethodType{
-	_AlertMethodTypeName[0:7]:   Webhook,
-	_AlertMethodTypeName[7:16]:  PagerDuty,
-	_AlertMethodTypeName[16:21]: Slack,
-	_AlertMethodTypeName[21:28]: Discord,
-	_AlertMethodTypeName[28:36]: Opsgenie,
-	_AlertMethodTypeName[36:46]: ServiceNow,
-	_AlertMethodTypeName[46:50]: Jira,
-	_AlertMethodTypeName[50:55]: Teams,
-	_AlertMethodTypeName[55:60]: Email,
+	_AlertMethodTypeName[0:7]:   AlertMethodTypeWebhook,
+	_AlertMethodTypeName[7:16]:  AlertMethodTypePagerDuty,
+	_AlertMethodTypeName[16:21]: AlertMethodTypeSlack,
+	_AlertMethodTypeName[21:28]: AlertMethodTypeDiscord,
+	_AlertMethodTypeName[28:36]: AlertMethodTypeOpsgenie,
+	_AlertMethodTypeName[36:46]: AlertMethodTypeServiceNow,
+	_AlertMethodTypeName[46:50]: AlertMethodTypeJira,
+	_AlertMethodTypeName[50:55]: AlertMethodTypeTeams,
+	_AlertMethodTypeName[55:60]: AlertMethodTypeEmail,
 }
 
 // ParseAlertMethodType attempts to convert a string to a AlertMethodType.

--- a/manifest/v1alpha/alertmethod/alert_method.go
+++ b/manifest/v1alpha/alertmethod/alert_method.go
@@ -62,23 +62,23 @@ type Spec struct {
 func (s Spec) GetType() (v1alpha.AlertMethodType, error) {
 	switch {
 	case s.Webhook != nil:
-		return v1alpha.Webhook, nil
+		return v1alpha.AlertMethodTypeWebhook, nil
 	case s.PagerDuty != nil:
-		return v1alpha.PagerDuty, nil
+		return v1alpha.AlertMethodTypePagerDuty, nil
 	case s.Slack != nil:
-		return v1alpha.Slack, nil
+		return v1alpha.AlertMethodTypeSlack, nil
 	case s.Discord != nil:
-		return v1alpha.Discord, nil
+		return v1alpha.AlertMethodTypeDiscord, nil
 	case s.Opsgenie != nil:
-		return v1alpha.Opsgenie, nil
+		return v1alpha.AlertMethodTypeOpsgenie, nil
 	case s.ServiceNow != nil:
-		return v1alpha.ServiceNow, nil
+		return v1alpha.AlertMethodTypeServiceNow, nil
 	case s.Jira != nil:
-		return v1alpha.Jira, nil
+		return v1alpha.AlertMethodTypeJira, nil
 	case s.Teams != nil:
-		return v1alpha.Teams, nil
+		return v1alpha.AlertMethodTypeTeams, nil
 	case s.Email != nil:
-		return v1alpha.Email, nil
+		return v1alpha.AlertMethodTypeEmail, nil
 	}
 	return 0, errors.New("unknown alert method type")
 }


### PR DESCRIPTION
## Motivation

Having sth like `v1alpha.Email` in the namespace is way too vague, we need more specific naming, that's why we need a prefix.