### PR TITLE
feat: Add APIErrors struct

### DIFF
--- a/sdk/http_errors.go
+++ b/sdk/http_errors.go
@@ -16,6 +16,7 @@ import (
 
 // HTTPError represents an HTTP error response from the API.
 type HTTPError struct {
+	APIErrors
 	// StatusCode is the HTTP status code of the response.
 	// Example: 200, 400, 404, 500.
 	StatusCode int `json:"statusCode"`
@@ -29,6 +30,10 @@ type HTTPError struct {
 	//
 	// [Nobl9 support]: https://nobl9.com/contact/support
 	TraceID string `json:"traceId,omitempty"`
+}
+
+// APIErrors is an object returned directly by the API which conveys specific API error(s) details.
+type APIErrors struct {
 	// Errors is a list of errors returned by the API.
 	// At least one error is always guaranteed to be set.
 	// At the very minimum it will contain just the [APIError.Title].
@@ -90,7 +95,9 @@ func processHTTPResponse(resp *http.Response) error {
 	httpErr := HTTPError{
 		StatusCode: resp.StatusCode,
 		TraceID:    resp.Header.Get(HeaderTraceID),
-		Errors:     apiErrors,
+		APIErrors: APIErrors{
+			Errors: apiErrors,
+		},
 	}
 	if resp.Request != nil {
 		if resp.Request.URL != nil {

--- a/sdk/http_errors_test.go
+++ b/sdk/http_errors_test.go
@@ -44,7 +44,9 @@ func TestHTTPError(t *testing.T) {
 				Method:     "GET",
 				URL:        "https://app.nobl9.com/api/slos",
 				TraceID:    "123",
-				Errors:     []APIError{{Title: "error!"}},
+				APIErrors: APIErrors{
+					Errors: []APIError{{Title: "error!"}},
+				},
 			}
 			require.Equal(t, expectedError, err)
 			expectedMessage := fmt.Sprintf("error! (code: %d, endpoint: GET https://app.nobl9.com/api/slos, traceId: 123)", code)
@@ -73,7 +75,9 @@ func TestHTTPError(t *testing.T) {
 			StatusCode: 400,
 			Method:     "GET",
 			URL:        "https://app.nobl9.com/api/slos",
-			Errors:     []APIError{{Title: "error!"}},
+			APIErrors: APIErrors{
+				Errors: []APIError{{Title: "error!"}},
+			},
 		}
 		require.Equal(t, expectedError, err)
 		expectedMessage := "Bad Request: error! (code: 400, endpoint: GET https://app.nobl9.com/api/slos)"
@@ -98,7 +102,9 @@ func TestHTTPError(t *testing.T) {
 			StatusCode: 555,
 			Method:     "GET",
 			URL:        "https://app.nobl9.com/api/slos",
-			Errors:     []APIError{{Title: "error!"}},
+			APIErrors: APIErrors{
+				Errors: []APIError{{Title: "error!"}},
+			},
 		}
 		require.Equal(t, expectedError, err)
 		expectedMessage := "error! (code: 555, endpoint: GET https://app.nobl9.com/api/slos)"
@@ -113,7 +119,9 @@ func TestHTTPError(t *testing.T) {
 		require.Error(t, err)
 		expectedError := &HTTPError{
 			StatusCode: 555,
-			Errors:     []APIError{{Title: "error!"}},
+			APIErrors: APIErrors{
+				Errors: []APIError{{Title: "error!"}},
+			},
 		}
 		require.Equal(t, expectedError, err)
 		expectedMessage := "error! (code: 555)"
@@ -198,7 +206,7 @@ func TestHTTPError(t *testing.T) {
 			Method:     "GET",
 			URL:        "https://app.nobl9.com/api/slos",
 			TraceID:    "123",
-			Errors:     apiErrors,
+			APIErrors:  APIErrors{Errors: apiErrors},
 		}
 		assert.Equal(t, expectedError, err)
 		expectedMessage := `Bad Request (code: 400, endpoint: GET https://app.nobl9.com/api/slos, traceId: 123)
@@ -232,7 +240,7 @@ func TestHTTPError(t *testing.T) {
 		require.Error(t, err)
 		expectedError := &HTTPError{
 			StatusCode: 400,
-			Errors:     apiErrors,
+			APIErrors:  APIErrors{Errors: apiErrors},
 		}
 		assert.Equal(t, expectedError, err)
 	})

--- a/sdk/http_errors_test.go
+++ b/sdk/http_errors_test.go
@@ -157,27 +157,29 @@ func TestHTTPError(t *testing.T) {
 	})
 	t.Run("read JSON API errors", func(t *testing.T) {
 		t.Parallel()
-		apiErrors := []APIError{
-			{
-				Title: "error1",
-			},
-			{
-				Title: "error2",
-				Code:  "some_code",
-			},
-			{
-				Title: "error3",
-				Code:  "other_code",
-				Source: &APIErrorSource{
-					PropertyName: "$.data",
+		apiErrors := APIErrors{
+			Errors: []APIError{
+				{
+					Title: "error1",
 				},
-			},
-			{
-				Title: "error4",
-				Code:  "yet_another_code",
-				Source: &APIErrorSource{
-					PropertyName:  "$.data[1].name",
-					PropertyValue: "value",
+				{
+					Title: "error2",
+					Code:  "some_code",
+				},
+				{
+					Title: "error3",
+					Code:  "other_code",
+					Source: &APIErrorSource{
+						PropertyName: "$.data",
+					},
+				},
+				{
+					Title: "error4",
+					Code:  "yet_another_code",
+					Source: &APIErrorSource{
+						PropertyName:  "$.data[1].name",
+						PropertyValue: "value",
+					},
 				},
 			},
 		}
@@ -206,7 +208,7 @@ func TestHTTPError(t *testing.T) {
 			Method:     "GET",
 			URL:        "https://app.nobl9.com/api/slos",
 			TraceID:    "123",
-			APIErrors:  APIErrors{Errors: apiErrors},
+			APIErrors:  apiErrors,
 		}
 		assert.Equal(t, expectedError, err)
 		expectedMessage := `Bad Request (code: 400, endpoint: GET https://app.nobl9.com/api/slos, traceId: 123)
@@ -228,7 +230,7 @@ func TestHTTPError(t *testing.T) {
 	})
 	t.Run("content type with charset", func(t *testing.T) {
 		t.Parallel()
-		apiErrors := []APIError{{Title: "error"}}
+		apiErrors := APIErrors{Errors: []APIError{{Title: "error"}}}
 		data, err := json.Marshal(apiErrors)
 		require.NoError(t, err)
 
@@ -240,7 +242,7 @@ func TestHTTPError(t *testing.T) {
 		require.Error(t, err)
 		expectedError := &HTTPError{
 			StatusCode: 400,
-			APIErrors:  APIErrors{Errors: apiErrors},
+			APIErrors:  apiErrors,
 		}
 		assert.Equal(t, expectedError, err)
 	})


### PR DESCRIPTION
## Summary

Corrected `APIError` decoding, it is now decoded as part of `APIErrors`. The `APIErrors` is in turn embedded into `HTTPError`.

## Release Notes

Added `APIErrors` struct which aggregates individual `APIError` and is embedded into `HTTPError`.
