### PR TITLE
fix: PC-14338 System Health Review report name should not be longer than 63 chars

### DIFF
--- a/internal/manifest/v1alpha/validation.go
+++ b/internal/manifest/v1alpha/validation.go
@@ -51,7 +51,7 @@ func FieldRuleMetadataDisplayName[S any](getter func(S) string) govy.PropertyRul
 	return govy.For(getter).
 		WithName("metadata.displayName").
 		OmitEmpty().
-		Rules(rules.StringLength(0, 63))
+		Rules(rules.StringMaxLength(63))
 }
 
 func FieldRuleMetadataProject[S any](getter func(S) string) govy.PropertyRules[string, S] {

--- a/internal/manifest/v1alpha/validation.go
+++ b/internal/manifest/v1alpha/validation.go
@@ -51,7 +51,7 @@ func FieldRuleMetadataDisplayName[S any](getter func(S) string) govy.PropertyRul
 	return govy.For(getter).
 		WithName("metadata.displayName").
 		OmitEmpty().
-		Rules(rules.StringMaxLength(63))
+		Rules(rules.StringLength(0, 63))
 }
 
 func FieldRuleMetadataProject[S any](getter func(S) string) govy.PropertyRules[string, S] {

--- a/manifest/v1alpha/report/validation_system_health_review.go
+++ b/manifest/v1alpha/report/validation_system_health_review.go
@@ -33,7 +33,8 @@ var systemHealthReviewValidation = govy.New[SystemHealthReviewConfig](
 var columnValidation = govy.New[ColumnSpec](
 	govy.For(func(s ColumnSpec) string { return s.DisplayName }).
 		WithName("displayName").
-		Required(),
+		Required().
+		Rules(rules.StringLength(0, 63)),
 	govy.ForMap(func(c ColumnSpec) map[LabelKey][]LabelValue { return c.Labels }).
 		WithName("labels").
 		Rules(rules.MapMinLength[map[LabelKey][]LabelValue](1)),

--- a/manifest/v1alpha/report/validation_system_health_review.go
+++ b/manifest/v1alpha/report/validation_system_health_review.go
@@ -34,7 +34,7 @@ var columnValidation = govy.New[ColumnSpec](
 	govy.For(func(s ColumnSpec) string { return s.DisplayName }).
 		WithName("displayName").
 		Required().
-		Rules(rules.StringLength(0, 63)),
+		Rules(rules.StringMaxLength(63)),
 	govy.ForMap(func(c ColumnSpec) map[LabelKey][]LabelValue { return c.Labels }).
 		WithName("labels").
 		Rules(rules.MapMinLength[map[LabelKey][]LabelValue](1)),

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -652,7 +652,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 			ExpectedErrors: []testutils.ExpectedError{
 				{
 					Prop: "spec.systemHealthReview.columns[0].displayName",
-					Code: rules.ErrorCodeStringLength,
+					Code: rules.ErrorCodeStringMaxLength,
 				},
 			},
 			Config: SystemHealthReviewConfig{

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -647,6 +647,34 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 				},
 			},
 		},
+		"fails with too long displayName": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop: "spec.systemHealthReview.columns[0].displayName",
+					Code: rules.ErrorCodeStringLength,
+				},
+			},
+			Config: SystemHealthReviewConfig{
+				TimeFrame: SystemHealthReviewTimeFrame{
+					Snapshot: SnapshotTimeFrame{
+						Point: SnapshotPointLatest,
+					},
+					TimeZone: "Europe/Warsaw",
+				},
+				RowGroupBy: RowGroupByProject,
+				Columns: []ColumnSpec{
+					{
+						DisplayName: "it is a very long display name, longer than sixty three characters",
+						Labels:      properLabel,
+					},
+				},
+				Thresholds: Thresholds{
+					RedLessThanOrEqual: ptr(0.0),
+					GreenGreaterThan:   ptr(0.2),
+				},
+			},
+		},
 		"fails with empty thresholds": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{


### PR DESCRIPTION
## Summary

Add validation for System Health Review column display name for consistency with other names in the system.

## Release Notes

Adjust System Health Review report validation.