### PR TITLE
chore: Add Error() to APIErrors (string representation of APIErrors)

### DIFF
--- a/sdk/http_error.tmpl
+++ b/sdk/http_error.tmpl
@@ -1,8 +1,26 @@
-{{- if and (len .Errors | eq 1) (not (index .Errors 0).Source) }}
-    {{- if .CodeText }}{{ .CodeText }}: {{ end -}}{{ (index .Errors 0).Title }} (code: {{ .Code }}{{- if .URL }}, endpoint: {{ .Method }} {{ .URL }}{{- end }}{{- if .TraceID }}, traceId: {{ .TraceID }}{{- end }})
+{{/* The trailing '-' is intentional as we'll let the template calling "api_error" decide how to indent it */}}
+{{- define "api_error" -}}
+- {{ .Title }}{{- if .Source }} (source: '{{ .Source.PropertyName }}'{{- if .Source.PropertyValue }}, value: '{{ .Source.PropertyValue }}'{{- end }}){{- end }}
+{{- end }}
+
+{{/* It's hard to remove the leading newline otherwise, that's why the if statement has a trailing '-' */}}
+{{- define "api_errors" }}
+{{- range $i, $err := .Errors }}
+{{- if eq $i 0 -}}
+{{ template "api_error" $err }}
 {{- else }}
-    {{- if .CodeText }}{{ .CodeText }} {{ end -}} (code: {{ .Code }}{{- if .URL }}, endpoint: {{ .Method }} {{ .URL }}{{- end }}{{- if .TraceID }}, traceId: {{ .TraceID }}{{- end }})
-    {{- range .Errors }}
-  - {{ .Title }}{{- if .Source }} (source: '{{ .Source.PropertyName }}'{{- if .Source.PropertyValue }}, value: '{{ .Source.PropertyValue }}'{{- end }}){{- end }}
-    {{- end }}
+{{ template "api_error" $err }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "http_error" }}
+{{- if and (len .Errors | eq 1) (not (index .Errors 0).Source) }}
+  {{- if .CodeText }}{{ .CodeText }}: {{ end -}}{{ (index .Errors 0).Title }} (code: {{ .Code }}{{- if .URL }}, endpoint: {{ .Method }} {{ .URL }}{{- end }}{{- if .TraceID }}, traceId: {{ .TraceID }}{{- end }})
+{{- else }}
+  {{- if .CodeText }}{{ .CodeText }} {{ end -}} (code: {{ .Code }}{{- if .URL }}, endpoint: {{ .Method }} {{ .URL }}{{- end }}{{- if .TraceID }}, traceId: {{ .TraceID }}{{- end }})
+  {{- range .Errors }}
+  {{ template "api_error" . }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/sdk/http_errors.go
+++ b/sdk/http_errors.go
@@ -52,6 +52,18 @@ type APIError struct {
 	Source *APIErrorSource `json:"source,omitempty"`
 }
 
+// Error returns a string representation of the error.
+func (r APIErrors) Error() string {
+	buf := bytes.Buffer{}
+	buf.Grow(len(httpErrorTemplateData))
+	if err := httpErrorTemplate.Execute(&buf, httpErrorTemplateFields{
+		Errors: r.Errors,
+	}); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to execute %T template: %v\n", r, err)
+	}
+	return buf.String()
+}
+
 // APIErrorSource provides additional context for the source of the [APIError].
 type APIErrorSource struct {
 	// PropertyName is an optional name of the property that caused the error.

--- a/sdk/http_errors.go
+++ b/sdk/http_errors.go
@@ -56,7 +56,7 @@ type APIError struct {
 func (r APIErrors) Error() string {
 	buf := bytes.Buffer{}
 	buf.Grow(len(httpErrorTemplateData))
-	if err := httpErrorTemplate.Execute(&buf, httpErrorTemplateFields{
+	if err := httpErrorTemplate.ExecuteTemplate(&buf, "api_errors", httpErrorTemplateFields{
 		Errors: r.Errors,
 	}); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "failed to execute %T template: %v\n", r, err)
@@ -82,7 +82,7 @@ func (r HTTPError) IsRetryable() bool {
 func (r HTTPError) Error() string {
 	buf := bytes.Buffer{}
 	buf.Grow(len(httpErrorTemplateData))
-	if err := httpErrorTemplate.Execute(&buf, httpErrorTemplateFields{
+	if err := httpErrorTemplate.ExecuteTemplate(&buf, "http_error", httpErrorTemplateFields{
 		Errors:   r.Errors,
 		Method:   r.Method,
 		URL:      r.URL,

--- a/sdk/http_errors_test.go
+++ b/sdk/http_errors_test.go
@@ -248,6 +248,40 @@ func TestHTTPError(t *testing.T) {
 	})
 }
 
+func TestAPIErrors_Error(t *testing.T) {
+	apiErrors := APIErrors{
+		Errors: []APIError{
+			{
+				Title: "error1",
+			},
+			{
+				Title: "error2",
+				Code:  "some_code",
+			},
+			{
+				Title: "error3",
+				Code:  "other_code",
+				Source: &APIErrorSource{
+					PropertyName: "$.data",
+				},
+			},
+			{
+				Title: "error4",
+				Code:  "yet_another_code",
+				Source: &APIErrorSource{
+					PropertyName:  "$.data[1].name",
+					PropertyValue: "value",
+				},
+			},
+		},
+	}
+	expectedMessage := `- error1
+- error2
+- error3 (source: '$.data')
+- error4 (source: '$.data[1].name', value: 'value')`
+	assert.EqualError(t, apiErrors, expectedMessage)
+}
+
 type mockReadCloser struct{ err error }
 
 func (mo *mockReadCloser) Read(p []byte) (n int, err error) { return 0, mo.err }


### PR DESCRIPTION
## Summary

Add method for a string representation of APIErrors.

## Related changes

https://github.com/nobl9/nobl9-go/pull/579
