### PR TITLE
fix: PC-14236 SHR thresholds validation for less than 1

### DIFF
--- a/manifest/v1alpha/report/validation_system_health_review.go
+++ b/manifest/v1alpha/report/validation_system_health_review.go
@@ -63,11 +63,11 @@ var reportThresholdsValidation = govy.New[Thresholds](
 	govy.ForPointer(func(s Thresholds) *float64 { return s.RedLessThanOrEqual }).
 		WithName("redLte").
 		Required().
-		Rules(rules.LTE(1.0)),
+		Rules(rules.LT(1.0)),
 	govy.ForPointer(func(s Thresholds) *float64 { return s.GreenGreaterThan }).
 		WithName("greenGt").
 		Required().
-		Rules(rules.LTE(1.0)),
+		Rules(rules.LT(1.0)),
 )
 
 var redLteValidation = govy.NewRule(func(v Thresholds) error {

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -673,7 +673,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 			ExpectedErrors: []testutils.ExpectedError{
 				{
 					Prop: "spec.systemHealthReview.thresholds.greenGt",
-					Code: rules.ErrorCodeLessThanOrEqualTo,
+					Code: rules.ErrorCodeLessThan,
 				},
 			},
 			Config: SystemHealthReviewConfig{


### PR DESCRIPTION
## Motivation

Flaky validation for System Health Review thresholds. They are not supposed to go up to 1.

## Summary

Changed validation from LTE to LT and adjusted tests.

## Release Notes

System Health Review spec now allows for green and red thresholds to be less than 1, not less than or equal to 1.