### PR TITLE
feat: add Duration() to v1alpha.HistoricalRetrievalDuration

### DIFF
--- a/manifest/v1alpha/data_sources.go
+++ b/manifest/v1alpha/data_sources.go
@@ -392,14 +392,14 @@ func HistoricalRetrievalDurationUnitFromString(unit string) (HistoricalRetrieval
 }
 
 func (d HistoricalRetrievalDuration) BiggerThan(b HistoricalRetrievalDuration) bool {
-	return d.duration() > b.duration()
+	return d.Duration() > b.Duration()
 }
 
 func (d HistoricalRetrievalDuration) IsZero() bool {
 	return d.Value == nil || *d.Value == 0
 }
 
-func (d HistoricalRetrievalDuration) duration() time.Duration {
+func (d HistoricalRetrievalDuration) Duration() time.Duration {
 	if d.Value == nil {
 		return time.Duration(0)
 	}

--- a/manifest/v1alpha/data_sources_test.go
+++ b/manifest/v1alpha/data_sources_test.go
@@ -53,7 +53,7 @@ func TestHistoricalRetrievalDuration_durationInMinutes(t *testing.T) {
 				Value: &tt.fields.Value,
 				Unit:  tt.fields.Unit,
 			}
-			assert.Equal(t, tt.want, d.duration())
+			assert.Equal(t, tt.want, d.Duration())
 		})
 	}
 }
@@ -64,7 +64,7 @@ func TestHistoricalRetrievalDuration_durationInMinutes_unsupportedUnit(t *testin
 		Value: ptr(12),
 		Unit:  testUnit,
 	}
-	assert.Equal(t, time.Duration(0), duration.duration())
+	assert.Equal(t, time.Duration(0), duration.Duration())
 }
 
 func TestGetDataRetrievalMaxDuration(t *testing.T) {


### PR DESCRIPTION
## Motivation

Expose `Duration` method on `v1alpha.HistoricalRetrievalDuration` struct.

## Release Notes

