### PR TITLE
feat: allow constant keyword in ServiceNow Obs (Lightstep) UQL queries [PC-14700]

### DIFF
--- a/manifest/v1alpha/slo/metrics_lightstep.go
+++ b/manifest/v1alpha/slo/metrics_lightstep.go
@@ -104,7 +104,7 @@ var lightstepLatencyDataTypeValidation = govy.New[LightstepMetric](
 		govy.WhenDescription("typeOfData is '%s'", LightstepLatencyDataType),
 	)
 
-var lightstepUQLRegexp = regexp.MustCompile(`((constant|spans_sample|assemble)\s+[a-z\d.])`)
+var lightstepUQLRegexp = regexp.MustCompile(`((spans_sample|assemble)\s+[a-z\d.])`)
 
 var lightstepMetricDataTypeValidation = govy.New[LightstepMetric](
 	govy.ForPointer(func(l LightstepMetric) *string { return l.StreamID }).

--- a/manifest/v1alpha/slo/metrics_lightstep_test.go
+++ b/manifest/v1alpha/slo/metrics_lightstep_test.go
@@ -320,7 +320,6 @@ spans count | rate | group_by [], sum
 			"spans_sample joined UQL": `(
 spans_sample count | delta | filter error == true && service == android | group_by [], sum;
 spans_sample count | delta | filter service == android | group_by [], sum) | join left/right * 100`,
-			"constant UQL":     "constant .5",
 			"spans_sample UQL": "spans_sample span filter",
 			"assemble UQL":     "assemble span",
 		} {


### PR DESCRIPTION
## Motivation

Allow the `constant` keyword in the UQL queries as there are valid use cases for constant values. 

## Summary

Change validation to allow `constant` in UQL. 


## Testing

- The `constant` in the UQL query should not throw validation error.

## Release Notes

Allow the `constant` keyword in the ServiceNow Observability UQL queries.
