### PR TITLE
chore: Update developer docs and examples

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -101,8 +101,13 @@ We use the following tools to do that:
   your own const-based enums. It can generate methods for decoding the custom
   type from and to string, so you can use the enum type directly in your
   struct.
-- [Our custom tool](scripts/generate-object-impl.go)
-  for generating `manifest.Object` methods implementation for all object kinds.
+- [objectimpl](../internal/cmd/objectimpl)
+  for generating `manifest.Object` implementation for all object kinds.
+- [docgen](../internal/cmd/docgen/)
+  for generating documentation based on validation rules, Go doc comments and
+  generate examples.
+- [examplegen](../internal/cmd/examplegen/)
+  for generating examples for each manifest object.
 
 ## Validation
 

--- a/internal/cmd/docgen/README.md
+++ b/internal/cmd/docgen/README.md
@@ -6,6 +6,7 @@ It merges:
 - Go doc comments
 - [Validation plan](../../validation/plan.go)
 - Custom documentation and formatting
+- Generated examples
 
 into a single YAML file.
 

--- a/internal/cmd/examplegen/README.md
+++ b/internal/cmd/examplegen/README.md
@@ -1,0 +1,21 @@
+# examplegen
+
+`examplegen` is a tool that generates examples for manifest objects.
+
+These examples are usually stored in the `examples` directory of
+the respective object's package or in the object's package directory itself
+inside `examples.yaml` file.
+
+Each object can have its variants and sub-variants.
+Example of such distinction for SLO is Prometheus based SLO with
+_calendar aligned_ time window.
+Prometheus will be the variant and _calendar aligned_ time window
+will be the sub-variant.
+
+## Usage
+
+Run from the repository root's Makefile:
+
+```shell
+make generate/examples
+```

--- a/internal/manifest/v1alpha/examples/doc.go
+++ b/internal/manifest/v1alpha/examples/doc.go
@@ -1,0 +1,8 @@
+// Package v1alphaExamples is responsible for generating v1alpha objects' examples.
+// Each object MUST expose the following function providing ALL its examples:
+//
+//	func <OBJECT_NAME>() []Example
+//
+// Each object's examples should be validated statically, place these tests under
+// validation_test.go file.
+package v1alphaExamples

--- a/internal/manifest/v1alpha/examples/example_test.go
+++ b/internal/manifest/v1alpha/examples/example_test.go
@@ -8,10 +8,11 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/nobl9/nobl9-go/internal/pathutils"
-	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nobl9/nobl9-go/internal/pathutils"
+	"github.com/nobl9/nobl9-go/manifest"
 )
 
 func TestExamples_EnsureAllKindsHaveExamples(t *testing.T) {

--- a/internal/manifest/v1alpha/examples/example_test.go
+++ b/internal/manifest/v1alpha/examples/example_test.go
@@ -1,0 +1,54 @@
+package v1alphaExamples
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/nobl9/nobl9-go/internal/pathutils"
+	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExamples_EnsureAllKindsHaveExamples(t *testing.T) {
+	path := filepath.Join(pathutils.FindModuleRoot(), "internal", "manifest", "v1alpha", "examples")
+	set := token.NewFileSet()
+	packs, err := parser.ParseDir(set, path, nil, 0)
+	require.NoError(t, err)
+
+	funcs := []*ast.FuncDecl{}
+	for _, pack := range packs {
+		for _, f := range pack.Files {
+			for _, d := range f.Decls {
+				if fn, isFn := d.(*ast.FuncDecl); isFn {
+					funcs = append(funcs, fn)
+				}
+			}
+		}
+	}
+
+	hasExpectedType := func(f *ast.FuncDecl) bool {
+		if f.Type.Params != nil && len(f.Type.Params.List) > 0 {
+			return false
+		}
+		if f.Type.Results == nil || len(f.Type.Results.List) != 1 {
+			return false
+		}
+		at, ok := f.Type.Results.List[0].Type.(*ast.ArrayType)
+		if !ok {
+			return false
+		}
+		return at.Elt.(*ast.Ident).Name == "Example"
+	}
+
+	for _, kind := range manifest.ApplicableKinds() {
+		found := slices.ContainsFunc(funcs, func(f *ast.FuncDecl) bool {
+			return kind.String() == f.Name.Name && hasExpectedType(f)
+		})
+		assert.True(t, found, "missing examples for kind %[1]s, expected function shape: 'func %[1]s() []Example'", kind)
+	}
+}

--- a/manifest/kind.go
+++ b/manifest/kind.go
@@ -37,7 +37,7 @@ func (k Kind) Equals(s string) bool {
 // Applicable returns true if the Kind can be applied or deleted by the user.
 // In other words, it informs whether the Kind's lifecycle is managed by the user.
 func (k Kind) Applicable() bool {
-	return k != KindAlert
+	return k != KindAlert && k != KindUserGroup
 }
 
 // ApplicableKinds returns all the Kind instances which can be applied or deleted by the user.


### PR DESCRIPTION
- Update developer docs
- Add test for making sure each new `manifest.Object` has generated examples
- Add `UserGroup` to non-applicable objects