### PR TITLE
fix: PC-13893 Revert changes from #529

### DIFF
--- a/internal/manifest/v1alpha/examples/slo_composite.go
+++ b/internal/manifest/v1alpha/examples/slo_composite.go
@@ -74,6 +74,7 @@ func (s sloCompositeExample) SLO() v1alphaSLO.SLO {
 				{
 					ObjectiveBase: v1alphaSLO.ObjectiveBase{
 						DisplayName: "User experience",
+						Value:       ptr(0.0),
 						Name:        "user-experience",
 					},
 					BudgetTarget:    ptr(0.95),

--- a/manifest/v1alpha/slo/examples/composite-slo.yaml
+++ b/manifest/v1alpha/slo/examples/composite-slo.yaml
@@ -29,6 +29,7 @@
     budgetingMethod: Occurrences
     objectives:
     - displayName: User experience
+      value: 0.0
       name: user-experience
       target: 0.95
       composite:
@@ -95,6 +96,7 @@
     budgetingMethod: Occurrences
     objectives:
     - displayName: User experience
+      value: 0.0
       name: user-experience
       target: 0.95
       composite:
@@ -158,6 +160,7 @@
     budgetingMethod: Timeslices
     objectives:
     - displayName: User experience
+      value: 0.0
       name: user-experience
       target: 0.95
       timeSliceTarget: 0.9
@@ -225,6 +228,7 @@
     budgetingMethod: Timeslices
     objectives:
     - displayName: User experience
+      value: 0.0
       name: user-experience
       target: 0.95
       timeSliceTarget: 0.9

--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -68,7 +68,7 @@ type Attachment struct {
 // ObjectiveBase base structure representing an objective.
 type ObjectiveBase struct {
 	DisplayName string   `json:"displayName"`
-	Value       *float64 `json:"value,omitempty"`
+	Value       *float64 `json:"value"`
 	Name        string   `json:"name"`
 	NameChanged bool     `json:"-"`
 }

--- a/sdk/test_data/reader/expected/composite_v2_slo.tpl.json
+++ b/sdk/test_data/reader/expected/composite_v2_slo.tpl.json
@@ -12,6 +12,7 @@
     "objectives": [
       {
         "displayName": "composite-obj",
+        "value": null,
         "name": "composite-obj",
         "target": 0.99,
         "composite": {


### PR DESCRIPTION
… Composite SLOs (#529)"

This reverts commit 0350ad44fc725bb176a114e1613f927ef400e04c.

## Motivation

Changes we introduced in #529 and https://github.com/nobl9/n9/pull/15176 are breaking API contract for older versions of SDK in a way that blocks the release. We must prepare better backward compatibility before introducing these changes.

## Summary

This reverses changes introduced in #529.

## Related changes

#529
https://github.com/nobl9/n9/pull/15176

## Testing

## Release Notes

Changes from #529 are reverted.
