### PR TITLE
feat: Add Replay support to Elasticsearch

### DIFF
--- a/manifest/v1alpha/agent/examples/elasticsearch.yaml
+++ b/manifest/v1alpha/agent/examples/elasticsearch.yaml
@@ -9,6 +9,19 @@ spec:
   releaseChannel: stable
   elasticsearch:
     url: http://elasticsearch-main.elasticsearch:9200
+  historicalDataRetrieval:
+    maxDuration:
+      value: 30
+      unit: Day
+    defaultDuration:
+      value: 15
+      unit: Day
+    triggeredBySloCreation:
+      value: 15
+      unit: Day
+    triggeredBySloEdit:
+      value: 15
+      unit: Day
   queryDelay:
     value: 2
     unit: Minute

--- a/manifest/v1alpha/data_sources.go
+++ b/manifest/v1alpha/data_sources.go
@@ -434,6 +434,7 @@ var agentDataRetrievalMaxDuration = map[DataSourceType]HistoricalRetrievalDurati
 	GoogleCloudMonitoring: {Value: ptr(30), Unit: HRDDay},
 	AzurePrometheus:       {Value: ptr(30), Unit: HRDDay},
 	LogicMonitor:          {Value: ptr(30), Unit: HRDDay},
+	Elasticsearch:         {Value: ptr(30), Unit: HRDDay},
 }
 
 var directDataRetrievalMaxDuration = map[DataSourceType]HistoricalRetrievalDuration{


### PR DESCRIPTION
## Motivation

Adding Replay support to Elasticsearch integration.

## Summary

Adds data retrieval definitions for Elasticsearch using Agent Connection.
Since Elasticsearch cannot be conffigured via Direct connection, those definitions for direct were not changed.

## Release Notes

Adds Replay support to Elasticsearch data source (Agent connection only).