### PR TITLE
feat: Add e2e tests for Reports, extend reports validation

### DIFF
--- a/manifest/v1alpha/report/validation_system_health_review.go
+++ b/manifest/v1alpha/report/validation_system_health_review.go
@@ -63,11 +63,11 @@ var reportThresholdsValidation = govy.New[Thresholds](
 	govy.ForPointer(func(s Thresholds) *float64 { return s.RedLessThanOrEqual }).
 		WithName("redLte").
 		Required().
-		Rules(rules.GTE(0.0), rules.LTE(1.0)),
+		Rules(rules.LTE(1.0)),
 	govy.ForPointer(func(s Thresholds) *float64 { return s.GreenGreaterThan }).
 		WithName("greenGt").
 		Required().
-		Rules(rules.GTE(0.0), rules.LTE(1.0)),
+		Rules(rules.LTE(1.0)),
 )
 
 var redLteValidation = govy.NewRule(func(v Thresholds) error {

--- a/manifest/v1alpha/report/validation_system_health_review.go
+++ b/manifest/v1alpha/report/validation_system_health_review.go
@@ -92,9 +92,11 @@ var snapshotValidation = govy.New[SnapshotTimeFrame](
 var snapshotTimeFramePastPointValidation = govy.New[SnapshotTimeFrame](
 	govy.ForPointer(func(s SnapshotTimeFrame) *time.Time { return s.DateTime }).
 		WithName("dateTime").
-		Required(),
+		Required().
+		Rules(dateTimeInThePast),
 	govy.Transform(func(s SnapshotTimeFrame) string { return s.Rrule }, rrule.StrToRRule).
-		WithName("rrule"),
+		WithName("rrule").
+		Rules(atLeastDailyFreq),
 ).When(
 	func(s SnapshotTimeFrame) bool { return s.Point == SnapshotPointPast },
 	govy.WhenDescription("past snapshot point"),
@@ -119,3 +121,22 @@ var snapshotTimeFrameLatestPointValidation = govy.New[SnapshotTimeFrame](
 	func(s SnapshotTimeFrame) bool { return s.Point == SnapshotPointLatest },
 	govy.WhenDescription("latest snapshot point"),
 )
+
+var atLeastDailyFreq = govy.NewRule(func(rule *rrule.RRule) error {
+	if rule == nil {
+		return nil
+	}
+	if rule.Options.Freq == rrule.HOURLY ||
+		rule.Options.Freq == rrule.MINUTELY ||
+		rule.Options.Freq == rrule.SECONDLY {
+		return errors.New("rrule must have at least daily frequency")
+	}
+	return nil
+})
+
+var dateTimeInThePast = govy.NewRule(func(dateTime time.Time) error {
+	if time.Now().Before(dateTime) {
+		return errors.New("dateTime must be in the past")
+	}
+	return nil
+})

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -669,12 +669,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 			},
 		},
 		"fails with invalid thresholds": {
-			ExpectedErrorsCount: 2,
+			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
-				{
-					Prop: "spec.systemHealthReview.thresholds.redLte",
-					Code: rules.ErrorCodeGreaterThanOrEqualTo,
-				},
 				{
 					Prop: "spec.systemHealthReview.thresholds.greenGt",
 					Code: rules.ErrorCodeLessThanOrEqualTo,

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/teambition/rrule-go"
 
 	"github.com/nobl9/govy/pkg/rules"
 
@@ -513,8 +514,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 					{DisplayName: "Column 1", Labels: properLabel},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -536,8 +537,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 				RowGroupBy: RowGroupByProject,
 				Columns:    []ColumnSpec{},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -591,8 +592,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 					{DisplayName: "Column 31", Labels: properLabel},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -616,8 +617,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -641,8 +642,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 					{Labels: properLabel},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -691,8 +692,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 					{DisplayName: "Column 1", Labels: properLabel},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(-0.1),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(1.1),
+					RedLessThanOrEqual: ptr(-0.1),
+					GreenGreaterThan:   ptr(1.1),
 				},
 			},
 		},
@@ -719,8 +720,8 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 				{DisplayName: "Column 1", Labels: properLabel},
 			},
 			Thresholds: Thresholds{
-				RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.2),
-				GreenGreaterThan:   func(f float64) *float64 { return &f }(0.1),
+				RedLessThanOrEqual: ptr(0.2),
+				GreenGreaterThan:   ptr(0.1),
 			},
 		}
 		err := validate(report)
@@ -752,8 +753,8 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -775,8 +776,8 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -800,8 +801,8 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -830,8 +831,8 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -860,8 +861,35 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
+				},
+			},
+		},
+		"fails with rrule frequency less than DAILY in past point snapshot": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.rrule",
+					Message: "rrule must have at least daily frequency",
+				},
+			},
+			Config: SystemHealthReviewConfig{
+				TimeFrame: SystemHealthReviewTimeFrame{
+					Snapshot: SnapshotTimeFrame{
+						Point:    SnapshotPointPast,
+						DateTime: ptr(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
+						Rrule:    "FREQ=SECONDLY;INTERVAL=2",
+					},
+					TimeZone: "Europe/Warsaw",
+				},
+				RowGroupBy: RowGroupByProject,
+				Columns: []ColumnSpec{
+					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
+				},
+				Thresholds: Thresholds{
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -891,8 +919,34 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.0),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.2),
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
+				},
+			},
+		},
+		"fails with dateTime in the future in past point snapshot": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.dateTime",
+					Message: "dateTime must be in the past",
+				},
+			},
+			Config: SystemHealthReviewConfig{
+				TimeFrame: SystemHealthReviewTimeFrame{
+					Snapshot: SnapshotTimeFrame{
+						Point:    SnapshotPointPast,
+						DateTime: ptr(time.Now().Add(time.Hour)),
+					},
+					TimeZone: "Europe/Warsaw",
+				},
+				RowGroupBy: RowGroupByProject,
+				Columns: []ColumnSpec{
+					{DisplayName: "Column 1", Labels: map[LabelKey][]LabelValue{"key1": {"value1"}}},
+				},
+				Thresholds: Thresholds{
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
 				},
 			},
 		},
@@ -902,6 +956,71 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			report.Spec.SystemHealthReview = &test.Config
 			err := validate(report)
 			testutils.AssertContainsErrors(t, report, err, test.ExpectedErrorsCount, test.ExpectedErrors...)
+		})
+	}
+}
+
+func TestAtLeastDailyFreq(t *testing.T) {
+	atLeastDailyFreqErr := "rrule must have at least daily frequency"
+	tests := []struct {
+		name          string
+		rule          string
+		expectedError string
+	}{
+		{
+			name:          "nil rule returns no error",
+			rule:          "",
+			expectedError: "",
+		},
+		{
+			name:          "hourly frequency returns error",
+			rule:          "FREQ=HOURLY;INTERVAL=1",
+			expectedError: atLeastDailyFreqErr,
+		},
+		{
+			name:          "minutely frequency returns error",
+			rule:          "FREQ=MINUTELY;INTERVAL=1",
+			expectedError: atLeastDailyFreqErr,
+		},
+		{
+			name:          "secondly frequency returns error",
+			rule:          "FREQ=SECONDLY;INTERVAL=1",
+			expectedError: atLeastDailyFreqErr,
+		},
+		{
+			name:          "daily frequency returns no error",
+			rule:          "FREQ=DAILY;INTERVAL=59",
+			expectedError: "",
+		},
+		{
+			name:          "weekly frequency returns no error",
+			rule:          "FREQ=WEEKLY;INTERVAL=59",
+			expectedError: "",
+		},
+		{
+			name:          "monthly frequency returns no error",
+			rule:          "FREQ=MONTHLY;INTERVAL=59",
+			expectedError: "",
+		},
+		{
+			name:          "yearly frequency returns no error",
+			rule:          "FREQ=YEARLY;INTERVAL=59",
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rule *rrule.RRule
+			if tt.rule != "" {
+				rule, _ = rrule.StrToRRule(tt.rule)
+			}
+			err := atLeastDailyFreq.Validate(rule)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedError)
+			}
 		})
 	}
 }
@@ -974,8 +1093,8 @@ func validReport() Report {
 					},
 				},
 				Thresholds: Thresholds{
-					RedLessThanOrEqual: func(f float64) *float64 { return &f }(0.8),
-					GreenGreaterThan:   func(f float64) *float64 { return &f }(0.95),
+					RedLessThanOrEqual: ptr(0.8),
+					GreenGreaterThan:   ptr(0.95),
 					ShowNoData:         true,
 				},
 			},

--- a/tests/v1alpha_report_test.go
+++ b/tests/v1alpha_report_test.go
@@ -1,0 +1,433 @@
+//go:build e2e_test
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nobl9/nobl9-go/manifest"
+	v1alphaReport "github.com/nobl9/nobl9-go/manifest/v1alpha/report"
+	objectsV1 "github.com/nobl9/nobl9-go/sdk/endpoints/objects/v1"
+)
+
+func Test_Objects_V1_V1alpha_Report(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	project := generateV1alphaProject(t)
+	timeZone := "Europe/Warsaw"
+	reports := []v1alphaReport.Report{
+		v1alphaReport.New(
+			v1alphaReport.Metadata{
+				Name:        generateName(),
+				DisplayName: "Report 1",
+			},
+			v1alphaReport.Spec{
+				Shared: true,
+				Filters: &v1alphaReport.Filters{
+					Projects: []string{project.GetName()},
+				},
+				SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+					TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+						Snapshot: v1alphaReport.SnapshotTimeFrame{
+							Point: v1alphaReport.SnapshotPointLatest,
+						},
+						TimeZone: timeZone,
+					},
+					RowGroupBy: v1alphaReport.RowGroupByProject,
+					Columns: []v1alphaReport.ColumnSpec{
+						{
+							DisplayName: "Column 1",
+							Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+								"team": {"grey"},
+							},
+						},
+					},
+					Thresholds: v1alphaReport.Thresholds{
+						RedLessThanOrEqual: ptr(0.8),
+						GreenGreaterThan:   ptr(0.95),
+						ShowNoData:         false,
+					},
+				},
+			}),
+		v1alphaReport.New(
+			v1alphaReport.Metadata{
+				Name:        generateName(),
+				DisplayName: "Report 2",
+			},
+			v1alphaReport.Spec{
+				Shared: true,
+				Filters: &v1alphaReport.Filters{
+					Projects: []string{project.GetName()},
+				},
+				SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+					TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+						Snapshot: v1alphaReport.SnapshotTimeFrame{
+							Point:    v1alphaReport.SnapshotPointPast,
+							DateTime: ptr(time.Date(2024, 7, 1, 10, 0, 0, 0, time.UTC)),
+						},
+						TimeZone: timeZone,
+					},
+					RowGroupBy: v1alphaReport.RowGroupByProject,
+					Columns: []v1alphaReport.ColumnSpec{
+						{
+							DisplayName: "Column 1",
+							Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+								"team": {"grey"},
+							},
+						},
+					},
+					Thresholds: v1alphaReport.Thresholds{
+						RedLessThanOrEqual: ptr(0.8),
+						GreenGreaterThan:   ptr(0.95),
+						ShowNoData:         false,
+					},
+				},
+			}),
+		v1alphaReport.New(
+			v1alphaReport.Metadata{
+				Name:        generateName(),
+				DisplayName: "Report 3",
+			},
+			v1alphaReport.Spec{
+				Shared: true,
+				Filters: &v1alphaReport.Filters{
+					Projects: []string{project.GetName()},
+				},
+				SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+					TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+						Snapshot: v1alphaReport.SnapshotTimeFrame{
+							Point:    v1alphaReport.SnapshotPointPast,
+							DateTime: ptr(time.Date(2024, 7, 1, 10, 0, 0, 0, time.UTC)),
+							Rrule:    "FREQ=WEEKLY",
+						},
+						TimeZone: timeZone,
+					},
+					RowGroupBy: v1alphaReport.RowGroupByProject,
+					Columns: []v1alphaReport.ColumnSpec{
+						{
+							DisplayName: "Column 1",
+							Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+								"team": {"grey"},
+							},
+						},
+					},
+					Thresholds: v1alphaReport.Thresholds{
+						RedLessThanOrEqual: ptr(0.8),
+						GreenGreaterThan:   ptr(0.95),
+						ShowNoData:         false,
+					},
+				},
+			}),
+		v1alphaReport.New(
+			v1alphaReport.Metadata{
+				Name:        generateName(),
+				DisplayName: "Report 3",
+			},
+			v1alphaReport.Spec{
+				Shared: true,
+				Filters: &v1alphaReport.Filters{
+					Projects: []string{project.GetName()},
+				},
+				SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+					TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+						Snapshot: v1alphaReport.SnapshotTimeFrame{
+							Point:    v1alphaReport.SnapshotPointPast,
+							DateTime: ptr(time.Date(2024, 7, 1, 10, 0, 0, 0, time.UTC)),
+							Rrule:    "FREQ=WEEKLY",
+						},
+						TimeZone: timeZone,
+					},
+					RowGroupBy: v1alphaReport.RowGroupByProject,
+					Columns: []v1alphaReport.ColumnSpec{
+						{
+							DisplayName: "Column 1",
+							Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+								"team": {"grey"},
+							},
+						},
+					},
+					Thresholds: v1alphaReport.Thresholds{
+						RedLessThanOrEqual: ptr(0.8),
+						GreenGreaterThan:   ptr(0.95),
+						ShowNoData:         false,
+					},
+				},
+			}),
+		v1alphaReport.New(
+			v1alphaReport.Metadata{
+				Name:        generateName(),
+				DisplayName: "Report 4",
+			},
+			v1alphaReport.Spec{
+				Shared: true,
+				Filters: &v1alphaReport.Filters{
+					Projects: []string{project.GetName()},
+				},
+				SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+					TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+						Snapshot: v1alphaReport.SnapshotTimeFrame{
+							Point: v1alphaReport.SnapshotPointLatest,
+						},
+						TimeZone: timeZone,
+					},
+					RowGroupBy: v1alphaReport.RowGroupByService,
+					Columns: []v1alphaReport.ColumnSpec{
+						{
+							DisplayName: "Column 1",
+							Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+								"team": {"grey"},
+							},
+						},
+					},
+					Thresholds: v1alphaReport.Thresholds{
+						RedLessThanOrEqual: ptr(0.8),
+						GreenGreaterThan:   ptr(0.95),
+						ShowNoData:         false,
+					},
+				},
+			}),
+	}
+
+	allObjects := make([]manifest.Object, 0)
+	allObjects = append(
+		allObjects,
+		project,
+	)
+	for _, report := range reports {
+		allObjects = append(allObjects, report)
+	}
+
+	v1Apply(t, allObjects)
+	t.Cleanup(func() { v1Delete(t, allObjects) })
+
+	filterTests := map[string]struct {
+		request    objectsV1.GetReportsRequest
+		expected   []v1alphaReport.Report
+		returnsAll bool
+	}{
+		"all": {
+			request:    objectsV1.GetReportsRequest{},
+			expected:   reports,
+			returnsAll: true,
+		},
+		"filter by name": {
+			request: objectsV1.GetReportsRequest{
+				Names: []string{reports[0].Metadata.Name},
+			},
+			expected: []v1alphaReport.Report{reports[0]},
+		},
+	}
+	for name, test := range filterTests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := client.Objects().V1().GetReports(ctx, test.request)
+			require.NoError(t, err)
+			if !test.returnsAll {
+				require.Equal(t, len(actual), len(test.expected))
+			}
+			assertSubset(t, actual, test.expected, assertV1alphaReportsAreEqual)
+		})
+	}
+}
+
+func assertV1alphaReportsAreEqual(t *testing.T, expected, actual v1alphaReport.Report) {
+	t.Helper()
+	assert.Regexp(t, timeRFC3339Regexp, actual.Spec.CreatedAt)
+	assert.Regexp(t, timeRFC3339Regexp, actual.Spec.UpdatedAt)
+	assert.Regexp(t, userIDRegexp, *actual.Spec.CreatedBy)
+	actual.Spec.CreatedAt = ""
+	actual.Spec.UpdatedAt = ""
+	actual.Spec.CreatedBy = nil
+	assert.Equal(t, expected, actual)
+}
+
+func Test_Objects_V1_V1alpha_ReportErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	timeZone := "Europe/Warsaw"
+
+	project := generateV1alphaProject(t)
+	allObjects := make([]manifest.Object, 0)
+	allObjects = append(
+		allObjects,
+		project,
+	)
+	v1Apply(t, allObjects)
+	t.Cleanup(func() { v1Delete(t, allObjects) })
+
+	testCases := map[string]struct {
+		report v1alphaReport.Report
+		error  string
+	}{
+		"project doesn't exist": {
+			report: v1alphaReport.New(
+				v1alphaReport.Metadata{
+					Name:        generateName(),
+					DisplayName: "Report 1",
+				},
+				v1alphaReport.Spec{
+					Shared: true,
+					Filters: &v1alphaReport.Filters{
+						Projects: []string{"non-existing-project"},
+					},
+					SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+						TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+							Snapshot: v1alphaReport.SnapshotTimeFrame{
+								Point: v1alphaReport.SnapshotPointLatest,
+							},
+							TimeZone: timeZone,
+						},
+						RowGroupBy: v1alphaReport.RowGroupByProject,
+						Columns: []v1alphaReport.ColumnSpec{
+							{
+								DisplayName: "Column 1",
+								Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+									"team": {"grey"},
+								},
+							},
+						},
+						Thresholds: v1alphaReport.Thresholds{
+							RedLessThanOrEqual: ptr(0.8),
+							GreenGreaterThan:   ptr(0.95),
+							ShowNoData:         false,
+						},
+					},
+				}),
+			error: "failed, because object Project non-existing-project referenced in its spec does not exist",
+		},
+		"service doesn't exist": {
+			report: v1alphaReport.New(
+				v1alphaReport.Metadata{
+					Name:        generateName(),
+					DisplayName: "Report 1",
+				},
+				v1alphaReport.Spec{
+					Shared: true,
+					Filters: &v1alphaReport.Filters{
+						Services: v1alphaReport.Services{
+							v1alphaReport.Service{
+								Name:    "non-existing-service",
+								Project: "non-existing-project",
+							},
+						},
+					},
+					SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+						TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+							Snapshot: v1alphaReport.SnapshotTimeFrame{
+								Point: v1alphaReport.SnapshotPointLatest,
+							},
+							TimeZone: timeZone,
+						},
+						RowGroupBy: v1alphaReport.RowGroupByProject,
+						Columns: []v1alphaReport.ColumnSpec{
+							{
+								DisplayName: "Column 1",
+								Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+									"team": {"grey"},
+								},
+							},
+						},
+						Thresholds: v1alphaReport.Thresholds{
+							RedLessThanOrEqual: ptr(0.8),
+							GreenGreaterThan:   ptr(0.95),
+							ShowNoData:         false,
+						},
+					},
+				}),
+			error: "failed, because object Service non-existing-service referenced in its spec does not exist",
+		},
+		"slo doesn't exist": {
+			report: v1alphaReport.New(
+				v1alphaReport.Metadata{
+					Name:        generateName(),
+					DisplayName: "Report 1",
+				},
+				v1alphaReport.Spec{
+					Shared: true,
+					Filters: &v1alphaReport.Filters{
+						SLOs: v1alphaReport.SLOs{
+							v1alphaReport.SLO{
+								Name:    "non-existing-slo",
+								Project: "non-existing-project",
+							},
+						},
+					},
+					SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+						TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+							Snapshot: v1alphaReport.SnapshotTimeFrame{
+								Point: v1alphaReport.SnapshotPointLatest,
+							},
+							TimeZone: timeZone,
+						},
+						RowGroupBy: v1alphaReport.RowGroupByProject,
+						Columns: []v1alphaReport.ColumnSpec{
+							{
+								DisplayName: "Column 1",
+								Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+									"team": {"grey"},
+								},
+							},
+						},
+						Thresholds: v1alphaReport.Thresholds{
+							RedLessThanOrEqual: ptr(0.8),
+							GreenGreaterThan:   ptr(0.95),
+							ShowNoData:         false,
+						},
+					},
+				}),
+			error: "failed, because object SLO non-existing-slo referenced in its spec does not exist",
+		},
+		"label doesn't exist": {
+			report: v1alphaReport.New(
+				v1alphaReport.Metadata{
+					Name:        generateName(),
+					DisplayName: "Report 1",
+				},
+				v1alphaReport.Spec{
+					Shared: true,
+					Filters: &v1alphaReport.Filters{
+						Projects: []string{project.GetName()},
+						Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+							"non-existing-label": {"non-existing-value"},
+						},
+					},
+					SystemHealthReview: &v1alphaReport.SystemHealthReviewConfig{
+						TimeFrame: v1alphaReport.SystemHealthReviewTimeFrame{
+							Snapshot: v1alphaReport.SnapshotTimeFrame{
+								Point: v1alphaReport.SnapshotPointLatest,
+							},
+							TimeZone: timeZone,
+						},
+						RowGroupBy: v1alphaReport.RowGroupByProject,
+						Columns: []v1alphaReport.ColumnSpec{
+							{
+								DisplayName: "Column 1",
+								Labels: map[v1alphaReport.LabelKey][]v1alphaReport.LabelValue{
+									"team": {"grey"},
+								},
+							},
+						},
+						Thresholds: v1alphaReport.Thresholds{
+							RedLessThanOrEqual: ptr(0.8),
+							GreenGreaterThan:   ptr(0.95),
+							ShowNoData:         false,
+						},
+					},
+				}),
+			error: "Validation failed: Label `non-existing-label` not found",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := client.Objects().V1().Apply(ctx, []manifest.Object{test.report})
+			assert.ErrorContains(t, err, test.error)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- PC-13726 Add e2e tests for Reports
- PC-13759 Snapshot Rrule frequency lower than DAILY forbidden
- PC-13823 Snapshot date time in the future forbidden
- PC-14191 Thresholds lower than 0 allowed
