### PR TITLE
test: PC-13893 Make E2E tests forward compatible

### DIFF
--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -293,5 +293,8 @@ func assertV1alphaSLOsAreEqual(t *testing.T, expected, actual v1alphaSLO.SLO) {
 	actual.Spec.CreatedBy = ""
 	actual.Status = nil
 	actual.Spec.TimeWindows[0].Period = nil
+	if actual.Spec.Objectives[0].Value == nil {
+		actual.Spec.Objectives[0].Value = ptr(0.0)
+	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Motivation

`value` field of `objective` for Composite SLO is being [deprecated](https://github.com/nobl9/nobl9-go/pull/549). Before the update in SDK can be made, a N9 platform first needs to be [updated](https://github.com/nobl9/n9/pull/15406). To be able to release changes in the platform, e2e tests of the latest released SDK need to pass against it.

## Summary

E2E test assertions will pass with and without [changes](https://github.com/nobl9/n9/pull/15406) in N9 platform.

## Related changes

https://github.com/nobl9/nobl9-go/pull/551
https://github.com/nobl9/nobl9-go/pull/549
https://github.com/nobl9/n9/pull/15406
https://github.com/nobl9/terraform-provider-nobl9/pull/312
https://github.com/nobl9/terraform-provider-nobl9/pull/295

## Testing

Run `make test/e2e` on both environments containing and not containing https://github.com/nobl9/n9/pull/15406.
