### PR TITLE
chore: Allow sequential apply/delete execution for end-to-end tests

### DIFF
--- a/.github/workflows/e2e-tests-dispatch.yml
+++ b/.github/workflows/e2e-tests-dispatch.yml
@@ -18,6 +18,11 @@ on:
         description: Okta authentication server identifier
         required: false
         type: string
+      sequentialApplyAndDelete:
+        description: Whether to perform apply/delete requests sequentially
+        required: false
+        type: boolean
+        default: true
 jobs:
   test:
     uses: ./.github/workflows/e2e-tests.yml
@@ -26,5 +31,6 @@ jobs:
       ref: "${{ github.ref_name }}"
       oktaOrgUrl: "${{ inputs.oktaOrgUrl }}"
       oktaAuthServer: "${{ inputs.oktaAuthServer }}"
+      sequentialApplyAndDelete: "${{ inputs.sequentialApplyAndDelete }}"
     secrets:
       clientSecret: "${{ inputs.clientSecret }}"

--- a/.github/workflows/e2e-tests-dispatch.yml
+++ b/.github/workflows/e2e-tests-dispatch.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       sequentialApplyAndDelete:
-        description: Whether to perform apply/delete requests sequentially
+        description: Perform apply/delete requests sequentially
         required: false
         type: boolean
         default: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: main
+      sequentialApplyAndDelete:
+        description: Whether to perform apply/delete requests sequentially
+        required: false
+        type: boolean
+        default: true
     secrets:
       clientSecret:
         description: Client secret to use for authentication
@@ -44,4 +49,5 @@ jobs:
           NOBL9_SDK_OKTA_ORG_URL: ${{ inputs.oktaOrgUrl }}
           NOBL9_SDK_OKTA_AUTH_SERVER: ${{ inputs.oktaAuthServer }}
           NOBL9_SDK_NO_CONFIG_FILE: true
+          NOBL9_SDK_TEST_RUN_SEQUENTIAL_APPLY_AND_DELETE: ${{ inputs.sequentialApplyAndDelete }}
         run: make test/e2e

--- a/tests/v1alpha_agent_test.go
+++ b/tests/v1alpha_agent_test.go
@@ -44,11 +44,11 @@ func Test_Objects_V1_V1alpha_Agent(t *testing.T) {
 	// Register cleanup first as we're not applying in a batch.
 	t.Cleanup(func() {
 		slices.Reverse(agents)
-		v1DeleteBatch(t, agents, 1, 5)
+		v1DeleteBatch(t, agents, 1)
 		v1Delete(t, []manifest.Object{project})
 	})
 	v1Apply(t, []manifest.Object{project})
-	v1ApplyBatch(t, agents, 1, 5)
+	v1ApplyBatch(t, agents, 1)
 
 	filterTests := map[string]struct {
 		request    objectsV1.GetAgentsRequest

--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -148,11 +148,11 @@ func Test_Objects_V1_V1alpha_SLO(t *testing.T) {
 
 	t.Cleanup(func() {
 		slices.Reverse(slos)
-		v1DeleteBatch(t, slos, 50, 1)
+		v1DeleteBatch(t, slos, 50)
 		v1Delete(t, dependencies)
 	})
 	v1Apply(t, dependencies)
-	v1ApplyBatch(t, slos, 50, 1)
+	v1ApplyBatch(t, slos, 50)
 	inputs := manifest.FilterByKind[v1alphaSLO.SLO](slos)
 
 	filterTests := map[string]struct {
@@ -228,7 +228,7 @@ func v1alphaSLODependencyAgents(t *testing.T) []manifest.Object {
 		agent.Spec.Description = objectPersistedDescription
 		agents = append(agents, agent)
 	}
-	v1ApplyBatch(t, agents, 1, 1)
+	v1ApplyBatch(t, agents, 1)
 	return agents
 }
 


### PR DESCRIPTION
## Motivation

Since we're currently running into concurrency problems, we need to be able to constrain parallelism of apply/delete operations on demand.

## Testing

```shell
export NOBL9_SDK_TEST_RUN_SEQUENTIAL_APPLY_AND_DELETE=true
make test/e2e
```

https://github.com/nobl9/nobl9-go/actions/runs/10095740091