### PR TITLE
chore: Add explicit generic arguments as workaround for GoLand IDE bug

### DIFF
--- a/manifest/v1alpha/annotation/validation.go
+++ b/manifest/v1alpha/annotation/validation.go
@@ -12,10 +12,10 @@ import (
 )
 
 func validate(p Annotation) *v1alpha.ObjectError {
-	return v1alpha.ValidateObject(validator, p, manifest.KindAnnotation)
+	return v1alpha.ValidateObject[Annotation](validator, p, manifest.KindAnnotation)
 }
 
-var validator = govy.New(
+var validator = govy.New[Annotation](
 	validationV1Alpha.FieldRuleAPIVersion(func(a Annotation) manifest.Version { return a.APIVersion }),
 	validationV1Alpha.FieldRuleKind(func(a Annotation) manifest.Kind { return a.Kind }, manifest.KindAnnotation),
 	govy.For(func(p Annotation) Metadata { return p.Metadata }).
@@ -25,7 +25,7 @@ var validator = govy.New(
 		Include(specValidation),
 )
 
-var metadataValidation = govy.New(
+var metadataValidation = govy.New[Metadata](
 	validationV1Alpha.FieldRuleMetadataName(func(m Metadata) string { return m.Name }),
 	govy.For(func(m Metadata) string { return m.Project }).
 		WithName("metadata.project").
@@ -33,7 +33,7 @@ var metadataValidation = govy.New(
 		Rules(rules.StringDNSLabel()),
 )
 
-var specValidation = govy.New(
+var specValidation = govy.New[Spec](
 	govy.For(func(s Spec) string { return s.Slo }).
 		WithName("slo").
 		Required().

--- a/manifest/v1alpha/budgetadjustment/validation.go
+++ b/manifest/v1alpha/budgetadjustment/validation.go
@@ -14,10 +14,10 @@ import (
 )
 
 func validate(b BudgetAdjustment) *v1alpha.ObjectError {
-	return v1alpha.ValidateObject(validator, b, manifest.KindBudgetAdjustment)
+	return v1alpha.ValidateObject[BudgetAdjustment](validator, b, manifest.KindBudgetAdjustment)
 }
 
-var validator = govy.New(
+var validator = govy.New[BudgetAdjustment](
 	validationV1Alpha.FieldRuleAPIVersion(func(b BudgetAdjustment) manifest.Version { return b.APIVersion }),
 	validationV1Alpha.FieldRuleKind(
 		func(b BudgetAdjustment) manifest.Kind { return b.Kind },
@@ -29,12 +29,12 @@ var validator = govy.New(
 		Include(specValidation),
 )
 
-var metadataValidation = govy.New(
+var metadataValidation = govy.New[Metadata](
 	validationV1Alpha.FieldRuleMetadataName(func(m Metadata) string { return m.Name }),
 	validationV1Alpha.FieldRuleMetadataDisplayName(func(m Metadata) string { return m.DisplayName }),
 )
 
-var specValidation = govy.New(
+var specValidation = govy.New[Spec](
 	govy.For(func(s Spec) string { return s.Description }).
 		WithName("description").
 		Rules(validationV1Alpha.StringDescription()),
@@ -52,7 +52,7 @@ var specValidation = govy.New(
 		Include(filtersValidationRule),
 )
 
-var filtersValidationRule = govy.New(
+var filtersValidationRule = govy.New[Filters](
 	govy.ForSlice(func(f Filters) []SLORef { return f.SLOs }).
 		WithName("slos").
 		Rules(rules.SliceMinLength[[]SLORef](1)).
@@ -62,7 +62,7 @@ var filtersValidationRule = govy.New(
 		}, "SLOs must be unique")),
 )
 
-var sloValidationRule = govy.New(
+var sloValidationRule = govy.New[SLORef](
 	govy.For(func(s SLORef) string { return s.Project }).
 		WithName("project").
 		Required().

--- a/manifest/v1alpha/data_sources.go
+++ b/manifest/v1alpha/data_sources.go
@@ -66,7 +66,7 @@ type HistoricalDataRetrieval struct {
 }
 
 func HistoricalDataRetrievalValidation() govy.Validator[HistoricalDataRetrieval] {
-	return govy.New(
+	return govy.New[HistoricalDataRetrieval](
 		govy.For(govy.GetSelf[HistoricalDataRetrieval]()).
 			Rules(defaultDataRetrievalDurationValidation),
 		govy.For(func(h HistoricalDataRetrieval) HistoricalRetrievalDuration { return h.MaxDuration }).
@@ -80,7 +80,7 @@ func HistoricalDataRetrievalValidation() govy.Validator[HistoricalDataRetrieval]
 	)
 }
 
-var historicalRetrievalDurationValidation = govy.New(
+var historicalRetrievalDurationValidation = govy.New[HistoricalRetrievalDuration](
 	govy.ForPointer(func(h HistoricalRetrievalDuration) *int { return h.Value }).
 		WithName("value").
 		Required().
@@ -131,7 +131,7 @@ var maxQueryDelay = Duration{
 }
 
 func QueryDelayValidation() govy.Validator[QueryDelay] {
-	return govy.New(
+	return govy.New[QueryDelay](
 		govy.For(func(q QueryDelay) Duration { return q.Duration }).
 			Rules(govy.NewRule(func(d Duration) error {
 				if d.Duration() > maxQueryDelay.Duration() {

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -14,10 +14,10 @@ import (
 )
 
 func validate(d Direct) *v1alpha.ObjectError {
-	return v1alpha.ValidateObject(validator, d, manifest.KindDirect)
+	return v1alpha.ValidateObject[Direct](validator, d, manifest.KindDirect)
 }
 
-var validator = govy.New(
+var validator = govy.New[Direct](
 	validationV1Alpha.FieldRuleAPIVersion(func(d Direct) manifest.Version { return d.APIVersion }),
 	validationV1Alpha.FieldRuleKind(func(d Direct) manifest.Kind { return d.Kind }, manifest.KindDirect),
 	validationV1Alpha.FieldRuleMetadataName(func(d Direct) string { return d.Metadata.Name }),
@@ -29,7 +29,7 @@ var validator = govy.New(
 		Include(specValidation),
 )
 
-var specValidation = govy.New(
+var specValidation = govy.New[Spec](
 	govy.For(govy.GetSelf[Spec]()).
 		Cascade(govy.CascadeModeStop).
 		Rules(exactlyOneDataSourceTypeValidationRule).
@@ -109,13 +109,13 @@ var specValidation = govy.New(
 )
 
 var (
-	datadogValidation = govy.New(
+	datadogValidation = govy.New[DatadogConfig](
 		govy.For(func(d DatadogConfig) string { return d.Site }).
 			WithName("site").
 			Required().
 			Rules(v1alpha.DataDogSiteValidationRule()),
 	)
-	newRelicValidation = govy.New(
+	newRelicValidation = govy.New[NewRelicConfig](
 		govy.For(func(n NewRelicConfig) int { return n.AccountID }).
 			WithName("accountId").
 			Required().
@@ -129,7 +129,7 @@ var (
 			).
 			Rules(rules.StringStartsWith("NRIQ-")),
 	)
-	appDynamicsValidation = govy.New(
+	appDynamicsValidation = govy.New[AppDynamicsConfig](
 		urlPropertyRules(func(a AppDynamicsConfig) string { return a.URL }),
 		govy.For(func(a AppDynamicsConfig) string { return a.ClientName }).
 			WithName("clientName").
@@ -138,13 +138,13 @@ var (
 			WithName("accountName").
 			Required(),
 	)
-	splunkObservabilityValidation = govy.New(
+	splunkObservabilityValidation = govy.New[SplunkObservabilityConfig](
 		govy.For(func(s SplunkObservabilityConfig) string { return s.Realm }).
 			WithName("realm").
 			Required(),
 	)
 	thousandEyesValidation = govy.New[ThousandEyesConfig]()
-	bigQueryValidation     = govy.New(
+	bigQueryValidation     = govy.New[BigQueryConfig](
 		govy.For(func(b BigQueryConfig) string { return b.ServiceAccountKey }).
 			WithName("serviceAccountKey").
 			HideValue().
@@ -154,26 +154,26 @@ var (
 			).
 			Rules(rules.StringJSON()),
 	)
-	splunkValidation = govy.New(
+	splunkValidation = govy.New[SplunkConfig](
 		urlPropertyRules(func(s SplunkConfig) string { return s.URL }),
 	)
 	cloudWatchValidation = govy.New[CloudWatchConfig]()
 	pingdomValidation    = govy.New[PingdomConfig]()
-	redshiftValidation   = govy.New(
+	redshiftValidation   = govy.New[RedshiftConfig](
 		govy.For(func(r RedshiftConfig) string { return r.SecretARN }).
 			WithName("secretARN").
 			Required(),
 	)
-	sumoLogicValidation = govy.New(
+	sumoLogicValidation = govy.New[SumoLogicConfig](
 		urlPropertyRules(func(s SumoLogicConfig) string { return s.URL }),
 	)
-	instanaValidation = govy.New(
+	instanaValidation = govy.New[InstanaConfig](
 		urlPropertyRules(func(i InstanaConfig) string { return i.URL }),
 	)
-	influxDBValidation = govy.New(
+	influxDBValidation = govy.New[InfluxDBConfig](
 		urlPropertyRules(func(i InfluxDBConfig) string { return i.URL }),
 	)
-	gcmValidation = govy.New(
+	gcmValidation = govy.New[GCMConfig](
 		govy.For(func(g GCMConfig) string { return g.ServiceAccountKey }).
 			WithName("serviceAccountKey").
 			HideValue().
@@ -183,7 +183,7 @@ var (
 			).
 			Rules(rules.StringJSON()),
 	)
-	lightstepValidation = govy.New(
+	lightstepValidation = govy.New[LightstepConfig](
 		govy.For(func(l LightstepConfig) string { return l.Organization }).
 			WithName("organization").
 			Required(),
@@ -195,17 +195,17 @@ var (
 			OmitEmpty().
 			Rules(rules.URL()),
 	)
-	dynatraceValidation = govy.New(
+	dynatraceValidation = govy.New[DynatraceConfig](
 		urlPropertyRules(func(d DynatraceConfig) string { return d.URL }),
 	)
-	azureMonitorValidation = govy.New(
+	azureMonitorValidation = govy.New[AzureMonitorConfig](
 		govy.For(func(a AzureMonitorConfig) string { return a.TenantID }).
 			WithName("tenantId").
 			Required().
 			Rules(rules.StringUUID()),
 	)
 	honeycombValidation    = govy.New[HoneycombConfig]()
-	logicMonitorValidation = govy.New(
+	logicMonitorValidation = govy.New[LogicMonitorConfig](
 		govy.For(func(l LogicMonitorConfig) string { return l.Account }).
 			WithName("account").
 			Required().

--- a/manifest/v1alpha/labels.go
+++ b/manifest/v1alpha/labels.go
@@ -28,7 +28,7 @@ var labelsExamples string
 var labelKeyRegexp = regexp.MustCompile(`^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$`)
 
 func LabelsValidationRules() govy.Validator[Labels] {
-	return govy.New(
+	return govy.New[Labels](
 		govy.ForMap(govy.GetSelf[Labels]()).
 			RulesForKeys(
 				rules.StringLength(minLabelKeyLength, maxLabelKeyLength),
@@ -39,7 +39,7 @@ func LabelsValidationRules() govy.Validator[Labels] {
 	)
 }
 
-var labelValuesValidation = govy.New(
+var labelValuesValidation = govy.New[[]labelValue](
 	govy.ForSlice(govy.GetSelf[[]labelValue]()).
 		Rules(rules.SliceUnique(rules.HashFuncSelf[labelValue]())).
 		RulesForEach(

--- a/manifest/v1alpha/metadata_annotations.go
+++ b/manifest/v1alpha/metadata_annotations.go
@@ -29,7 +29,7 @@ var metadataAnnotationsExamples string
 var annotationKeyRegexp = regexp.MustCompile(`^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$`)
 
 func MetadataAnnotationsValidationRules() govy.Validator[MetadataAnnotations] {
-	return govy.New(
+	return govy.New[MetadataAnnotations](
 		govy.ForMap(govy.GetSelf[MetadataAnnotations]()).
 			RulesForKeys(
 				rules.StringLength(minAnnotationKeyLength, maxAnnotationKeyLength),
@@ -40,7 +40,7 @@ func MetadataAnnotationsValidationRules() govy.Validator[MetadataAnnotations] {
 	)
 }
 
-var annotationValueValidator = govy.New(
+var annotationValueValidator = govy.New[string](
 	govy.For(govy.GetSelf[string]()).
 		Rules(
 			rules.StringMaxLength(maxAnnotationValueLength),

--- a/manifest/v1alpha/project/validation.go
+++ b/manifest/v1alpha/project/validation.go
@@ -9,10 +9,10 @@ import (
 )
 
 func validate(p Project) *v1alpha.ObjectError {
-	return v1alpha.ValidateObject(validator, p, manifest.KindProject)
+	return v1alpha.ValidateObject[Project](validator, p, manifest.KindProject)
 }
 
-var validator = govy.New(
+var validator = govy.New[Project](
 	validationV1Alpha.FieldRuleAPIVersion(func(p Project) manifest.Version { return p.APIVersion }),
 	validationV1Alpha.FieldRuleKind(func(p Project) manifest.Kind { return p.Kind }, manifest.KindProject),
 	validationV1Alpha.FieldRuleMetadataName(func(p Project) string { return p.Metadata.Name }),

--- a/manifest/v1alpha/report/validation.go
+++ b/manifest/v1alpha/report/validation.go
@@ -12,10 +12,10 @@ import (
 )
 
 func validate(r Report) *v1alpha.ObjectError {
-	return v1alpha.ValidateObject(validator, r, manifest.KindReport)
+	return v1alpha.ValidateObject[Report](validator, r, manifest.KindReport)
 }
 
-var validator = govy.New(
+var validator = govy.New[Report](
 	validationV1Alpha.FieldRuleAPIVersion(func(r Report) manifest.Version { return r.APIVersion }),
 	validationV1Alpha.FieldRuleKind(func(r Report) manifest.Kind { return r.Kind }, manifest.KindReport),
 	govy.For(func(r Report) Metadata { return r.Metadata }).
@@ -79,13 +79,13 @@ var filtersValidation = govy.New[Filters](
 		IncludeForEach(sloValidation),
 )
 
-var requiredNameValidation = govy.New(
+var requiredNameValidation = govy.New[string](
 	govy.For(govy.GetSelf[string]()).
 		Required().
 		Rules(rules.StringDNSLabel()),
 )
 
-var serviceValidation = govy.New(
+var serviceValidation = govy.New[Service](
 	govy.For(func(s Service) string { return s.Project }).
 		WithName("project").
 		Include(requiredNameValidation),
@@ -94,7 +94,7 @@ var serviceValidation = govy.New(
 		Include(requiredNameValidation),
 )
 
-var sloValidation = govy.New(
+var sloValidation = govy.New[SLO](
 	govy.For(func(s SLO) string { return s.Project }).
 		WithName("project").
 		Include(requiredNameValidation),

--- a/manifest/v1alpha/slo/metrics_amazon_prometheus.go
+++ b/manifest/v1alpha/slo/metrics_amazon_prometheus.go
@@ -10,7 +10,7 @@ type AmazonPrometheusMetric struct {
 	PromQL *string `json:"promql"`
 }
 
-var amazonPrometheusValidation = govy.New(
+var amazonPrometheusValidation = govy.New[AmazonPrometheusMetric](
 	govy.ForPointer(func(p AmazonPrometheusMetric) *string { return p.PromQL }).
 		WithName("promql").
 		Required().

--- a/manifest/v1alpha/slo/metrics_app_dynamics.go
+++ b/manifest/v1alpha/slo/metrics_app_dynamics.go
@@ -19,7 +19,7 @@ type AppDynamicsMetric struct {
 	MetricPath      *string `json:"metricPath"`
 }
 
-var appDynamicsCountMetricsLevelValidation = govy.New(
+var appDynamicsCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).Rules(
 		govy.NewRule(func(c CountMetricsSpec) error {
 			total := c.TotalMetric
@@ -55,7 +55,7 @@ var appDynamicsCountMetricsLevelValidation = govy.New(
 
 var appDynamicsMetricPathWildcardRegex = regexp.MustCompile(`([^\s|]\*)|(\*[^\s|])`)
 
-var appDynamicsValidation = govy.New(
+var appDynamicsValidation = govy.New[AppDynamicsMetric](
 	govy.ForPointer(func(a AppDynamicsMetric) *string { return a.ApplicationName }).
 		WithName("applicationName").
 		Required().

--- a/manifest/v1alpha/slo/metrics_azure_monitor.go
+++ b/manifest/v1alpha/slo/metrics_azure_monitor.go
@@ -54,7 +54,7 @@ var supportedAzureMonitorDataTypes = []string{
 
 var azureMonitorResourceIDRegex = regexp.MustCompile(`^/subscriptions/[a-zA-Z0-9-]+/resourceGroups/[a-zA-Z0-9-._()]+/providers/[a-zA-Z0-9-.()_]+/[a-zA-Z0-9-_()]+/[a-zA-Z0-9-_()]+$`) //nolint:lll
 
-var azureMonitorValidation = govy.New(
+var azureMonitorValidation = govy.New[AzureMonitorMetric](
 	govy.For(govy.GetSelf[AzureMonitorMetric]()).
 		Include(azureMonitorMetricDataTypeValidation).
 		Include(azureMonitorMetricLogsDataTypeValidation),
@@ -64,7 +64,7 @@ var azureMonitorValidation = govy.New(
 		Rules(rules.OneOf(supportedAzureMonitorDataTypes...)),
 )
 
-var azureMonitorMetricDataTypeValidation = govy.New(
+var azureMonitorMetricDataTypeValidation = govy.New[AzureMonitorMetric](
 	govy.For(func(a AzureMonitorMetric) string { return a.MetricName }).
 		WithName("metricName").
 		Required(),
@@ -98,7 +98,7 @@ var azureMonitorMetricDataTypeValidation = govy.New(
 
 var validAzureResourceGroupRegex = regexp.MustCompile(`^[a-zA-Z0-9-._()]+$`)
 
-var azureMonitorMetricLogAnalyticsWorkspaceValidation = govy.New(
+var azureMonitorMetricLogAnalyticsWorkspaceValidation = govy.New[AzureMonitorMetricLogAnalyticsWorkspace](
 	govy.For(func(a AzureMonitorMetricLogAnalyticsWorkspace) string { return a.SubscriptionID }).
 		WithName("subscriptionId").
 		Required().
@@ -113,7 +113,7 @@ var azureMonitorMetricLogAnalyticsWorkspaceValidation = govy.New(
 		Rules(rules.StringUUID()),
 )
 
-var azureMonitorMetricLogsDataTypeValidation = govy.New(
+var azureMonitorMetricLogsDataTypeValidation = govy.New[AzureMonitorMetric](
 	govy.ForPointer(func(a AzureMonitorMetric) *AzureMonitorMetricLogAnalyticsWorkspace { return a.Workspace }).
 		WithName("workspace").
 		Required().
@@ -147,7 +147,7 @@ var azureMonitorMetricLogsDataTypeValidation = govy.New(
 	govy.WhenDescription("dataType is '%s'", AzureMonitorDataTypeLogs),
 )
 
-var azureMonitorMetricDimensionValidation = govy.New(
+var azureMonitorMetricDimensionValidation = govy.New[AzureMonitorMetricDimension](
 	govy.ForPointer(func(a AzureMonitorMetricDimension) *string { return a.Name }).
 		WithName("name").
 		Required().
@@ -164,7 +164,7 @@ var azureMonitorMetricDimensionValidation = govy.New(
 			rules.StringASCII()),
 )
 
-var azureMonitorCountMetricsLevelValidation = govy.New(
+var azureMonitorCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).Rules(
 		govy.NewRule(func(c CountMetricsSpec) error {
 			total := c.TotalMetric

--- a/manifest/v1alpha/slo/metrics_azure_prometheus.go
+++ b/manifest/v1alpha/slo/metrics_azure_prometheus.go
@@ -10,7 +10,7 @@ type AzurePrometheusMetric struct {
 	PromQL string `json:"promql"`
 }
 
-var azurePrometheusValidation = govy.New(
+var azurePrometheusValidation = govy.New[AzurePrometheusMetric](
 	govy.For(func(p AzurePrometheusMetric) string { return p.PromQL }).
 		WithName("promql").
 		Required().

--- a/manifest/v1alpha/slo/metrics_bigquery.go
+++ b/manifest/v1alpha/slo/metrics_bigquery.go
@@ -16,7 +16,7 @@ type BigQueryMetric struct {
 	Location  string `json:"location"`
 }
 
-var bigQueryCountMetricsLevelValidation = govy.New(
+var bigQueryCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			govy.NewRule(func(c CountMetricsSpec) error {
@@ -36,7 +36,7 @@ var bigQueryCountMetricsLevelValidation = govy.New(
 	govy.WhenDescription("countMetrics is bigQuery"),
 )
 
-var bigQueryValidation = govy.New(
+var bigQueryValidation = govy.New[BigQueryMetric](
 	govy.For(func(b BigQueryMetric) string { return b.ProjectID }).
 		WithName("projectId").
 		Required().

--- a/manifest/v1alpha/slo/metrics_cloudwatch.go
+++ b/manifest/v1alpha/slo/metrics_cloudwatch.go
@@ -48,7 +48,7 @@ type CloudWatchMetricDimension struct {
 	Value *string `json:"value"`
 }
 
-var cloudWatchValidation = govy.New(
+var cloudWatchValidation = govy.New[CloudWatchMetric](
 	govy.For(govy.GetSelf[CloudWatchMetric]()).
 		Cascade(govy.CascadeModeStop).
 		Rules(govy.NewRule(func(c CloudWatchMetric) error {
@@ -87,7 +87,7 @@ var cloudWatchValidation = govy.New(
 			}()...)),
 )
 
-var cloudWatchSQLConfigValidation = govy.New(
+var cloudWatchSQLConfigValidation = govy.New[CloudWatchMetric](
 	govy.ForPointer(func(c CloudWatchMetric) *string { return c.SQL }).
 		WithName("sql").
 		Required().
@@ -97,7 +97,7 @@ var cloudWatchSQLConfigValidation = govy.New(
 	govy.WhenDescription("sql is provided"),
 )
 
-var cloudWatchJSONConfigValidation = govy.New(
+var cloudWatchJSONConfigValidation = govy.New[CloudWatchMetric](
 	govy.ForPointer(func(c CloudWatchMetric) *string { return c.JSON }).
 		WithName("json").
 		Required().
@@ -107,7 +107,7 @@ var cloudWatchJSONConfigValidation = govy.New(
 	govy.WhenDescription("json is provided"),
 )
 
-var cloudWatchStandardConfigValidation = govy.New(
+var cloudWatchStandardConfigValidation = govy.New[CloudWatchMetric](
 	govy.ForPointer(func(c CloudWatchMetric) *string { return c.Namespace }).
 		WithName("namespace").
 		Required().
@@ -157,7 +157,7 @@ var (
 	cloudWatchAccountIDRegexp = regexp.MustCompile(`^\d{12}$`)
 )
 
-var cloudwatchMetricDimensionValidation = govy.New(
+var cloudwatchMetricDimensionValidation = govy.New[CloudWatchMetricDimension](
 	govy.ForPointer(func(c CloudWatchMetricDimension) *string { return c.Name }).
 		WithName("name").
 		Required().

--- a/manifest/v1alpha/slo/metrics_datadog.go
+++ b/manifest/v1alpha/slo/metrics_datadog.go
@@ -10,7 +10,7 @@ type DatadogMetric struct {
 	Query *string `json:"query"`
 }
 
-var datadogValidation = govy.New(
+var datadogValidation = govy.New[DatadogMetric](
 	govy.ForPointer(func(d DatadogMetric) *string { return d.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_dynatrace.go
+++ b/manifest/v1alpha/slo/metrics_dynatrace.go
@@ -10,7 +10,7 @@ type DynatraceMetric struct {
 	MetricSelector *string `json:"metricSelector"`
 }
 
-var dynatraceValidation = govy.New(
+var dynatraceValidation = govy.New[DynatraceMetric](
 	govy.ForPointer(func(d DynatraceMetric) *string { return d.MetricSelector }).
 		WithName("metricSelector").
 		Required().

--- a/manifest/v1alpha/slo/metrics_elasticsearch.go
+++ b/manifest/v1alpha/slo/metrics_elasticsearch.go
@@ -11,7 +11,7 @@ type ElasticsearchMetric struct {
 	Query *string `json:"query"`
 }
 
-var elasticsearchValidation = govy.New(
+var elasticsearchValidation = govy.New[ElasticsearchMetric](
 	govy.ForPointer(func(e ElasticsearchMetric) *string { return e.Index }).
 		WithName("index").
 		Required().

--- a/manifest/v1alpha/slo/metrics_gcm.go
+++ b/manifest/v1alpha/slo/metrics_gcm.go
@@ -8,7 +8,7 @@ type GCMMetric struct {
 	ProjectID string `json:"projectId"`
 }
 
-var gcmValidation = govy.New(
+var gcmValidation = govy.New[GCMMetric](
 	govy.For(func(e GCMMetric) string { return e.Query }).
 		WithName("query").
 		Required(),

--- a/manifest/v1alpha/slo/metrics_generic.go
+++ b/manifest/v1alpha/slo/metrics_generic.go
@@ -9,7 +9,7 @@ type GenericMetric struct {
 	Query *string `json:"query"`
 }
 
-var genericValidation = govy.New(
+var genericValidation = govy.New[GenericMetric](
 	govy.ForPointer(func(e GenericMetric) *string { return e.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_grafana_loki.go
+++ b/manifest/v1alpha/slo/metrics_grafana_loki.go
@@ -10,7 +10,7 @@ type GrafanaLokiMetric struct {
 	Logql *string `json:"logql"`
 }
 
-var grafanaLokiValidation = govy.New(
+var grafanaLokiValidation = govy.New[GrafanaLokiMetric](
 	govy.ForPointer(func(g GrafanaLokiMetric) *string { return g.Logql }).
 		WithName("logql").
 		Required().

--- a/manifest/v1alpha/slo/metrics_graphite.go
+++ b/manifest/v1alpha/slo/metrics_graphite.go
@@ -12,7 +12,7 @@ type GraphiteMetric struct {
 	MetricPath *string `json:"metricPath"`
 }
 
-var graphiteValidation = govy.New(
+var graphiteValidation = govy.New[GraphiteMetric](
 	govy.ForPointer(func(g GraphiteMetric) *string { return g.MetricPath }).
 		WithName("metricPath").
 		Required().

--- a/manifest/v1alpha/slo/metrics_honeycomb.go
+++ b/manifest/v1alpha/slo/metrics_honeycomb.go
@@ -15,7 +15,7 @@ type HoneycombMetric struct {
 	Attribute   string `json:"attribute,omitempty"`
 }
 
-var honeycombValidation = govy.New(
+var honeycombValidation = govy.New[HoneycombMetric](
 	govy.For(func(h HoneycombMetric) string { return h.Calculation }).
 		WithName("calculation").
 		Required().
@@ -28,7 +28,7 @@ var supportedHoneycombCalculationTypes = []string{
 	"RATE_AVG", "RATE_SUM", "RATE_MAX",
 }
 
-var attributeRequired = govy.New(
+var attributeRequired = govy.New[HoneycombMetric](
 	govy.For(func(h HoneycombMetric) string { return h.Attribute }).
 		WithName("attribute").
 		Required().

--- a/manifest/v1alpha/slo/metrics_influxdb.go
+++ b/manifest/v1alpha/slo/metrics_influxdb.go
@@ -12,7 +12,7 @@ type InfluxDBMetric struct {
 	Query *string `json:"query"`
 }
 
-var influxdbValidation = govy.New(
+var influxdbValidation = govy.New[InfluxDBMetric](
 	govy.ForPointer(func(i InfluxDBMetric) *string { return i.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_instana.go
+++ b/manifest/v1alpha/slo/metrics_instana.go
@@ -47,7 +47,7 @@ const (
 	instanaMetricRetrievalMethodSnapshot = "snapshot"
 )
 
-var instanaCountMetricsLevelValidation = govy.New(
+var instanaCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			govy.NewRule(func(c CountMetricsSpec) error {
@@ -85,9 +85,9 @@ var instanaValidation = govy.ForPointer(func(m MetricSpec) *InstanaMetric { retu
 		return nil
 	}))
 
-var instanaCountMetricsValidation = govy.New(
+var instanaCountMetricsValidation = govy.New[MetricSpec](
 	instanaValidation.
-		Include(govy.New(
+		Include(govy.New[InstanaMetric](
 			govy.For(func(i InstanaMetric) string { return i.MetricType }).
 				WithName("metricType").
 				Required().
@@ -102,9 +102,9 @@ var instanaCountMetricsValidation = govy.New(
 		)),
 )
 
-var instanaRawMetricValidation = govy.New(
+var instanaRawMetricValidation = govy.New[MetricSpec](
 	instanaValidation.
-		Include(govy.New(
+		Include(govy.New[InstanaMetric](
 			govy.For(func(i InstanaMetric) string { return i.MetricType }).
 				WithName("metricType").
 				Required().
@@ -118,7 +118,7 @@ var instanaRawMetricValidation = govy.New(
 		)),
 )
 
-var instanaInfrastructureMetricValidation = govy.New(
+var instanaInfrastructureMetricValidation = govy.New[InstanaInfrastructureMetricType](
 	govy.For(govy.GetSelf[InstanaInfrastructureMetricType]()).
 		Rules(govy.NewRule(func(i InstanaInfrastructureMetricType) error {
 			switch i.MetricRetrievalMethod {
@@ -156,7 +156,7 @@ var validInstanaLatencyAggregations = []string{
 	"p50", "p75", "p90", "p95", "p98", "p99",
 }
 
-var instanaApplicationMetricValidation = govy.New(
+var instanaApplicationMetricValidation = govy.New[InstanaApplicationMetricType](
 	govy.For(govy.GetSelf[InstanaApplicationMetricType]()).
 		Rules(govy.NewRule(func(i InstanaApplicationMetricType) error {
 			switch i.MetricID {
@@ -193,7 +193,7 @@ var instanaApplicationMetricValidation = govy.New(
 	govy.For(func(i InstanaApplicationMetricType) InstanaApplicationMetricGroupBy { return i.GroupBy }).
 		WithName("groupBy").
 		Required().
-		Include(govy.New(
+		Include(govy.New[InstanaApplicationMetricGroupBy](
 			govy.For(func(i InstanaApplicationMetricGroupBy) string { return i.Tag }).
 				WithName("tag").
 				Required(),

--- a/manifest/v1alpha/slo/metrics_lightstep.go
+++ b/manifest/v1alpha/slo/metrics_lightstep.go
@@ -25,7 +25,7 @@ type LightstepMetric struct {
 	UQL        *string  `json:"uql,omitempty"`
 }
 
-var lightstepCountMetricsLevelValidation = govy.New(
+var lightstepCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(govy.NewRule(func(c CountMetricsSpec) error {
 			if c.GoodMetric.Lightstep.StreamID == nil || c.TotalMetric.Lightstep.StreamID == nil {
@@ -48,13 +48,13 @@ var lightstepCountMetricsLevelValidation = govy.New(
 func createLightstepMetricSpecValidation(
 	include govy.Validator[LightstepMetric],
 ) govy.Validator[MetricSpec] {
-	return govy.New(
+	return govy.New[MetricSpec](
 		govy.ForPointer(func(m MetricSpec) *LightstepMetric { return m.Lightstep }).
 			WithName("lightstep").
 			Include(include))
 }
 
-var lightstepRawMetricValidation = createLightstepMetricSpecValidation(govy.New(
+var lightstepRawMetricValidation = createLightstepMetricSpecValidation(govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.TypeOfData }).
 		WithName("typeOfData").
 		Required().
@@ -65,21 +65,21 @@ var lightstepRawMetricValidation = createLightstepMetricSpecValidation(govy.New(
 		)),
 ))
 
-var lightstepTotalCountMetricValidation = createLightstepMetricSpecValidation(govy.New(
+var lightstepTotalCountMetricValidation = createLightstepMetricSpecValidation(govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.TypeOfData }).
 		WithName("typeOfData").
 		Required().
 		Rules(rules.OneOf(LightstepTotalCountDataType, LightstepMetricDataType)),
 ))
 
-var lightstepGoodCountMetricValidation = createLightstepMetricSpecValidation(govy.New(
+var lightstepGoodCountMetricValidation = createLightstepMetricSpecValidation(govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.TypeOfData }).
 		WithName("typeOfData").
 		Required().
 		Rules(rules.OneOf(LightstepGoodCountDataType, LightstepMetricDataType)),
 ))
 
-var lightstepValidation = govy.New(
+var lightstepValidation = govy.New[LightstepMetric](
 	govy.For(govy.GetSelf[LightstepMetric]()).
 		Include(lightstepLatencyDataTypeValidation).
 		Include(lightstepMetricDataTypeValidation).
@@ -87,7 +87,7 @@ var lightstepValidation = govy.New(
 		Include(lightstepErrorRateDataTypeValidation),
 )
 
-var lightstepLatencyDataTypeValidation = govy.New(
+var lightstepLatencyDataTypeValidation = govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.StreamID }).
 		WithName("streamId").
 		Required(),
@@ -106,7 +106,7 @@ var lightstepLatencyDataTypeValidation = govy.New(
 
 var lightstepUQLRegexp = regexp.MustCompile(`((constant|spans_sample|assemble)\s+[a-z\d.])`)
 
-var lightstepMetricDataTypeValidation = govy.New(
+var lightstepMetricDataTypeValidation = govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.StreamID }).
 		WithName("streamId").
 		Rules(rules.Forbidden[string]()),
@@ -123,7 +123,7 @@ var lightstepMetricDataTypeValidation = govy.New(
 		govy.WhenDescription("typeOfData is '%s'", LightstepMetricDataType),
 	)
 
-var lightstepGoodAndTotalDataTypeValidation = govy.New(
+var lightstepGoodAndTotalDataTypeValidation = govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.StreamID }).
 		WithName("streamId").
 		Required(),
@@ -144,7 +144,7 @@ var lightstepGoodAndTotalDataTypeValidation = govy.New(
 			LightstepGoodCountDataType, LightstepTotalCountDataType),
 	)
 
-var lightstepErrorRateDataTypeValidation = govy.New(
+var lightstepErrorRateDataTypeValidation = govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.StreamID }).
 		WithName("streamId").
 		Required(),

--- a/manifest/v1alpha/slo/metrics_logic_monitor.go
+++ b/manifest/v1alpha/slo/metrics_logic_monitor.go
@@ -13,7 +13,7 @@ type LogicMonitorMetric struct {
 	Line                       string `json:"line"`
 }
 
-var logicMonitorValidation = govy.New(
+var logicMonitorValidation = govy.New[LogicMonitorMetric](
 	govy.For(func(e LogicMonitorMetric) string { return e.QueryType }).
 		WithName("queryType").
 		Required().

--- a/manifest/v1alpha/slo/metrics_newrelic.go
+++ b/manifest/v1alpha/slo/metrics_newrelic.go
@@ -12,7 +12,7 @@ type NewRelicMetric struct {
 	NRQL *string `json:"nrql"`
 }
 
-var newRelicValidation = govy.New(
+var newRelicValidation = govy.New[NewRelicMetric](
 	govy.ForPointer(func(n NewRelicMetric) *string { return n.NRQL }).
 		WithName("nrql").
 		Required().

--- a/manifest/v1alpha/slo/metrics_opentsdb.go
+++ b/manifest/v1alpha/slo/metrics_opentsdb.go
@@ -10,7 +10,7 @@ type OpenTSDBMetric struct {
 	Query *string `json:"query"`
 }
 
-var openTSDBValidation = govy.New(
+var openTSDBValidation = govy.New[OpenTSDBMetric](
 	govy.ForPointer(func(o OpenTSDBMetric) *string { return o.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_pingdom.go
+++ b/manifest/v1alpha/slo/metrics_pingdom.go
@@ -29,7 +29,7 @@ const (
 	pingdomStatusUnknown     = "unknown"
 )
 
-var pingdomCountMetricsLevelValidation = govy.New(
+var pingdomCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			govy.NewRule(func(c CountMetricsSpec) error {
@@ -60,20 +60,20 @@ var pingdomCountMetricsLevelValidation = govy.New(
 func createPingdomMetricSpecValidation(
 	include govy.Validator[PingdomMetric],
 ) govy.Validator[MetricSpec] {
-	return govy.New(
+	return govy.New[MetricSpec](
 		govy.ForPointer(func(m MetricSpec) *PingdomMetric { return m.Pingdom }).
 			WithName("pingdom").
 			Include(include))
 }
 
-var pingdomRawMetricValidation = createPingdomMetricSpecValidation(govy.New(
+var pingdomRawMetricValidation = createPingdomMetricSpecValidation(govy.New[PingdomMetric](
 	govy.ForPointer(func(p PingdomMetric) *string { return p.CheckType }).
 		WithName("checkType").
 		Required().
 		Rules(rules.EQ(PingdomTypeUptime)),
 ))
 
-var pingdomCountMetricsValidation = createPingdomMetricSpecValidation(govy.New(
+var pingdomCountMetricsValidation = createPingdomMetricSpecValidation(govy.New[PingdomMetric](
 	govy.ForPointer(func(p PingdomMetric) *string { return p.CheckType }).
 		WithName("checkType").
 		Required().
@@ -87,7 +87,7 @@ var pingdomCountMetricsValidation = createPingdomMetricSpecValidation(govy.New(
 		Rules(rules.Required[*string]()),
 ))
 
-var pingdomValidation = govy.New(
+var pingdomValidation = govy.New[PingdomMetric](
 	govy.For(govy.GetSelf[PingdomMetric]()).
 		Include(pingdomUptimeCheckTypeValidation).
 		Include(pingdomTransactionCheckTypeValidation),
@@ -100,7 +100,7 @@ var pingdomValidation = govy.New(
 			rules.StringMatchRegexp(regexp.MustCompile(`^(?:|\d+)$`))), // nolint: gocritic
 )
 
-var pingdomUptimeCheckTypeValidation = govy.New(
+var pingdomUptimeCheckTypeValidation = govy.New[PingdomMetric](
 	govy.ForPointer(func(m PingdomMetric) *string { return m.Status }).
 		WithName("status").
 		Rules(govy.NewRule(func(s string) error {
@@ -121,7 +121,7 @@ var pingdomUptimeCheckTypeValidation = govy.New(
 		govy.WhenDescription("checkType is equal to '%s'", PingdomTypeUptime),
 	)
 
-var pingdomTransactionCheckTypeValidation = govy.New(
+var pingdomTransactionCheckTypeValidation = govy.New[PingdomMetric](
 	govy.ForPointer(func(m PingdomMetric) *string { return m.Status }).
 		WithName("status").
 		Rules(rules.Forbidden[string]()),

--- a/manifest/v1alpha/slo/metrics_prometheus.go
+++ b/manifest/v1alpha/slo/metrics_prometheus.go
@@ -10,7 +10,7 @@ type PrometheusMetric struct {
 	PromQL *string `json:"promql"`
 }
 
-var prometheusValidation = govy.New(
+var prometheusValidation = govy.New[PrometheusMetric](
 	govy.ForPointer(func(p PrometheusMetric) *string { return p.PromQL }).
 		WithName("promql").
 		Required().

--- a/manifest/v1alpha/slo/metrics_redshift.go
+++ b/manifest/v1alpha/slo/metrics_redshift.go
@@ -17,7 +17,7 @@ type RedshiftMetric struct {
 	Query        *string `json:"query"`
 }
 
-var redshiftCountMetricsLevelValidation = govy.New(
+var redshiftCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			govy.NewRule(func(c CountMetricsSpec) error {
@@ -40,7 +40,7 @@ var redshiftCountMetricsLevelValidation = govy.New(
 	govy.WhenDescription("countMetrics is redshift"),
 )
 
-var redshiftValidation = govy.New(
+var redshiftValidation = govy.New[RedshiftMetric](
 	govy.ForPointer(func(r RedshiftMetric) *string { return r.Region }).
 		WithName("region").
 		Required().

--- a/manifest/v1alpha/slo/metrics_splunk.go
+++ b/manifest/v1alpha/slo/metrics_splunk.go
@@ -16,7 +16,7 @@ type SplunkMetric struct {
 	Query *string `json:"query"`
 }
 
-var splunkCountMetricsLevelValidation = govy.New(
+var splunkCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			govy.NewRule(func(c CountMetricsSpec) error {
@@ -32,7 +32,7 @@ var splunkCountMetricsLevelValidation = govy.New(
 	govy.WhenDescription("countMetrics is splunk"),
 )
 
-var splunkValidation = govy.New(
+var splunkValidation = govy.New[SplunkMetric](
 	govy.ForPointer(func(s SplunkMetric) *string { return s.Query }).
 		WithName("query").
 		Required().
@@ -46,7 +46,7 @@ var splunkValidation = govy.New(
 				WithDetails(`query has to contain index=<NAME> or "index"=<NAME>`)),
 )
 
-var splunkSingleQueryValidation = govy.New(
+var splunkSingleQueryValidation = govy.New[SplunkMetric](
 	govy.ForPointer(func(s SplunkMetric) *string { return s.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_splunk_observability.go
+++ b/manifest/v1alpha/slo/metrics_splunk_observability.go
@@ -10,7 +10,7 @@ type SplunkObservabilityMetric struct {
 	Program *string `json:"program"`
 }
 
-var splunkObservabilityValidation = govy.New(
+var splunkObservabilityValidation = govy.New[SplunkObservabilityMetric](
 	govy.ForPointer(func(s SplunkObservabilityMetric) *string { return s.Program }).
 		WithName("program").
 		Required().

--- a/manifest/v1alpha/slo/metrics_sumo_logic.go
+++ b/manifest/v1alpha/slo/metrics_sumo_logic.go
@@ -27,7 +27,7 @@ const (
 	sumoLogicTypeLogs   = "logs"
 )
 
-var sumoLogicCountMetricsLevelValidation = govy.New(
+var sumoLogicCountMetricsLevelValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Rules(
 			// Quantization must be equal for good and total.
@@ -68,7 +68,7 @@ var sumoLogicCountMetricsLevelValidation = govy.New(
 	govy.WhenDescription("countMetrics is sumoLogic"),
 )
 
-var sumoLogicValidation = govy.New(
+var sumoLogicValidation = govy.New[SumoLogicMetric](
 	govy.For(govy.GetSelf[SumoLogicMetric]()).
 		Include(sumoLogicMetricTypeValidation).
 		Include(sumoLogicLogsTypeValidation),
@@ -80,7 +80,7 @@ var sumoLogicValidation = govy.New(
 
 var sumoLogicValidRollups = []string{"Avg", "Sum", "Min", "Max", "Count", "None"}
 
-var sumoLogicMetricTypeValidation = govy.New(
+var sumoLogicMetricTypeValidation = govy.New[SumoLogicMetric](
 	govy.ForPointer(func(p SumoLogicMetric) *string { return p.Query }).
 		WithName("query").
 		Required(),
@@ -109,7 +109,7 @@ var sumoLogicMetricTypeValidation = govy.New(
 		govy.WhenDescription("type is '%s'", sumoLogicTypeMetric),
 	)
 
-var sumoLogicLogsTypeValidation = govy.New(
+var sumoLogicLogsTypeValidation = govy.New[SumoLogicMetric](
 	govy.ForPointer(func(p SumoLogicMetric) *string { return p.Query }).
 		WithName("query").
 		Required().

--- a/manifest/v1alpha/slo/metrics_thousand_eyes.go
+++ b/manifest/v1alpha/slo/metrics_thousand_eyes.go
@@ -24,13 +24,13 @@ const (
 	ThousandEyesDNSSECValid             = "dns-dnssec-valid"
 )
 
-var thousandEyesCountMetricsValidation = govy.New(
+var thousandEyesCountMetricsValidation = govy.New[MetricSpec](
 	govy.ForPointer(func(m MetricSpec) *ThousandEyesMetric { return m.ThousandEyes }).
 		WithName("thousandEyes").
 		Rules(rules.Forbidden[ThousandEyesMetric]()),
 )
 
-var thousandEyesRawMetricValidation = govy.New(
+var thousandEyesRawMetricValidation = govy.New[MetricSpec](
 	govy.ForPointer(func(m MetricSpec) *ThousandEyesMetric { return m.ThousandEyes }).
 		WithName("thousandEyes").
 		Include(thousandEyesValidation),
@@ -49,7 +49,7 @@ var supportedThousandEyesTestTypes = []string{
 	ThousandEyesDNSSECValid,
 }
 
-var thousandEyesValidation = govy.New(
+var thousandEyesValidation = govy.New[ThousandEyesMetric](
 	govy.ForPointer(func(m ThousandEyesMetric) *int64 { return m.TestID }).
 		WithName("testID").
 		Required().

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -22,7 +22,7 @@ const (
 	errCodeTimeSliceTarget                  = "time_slice_target"
 )
 
-var specMetricsValidation = govy.New(
+var specMetricsValidation = govy.New[Spec](
 	govy.For(govy.GetSelf[Spec]()).
 		Cascade(govy.CascadeModeStop).
 		Rules(govy.NewRule(func(s Spec) error {
@@ -55,7 +55,7 @@ var specMetricsValidation = govy.New(
 		Rules(timeSliceTargetsValidationRule),
 )
 
-var countMetricsSpecValidation = govy.New(
+var countMetricsSpecValidation = govy.New[CountMetricsSpec](
 	govy.For(govy.GetSelf[CountMetricsSpec]()).
 		Include(
 			azureMonitorCountMetricsLevelValidation,
@@ -96,7 +96,7 @@ var countMetricsSpecValidation = govy.New(
 			singleQueryMetricSpecValidation),
 )
 
-var rawMetricsValidation = govy.New(
+var rawMetricsValidation = govy.New[RawMetricSpec](
 	govy.ForPointer(func(r RawMetricSpec) *MetricSpec { return r.MetricQuery }).
 		WithName("query").
 		Required().
@@ -108,7 +108,7 @@ var rawMetricsValidation = govy.New(
 			instanaRawMetricValidation),
 )
 
-var countMetricsValidation = govy.New(
+var countMetricsValidation = govy.New[MetricSpec](
 	govy.For(govy.GetSelf[MetricSpec]()).
 		Include(
 			pingdomCountMetricsValidation,
@@ -116,13 +116,13 @@ var countMetricsValidation = govy.New(
 			instanaCountMetricsValidation),
 )
 
-var singleQueryMetricSpecValidation = govy.New(
+var singleQueryMetricSpecValidation = govy.New[MetricSpec](
 	govy.ForPointer(func(m MetricSpec) *SplunkMetric { return m.Splunk }).
 		WithName("splunk").
 		Include(splunkSingleQueryValidation),
 )
 
-var metricSpecValidation = govy.New(
+var metricSpecValidation = govy.New[MetricSpec](
 	govy.ForPointer(func(m MetricSpec) *AppDynamicsMetric { return m.AppDynamics }).
 		WithName("appDynamics").
 		Include(appDynamicsValidation),

--- a/manifest/v1alpha/slo/time_window.go
+++ b/manifest/v1alpha/slo/time_window.go
@@ -53,7 +53,7 @@ const (
 	maximumCalendarTimeWindowSize = 366 * 24 * time.Hour // 366 days
 )
 
-var timeWindowsValidation = govy.New(
+var timeWindowsValidation = govy.New[TimeWindow](
 	govy.For(func(t TimeWindow) string { return t.Unit }).
 		WithName("unit").
 		Required().
@@ -63,7 +63,7 @@ var timeWindowsValidation = govy.New(
 		Rules(rules.GT(0)),
 	govy.ForPointer(func(t TimeWindow) *Calendar { return t.Calendar }).
 		WithName("calendar").
-		Include(govy.New(
+		Include(govy.New[Calendar](
 			govy.For(func(c Calendar) string { return c.StartTime }).
 				WithName("startTime").
 				Required().

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -22,10 +22,10 @@ func validate(s SLO) *v1alpha.ObjectError {
 			}
 		}
 	}
-	return v1alpha.ValidateObject(validator, s, manifest.KindSLO)
+	return v1alpha.ValidateObject[SLO](validator, s, manifest.KindSLO)
 }
 
-var validator = govy.New(
+var validator = govy.New[SLO](
 	validationV1Alpha.FieldRuleAPIVersion(func(s SLO) manifest.Version { return s.APIVersion }),
 	validationV1Alpha.FieldRuleKind(func(s SLO) manifest.Kind { return s.Kind }, manifest.KindSLO),
 	govy.For(func(s SLO) SLO { return s }).
@@ -40,7 +40,7 @@ var validator = govy.New(
 		Include(specValidation),
 )
 
-var metadataValidation = govy.New(
+var metadataValidation = govy.New[Metadata](
 	validationV1Alpha.FieldRuleMetadataName(func(m Metadata) string { return m.Name }),
 	validationV1Alpha.FieldRuleMetadataDisplayName(func(m Metadata) string { return m.DisplayName }),
 	validationV1Alpha.FieldRuleMetadataProject(func(m Metadata) string { return m.Project }),
@@ -68,7 +68,7 @@ func getCompositeObjectiveComponents(s SLO) []CompositeObjective {
 	return make([]CompositeObjective, 0)
 }
 
-var sloValidationComposite = govy.New(
+var sloValidationComposite = govy.New[SLO](
 	govy.For(govy.GetSelf[SLO]()).
 		Rules(
 			govy.NewRule(func(s SLO) error {
@@ -120,7 +120,7 @@ var sloValidationComposite = govy.New(
 	govy.WhenDescription("at least one composite objective is defined"),
 )
 
-var specValidation = govy.New(
+var specValidation = govy.New[Spec](
 	govy.For(govy.GetSelf[Spec]()).
 		Cascade(govy.CascadeModeStop).
 		Include(specMetricsValidation),
@@ -198,7 +198,7 @@ var specValidation = govy.New(
 		),
 )
 
-var attachmentValidation = govy.New(
+var attachmentValidation = govy.New[Attachment](
 	govy.For(func(a Attachment) string { return a.URL }).
 		WithName("url").
 		Required().
@@ -208,14 +208,14 @@ var attachmentValidation = govy.New(
 		Rules(rules.StringLength(0, 63)),
 )
 
-var compositeValidation = govy.New(
+var compositeValidation = govy.New[Composite](
 	govy.ForPointer(func(c Composite) *float64 { return c.BudgetTarget }).
 		WithName("target").
 		Required().
 		Rules(rules.GT(0.0), rules.LT(1.0)),
 	govy.ForPointer(func(c Composite) *CompositeBurnRateCondition { return c.BurnRateCondition }).
 		WithName("burnRateCondition").
-		Include(govy.New(
+		Include(govy.New[CompositeBurnRateCondition](
 			govy.For(func(b CompositeBurnRateCondition) float64 { return b.Value }).
 				WithName("value").
 				Rules(rules.GTE(0.0), rules.LTE(1000.0)),
@@ -253,7 +253,7 @@ var specCompositeValidationRule = govy.NewRule(func(s Spec) error {
 	return nil
 })
 
-var compositeObjectiveRule = govy.New(
+var compositeObjectiveRule = govy.New[CompositeObjective](
 	govy.For(func(c CompositeObjective) string { return c.Project }).
 		WithName("project").
 		Required().
@@ -279,16 +279,16 @@ var compositeObjectiveRule = govy.New(
 		)),
 )
 
-var anomalyConfigValidation = govy.New(
+var anomalyConfigValidation = govy.New[AnomalyConfig](
 	govy.ForPointer(func(a AnomalyConfig) *AnomalyConfigNoData { return a.NoData }).
 		WithName("noData").
-		Include(govy.New(
+		Include(govy.New[AnomalyConfigNoData](
 			govy.ForSlice(func(a AnomalyConfigNoData) []AnomalyConfigAlertMethod { return a.AlertMethods }).
 				WithName("alertMethods").
 				Cascade(govy.CascadeModeStop).
 				Rules(rules.SliceMinLength[[]AnomalyConfigAlertMethod](1)).
 				Rules(rules.SliceUnique(rules.HashFuncSelf[AnomalyConfigAlertMethod]())).
-				IncludeForEach(govy.New(
+				IncludeForEach(govy.New[AnomalyConfigAlertMethod](
 					govy.For(func(a AnomalyConfigAlertMethod) string { return a.Name }).
 						WithName("name").
 						Required().
@@ -300,10 +300,10 @@ var anomalyConfigValidation = govy.New(
 		)),
 )
 
-var indicatorValidation = govy.New(
+var indicatorValidation = govy.New[Indicator](
 	govy.For(func(i Indicator) MetricSourceSpec { return i.MetricSource }).
 		WithName("metricSource").
-		Include(govy.New(
+		Include(govy.New[MetricSourceSpec](
 			govy.For(func(m MetricSourceSpec) string { return m.Name }).
 				WithName("name").
 				Required().
@@ -322,7 +322,7 @@ var indicatorValidation = govy.New(
 		Include(metricSpecValidation),
 )
 
-var objectiveValidation = govy.New(
+var objectiveValidation = govy.New[Objective](
 	govy.For(govy.GetSelf[Objective]()).
 		Include(rawMetricObjectiveValidation),
 	govy.For(func(o Objective) ObjectiveBase { return o.ObjectiveBase }).
@@ -342,7 +342,7 @@ var objectiveValidation = govy.New(
 		Include(rawMetricsValidation),
 )
 
-var rawMetricObjectiveValidation = govy.New(
+var rawMetricObjectiveValidation = govy.New[Objective](
 	govy.ForPointer(func(o Objective) *float64 { return o.ObjectiveBase.Value }).
 		WithName("value").
 		Required(),
@@ -356,7 +356,7 @@ var rawMetricObjectiveValidation = govy.New(
 		govy.WhenDescription("rawMetric is defined"),
 	)
 
-var objectiveBaseValidation = govy.New(
+var objectiveBaseValidation = govy.New[ObjectiveBase](
 	govy.For(func(o ObjectiveBase) string { return o.Name }).
 		WithName("name").
 		OmitEmpty().
@@ -374,7 +374,7 @@ func arePointerValuesEqual[T comparable](p1, p2 *T) bool {
 	return *p1 == *p2
 }
 
-var specValidationNonComposite = govy.New(
+var specValidationNonComposite = govy.New[Spec](
 	govy.ForPointer(func(s Spec) *Indicator { return s.Indicator }).
 		WithName("indicator").
 		Required().
@@ -384,7 +384,7 @@ var specValidationNonComposite = govy.New(
 	govy.WhenDescription("none of the objectives is of composite type"),
 )
 
-var specValidationComposite = govy.New(
+var specValidationComposite = govy.New[Spec](
 	govy.ForPointer(func(s Spec) *Indicator { return s.Indicator }).
 		WithName("indicator").
 		Rules(
@@ -403,12 +403,12 @@ var specValidationComposite = govy.New(
 		WithName("objectives").
 		Rules(rules.SliceLength[[]Objective](1, 1).
 			WithMessage("this SLO contains a composite objective. No more objectives can be added to it")).
-		IncludeForEach(govy.New(
+		IncludeForEach(govy.New[Objective](
 			govy.For(func(o Objective) ObjectiveBase { return o.ObjectiveBase }).
 				Include(objectiveBaseValidation),
 			govy.ForPointer(func(o Objective) *CompositeSpec { return o.Composite }).
 				WithName("composite").
-				Include(govy.New(
+				Include(govy.New[CompositeSpec](
 					govy.For(func(c CompositeSpec) string { return c.MaxDelay }).
 						WithName("maxDelay").
 						Required(),


### PR DESCRIPTION
## Motivation

There is a major bug in GoLand IDE which causes it to report errors where generic types should be inferred:

https://youtrack.jetbrains.com/issue/GO-15340/False-positive-Cannot-infer-Type-and-Type-does-not-implement
https://youtrack.jetbrains.com/issue/GO-16975/Type-inference-reports-Type-does-not-implement-WorkerT

## Summary

Everywhere where generic argument is inferred and GoLand was reporting error, I added an explicit generic argument to avoid inference.