### PR TITLE
chore: Switch go-yaml library to Nobl9 fork

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-un:
+run:
   timeout: 5m
   modules-download-mode: readonly
   skip-dirs-use-default: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-run:
+un:
   timeout: 5m
   modules-download-mode: readonly
-  skip-dirs:
-    - scripts
   skip-dirs-use-default: true
 
 issues:
@@ -24,6 +22,8 @@ issues:
     - linters:
         - revive
       text: "error-strings: error strings should not be capitalized or end with punctuation or a newline"
+  exclude-dirs:
+    - scripts
   # Value 0 means show all.
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/MicahParks/keyfunc/v3 v3.3.3
 	github.com/aws/aws-sdk-go v1.54.14
 	github.com/bmatcuk/doublestar/v4 v4.6.1
-	github.com/goccy/go-yaml v1.11.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/nobl9/go-yaml v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	github.com/teambition/rrule-go v1.8.2
@@ -31,6 +31,3 @@ require (
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// We might in the end decide to just go with the fork direcly.
-replace github.com/goccy/go-yaml => github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9 h1:HWAY7k8zA8T3dgQRg6llwyWshguD6bIeaVXukNrnen4=
-github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/nobl9/go-yaml v1.0.1 h1:Aj1kSaYdRQTKlvS6ihvXzQJhCpoHhtf9nfA95zqWH4Q=
+github.com/nobl9/go-yaml v1.0.1/go.mod h1:t7vCO8ctYdBweZxU5lUgxzAw31+ZcqJYeqRtrv+5RHI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/docgen/main.go
+++ b/internal/cmd/docgen/main.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 
 	"github.com/nobl9/nobl9-go/internal/validation"
 	"github.com/nobl9/nobl9-go/manifest"

--- a/internal/manifest/v1alphatest/labels_validation.go
+++ b/internal/manifest/v1alphatest/labels_validation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"

--- a/internal/manifest/v1alphatest/metadata_annotations_validation.go
+++ b/internal/manifest/v1alphatest/metadata_annotations_validation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"

--- a/internal/validation/example_test.go
+++ b/internal/validation/example_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 
 	"github.com/nobl9/nobl9-go/internal/validation"
 )

--- a/manifest/v1alpha/dataexport/data_export.go
+++ b/manifest/v1alpha/dataexport/data_export.go
@@ -3,7 +3,7 @@ package dataexport
 import (
 	"encoding/json"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 
 	"github.com/nobl9/nobl9-go/internal/serdeutil"
 	"github.com/nobl9/nobl9-go/manifest"

--- a/manifest/v1alpha/parser/parser.go
+++ b/manifest/v1alpha/parser/parser.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/pkg/errors"
 
 	"github.com/nobl9/nobl9-go/manifest"

--- a/sdk/decode.go
+++ b/sdk/decode.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/pkg/errors"
 
 	"github.com/nobl9/nobl9-go/manifest"

--- a/sdk/decode_test.go
+++ b/sdk/decode_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/sdk/encode.go
+++ b/sdk/encode.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 
 	"github.com/nobl9/nobl9-go/manifest"
 )


### PR DESCRIPTION
## Motivation

Modules using `nobl9-go` cannot rely on `replace` clause in the SDK if they are using `go-yaml` package as well, in such scenario these modules have to using `replace` clause too and this in turn breaks `go install`, here's an example:

```
go install github.com/nobl9/sloctl/cmd/sloctl@latest
go: downloading github.com/nobl9/sloctl v0.3.2
go: github.com/nobl9/sloctl/cmd/sloctl@latest (in github.com/nobl9/sloctl@v0.3.2):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```