### PR TITLE
fix: Removing redundant validation in LogicMonitor [PC-13783]

### DIFF
--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -208,14 +208,6 @@ var (
 			WithName("account").
 			Required().
 			Rules(validation.StringNotEmpty()),
-		validation.For(func(l LogicMonitorConfig) string { return l.AccessID }).
-			WithName("accessId").
-			Required().
-			Rules(validation.StringNotEmpty()),
-		validation.For(func(l LogicMonitorConfig) string { return l.AccessKey }).
-			WithName("accessKey").
-			Required().
-			Rules(validation.StringNotEmpty()),
 	)
 	azurePrometheusValidation = validation.New[AzurePrometheusConfig](
 		urlPropertyRules(func(s AzurePrometheusConfig) string { return s.URL }),

--- a/manifest/v1alpha/direct/validation_test.go
+++ b/manifest/v1alpha/direct/validation_test.go
@@ -923,24 +923,6 @@ func TestValidateSpec_LogicMonitor(t *testing.T) {
 			Code: validation.ErrorCodeRequired,
 		})
 	})
-	t.Run("invalid accountID", func(t *testing.T) {
-		direct := validDirect(v1alpha.LogicMonitor)
-		direct.Spec.LogicMonitor.AccessID = ""
-		err := validate(direct)
-		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: "spec.logicMonitor.accessId",
-			Code: validation.ErrorCodeRequired,
-		})
-	})
-	t.Run("invalid accessKey", func(t *testing.T) {
-		direct := validDirect(v1alpha.LogicMonitor)
-		direct.Spec.LogicMonitor.AccessKey = ""
-		err := validate(direct)
-		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: "spec.logicMonitor.accessKey",
-			Code: validation.ErrorCodeRequired,
-		})
-	})
 }
 
 func TestValidateSpec_AzurePrometheus(t *testing.T) {


### PR DESCRIPTION
## Release Notes

Removing redundant validation for `ClientID` and `ClientSecret` in Logic Monitor

