### PR TITLE
feat: extend SLO status replay with source and user [PC-14276]

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -166,8 +166,10 @@ type Status struct {
 }
 
 type ReplayStatus struct {
-	Status    string `json:"status"`
-	Unit      string `json:"unit"`
-	Value     int    `json:"value"`
-	StartTime string `json:"startTime,omitempty"`
+	Source      string `json:"source"`
+	Status      string `json:"status"`
+	TriggeredBy string `json:"triggeredBy"`
+	Unit        string `json:"unit"`
+	Value       int    `json:"value"`
+	StartTime   string `json:"startTime"`
 }

--- a/sdk/models/replay.go
+++ b/sdk/models/replay.go
@@ -40,10 +40,12 @@ type ReplayWithStatus struct {
 }
 
 type ReplayStatus struct {
-	Status    string `json:"status"`
-	Unit      string `json:"unit"`
-	Value     int    `json:"value"`
-	StartTime string `json:"startTime,omitempty"`
+	Source      string `json:"source"`
+	Status      string `json:"status"`
+	TriggeredBy string `json:"triggeredBy"`
+	Unit        string `json:"unit"`
+	Value       int    `json:"value"`
+	StartTime   string `json:"startTime"`
 }
 
 // Variants of ReplayStatus.Status.


### PR DESCRIPTION
## Motivation

Extend ReplayStatus with source and the user who triggered the Replay. 

## Summary

- added fields to `v1alpha.ReplayStatus`:
  -  `Source` - `user` | `composite_slo` | `error_budget_adjustment`
  -  `TriggeredBy` - user okta ID

## Release Notes

Extend `v1alpha.ReplayStatus` with source and the user who triggered the Replay. 
