### PR TITLE
fix: CountMetrics validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/nobl9/go-yaml v1.0.1
-	github.com/nobl9/govy v0.6.0
+	github.com/nobl9/govy v0.9.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	github.com/teambition/rrule-go v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/nobl9/go-yaml v1.0.1 h1:Aj1kSaYdRQTKlvS6ihvXzQJhCpoHhtf9nfA95zqWH4Q=
 github.com/nobl9/go-yaml v1.0.1/go.mod h1:t7vCO8ctYdBweZxU5lUgxzAw31+ZcqJYeqRtrv+5RHI=
-github.com/nobl9/govy v0.6.0 h1:8L3H4zeqA7sUCBg1tuyyudLpOi7vHz6WYTRfu/VyKeg=
-github.com/nobl9/govy v0.6.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
+github.com/nobl9/govy v0.9.1 h1:ht+mgbDB40QEZEmHpzG2xqey+PbfzCwgj3+vdJuHAVQ=
+github.com/nobl9/govy v0.9.1/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/manifest/v1alpha/slo/metrics_splunk.go
+++ b/manifest/v1alpha/slo/metrics_splunk.go
@@ -3,34 +3,14 @@ package slo
 import (
 	"regexp"
 
-	"github.com/pkg/errors"
-
 	"github.com/nobl9/govy/pkg/govy"
 	"github.com/nobl9/govy/pkg/rules"
-
-	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 )
 
 // SplunkMetric represents metric from Splunk
 type SplunkMetric struct {
 	Query *string `json:"query"`
 }
-
-var splunkCountMetricsLevelValidation = govy.New[CountMetricsSpec](
-	govy.For(govy.GetSelf[CountMetricsSpec]()).
-		Rules(
-			govy.NewRule(func(c CountMetricsSpec) error {
-				if c.GoodTotalMetric != nil {
-					if c.GoodMetric != nil || c.BadMetric != nil || c.TotalMetric != nil {
-						return errors.New("goodTotal is mutually exclusive with good, bad, and total")
-					}
-				}
-				return nil
-			}).WithErrorCode(rules.ErrorCodeMutuallyExclusive)),
-).When(
-	whenCountMetricsIs(v1alpha.Splunk),
-	govy.WhenDescription("countMetrics is splunk"),
-)
 
 var splunkValidation = govy.New[SplunkMetric](
 	govy.ForPointer(func(s SplunkMetric) *string { return s.Query }).

--- a/manifest/v1alpha/slo/metrics_splunk_test.go
+++ b/manifest/v1alpha/slo/metrics_splunk_test.go
@@ -121,18 +121,6 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
-	t.Run("goodTotal mixed with bad", func(t *testing.T) {
-		slo := validSingleQueryGoodOverTotalCountMetricSLO(v1alpha.Splunk)
-		slo.Spec.Objectives[0].CountMetrics.BadMetric = validMetricSpec(v1alpha.Splunk)
-		err := validate(slo)
-		testutils.AssertContainsErrors(t, slo, err, 2, testutils.ExpectedError{
-			Prop: "spec.objectives[0].countMetrics.bad",
-			Code: joinErrorCodes(errCodeBadOverTotalDisabled, rules.ErrorCodeOneOf),
-		}, testutils.ExpectedError{
-			Prop: "spec.objectives[0].countMetrics",
-			Code: rules.ErrorCodeMutuallyExclusive,
-		})
-	})
 	t.Run("invalid query", func(t *testing.T) {
 		tests := map[string]struct {
 			Query        string

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -19,6 +19,7 @@ const (
 	errCodeSingleQueryGoodOverTotalDisabled = "single_query_good_over_total_disabled"
 	errCodeExactlyOneMetricSpecType         = "exactly_one_metric_spec_type"
 	errCodeEitherBadOrGoodCountMetric       = "either_bad_or_good_count_metric"
+	errCodeCountMetricsMustBePair           = "count_metrics_must_be_pair"
 	errCodeTimeSliceTarget                  = "time_slice_target"
 )
 
@@ -47,6 +48,17 @@ var specMetricsValidation = govy.New[Spec](
 						govy.NewRuleError(
 							"cannot have both 'bad' and 'good' metrics defined",
 							errCodeEitherBadOrGoodCountMetric,
+						)).PrependParentPropertyName(govy.SliceElementName("objectives", i))
+				}
+				noGooNoBad := objective.CountMetrics.GoodMetric == nil && objective.CountMetrics.BadMetric == nil
+				if objective.CountMetrics.GoodTotalMetric == nil &&
+					(objective.CountMetrics.TotalMetric == nil || noGooNoBad) {
+					return govy.NewPropertyError(
+						"countMetrics",
+						nil,
+						govy.NewRuleError(
+							"count metrics reqires a pair of ('good' and 'total') or ('bad' and 'total') metrics",
+							errCodeCountMetricsMustBePair,
 						)).PrependParentPropertyName(govy.SliceElementName("objectives", i))
 				}
 			}

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -57,7 +57,7 @@ var specMetricsValidation = govy.New[Spec](
 						"countMetrics",
 						nil,
 						govy.NewRuleError(
-							"count metrics reqires a pair of ('good' and 'total') or ('bad' and 'total') metrics",
+							"count metrics requires a pair of ('good' and 'total') or ('bad' and 'total') metrics",
 							errCodeCountMetricsMustBePair,
 						)).PrependParentPropertyName(govy.SliceElementName("objectives", i))
 				}

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -123,7 +123,7 @@ var sloValidationComposite = govy.New[SLO](
 var specValidation = govy.New[Spec](
 	govy.For(govy.GetSelf[Spec]()).
 		Cascade(govy.CascadeModeStop).
-		Include(specMetricsValidation), // TODO push new validators there?
+		Include(specMetricsValidation),
 	govy.For(govy.GetSelf[Spec]()).
 		WithName("composite").
 		When(func(s Spec) bool { return s.Composite != nil }).

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -167,19 +167,7 @@ var specValidation = govy.New[Spec](
 		RulesForEach(timeWindowValidationRule()),
 	govy.ForSlice(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
-		RulesForEach(
-			govy.For(func(o Objective) *CountMetricsSpec { return o.CountMetrics }).
-				WithName("countMetrics").
-				Cascade(govy.CascadeModeStop).
-				When(func(o Objective) bool { return o.CountMetrics != nil }).
-				Rules(
-					rules.MutuallyExclusive(true, map[string]func(*CountMetricsSpec) any{
-						"goodAndTotal":    func(c *CountMetricsSpec) any { return c.GoodMetric != nil && c.TotalMetric != nil },
-						"badAndTotal":     func(c *CountMetricsSpec) any { return c.BadMetric != nil && c.TotalMetric != nil },
-						"goodTotalMetric": func(c *CountMetricsSpec) any { return c.GoodTotalMetric },
-					}).WithMessage("provide a pair of ('good' and 'total') or ('bad' and 'total') or a goodTotalMetric single query"),
-				),
-		),
+		RulesForEach(),
 	govy.ForSlice(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
 		Cascade(govy.CascadeModeStop).

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -1220,6 +1220,42 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 			Code: errCodeEitherBadOrGoodCountMetric,
 		})
 	})
+	t.Run("only bad provided", func(t *testing.T) {
+		slo := validCountMetricSLO(v1alpha.AzureMonitor)
+		slo.Spec.Objectives[0].CountMetrics = &CountMetricsSpec{
+			Incremental: ptr(true),
+			BadMetric:   validMetricSpec(v1alpha.AzureMonitor),
+		}
+		err := validate(slo)
+		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
+			Prop: "spec.objectives[0].countMetrics",
+			Code: errCodeCountMetricsMustBePair,
+		})
+	})
+	t.Run("only good provided", func(t *testing.T) {
+		slo := validCountMetricSLO(v1alpha.AzureMonitor)
+		slo.Spec.Objectives[0].CountMetrics = &CountMetricsSpec{
+			Incremental: ptr(true),
+			GoodMetric:  validMetricSpec(v1alpha.AzureMonitor),
+		}
+		err := validate(slo)
+		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
+			Prop: "spec.objectives[0].countMetrics",
+			Code: errCodeCountMetricsMustBePair,
+		})
+	})
+	t.Run("only total provided", func(t *testing.T) {
+		slo := validCountMetricSLO(v1alpha.AzureMonitor)
+		slo.Spec.Objectives[0].CountMetrics = &CountMetricsSpec{
+			Incremental: ptr(true),
+			TotalMetric: validMetricSpec(v1alpha.AzureMonitor),
+		}
+		err := validate(slo)
+		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
+			Prop: "spec.objectives[0].countMetrics",
+			Code: errCodeCountMetricsMustBePair,
+		})
+	})
 	t.Run("exactly one metric spec type", func(t *testing.T) {
 		for name, metrics := range map[string][]*CountMetricsSpec{
 			"single objective - total": {

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -1369,7 +1369,6 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
 					Prop: "spec",
 					Code: errCodeExactlyOneMetricSpecType,
-					// Code: rules.ErrorCodeMutuallyExclusive,
 				})
 			})
 		}


### PR DESCRIPTION
## Motivation

The CountMetrics validation was missing a case when only one metric was provided. It was failing with an error on our backend but cusomers didn't get a good error - it already tripped one of our customers.

## Testing

- Extended unit tests
- Can be tested by applying an SLO with for example only total.

## Release Notes

Fixed `v1alpha.SLO.Spec.Objectives[*].CountMetrics` validation for cases when only one metric was provided.
