### PR TITLE
feat: Extend list of alert method template variables with `alert_id`

### DIFF
--- a/manifest/v1alpha/alertmethod/notification_template.go
+++ b/manifest/v1alpha/alertmethod/notification_template.go
@@ -20,6 +20,7 @@ const (
 	TplVarObjectiveName                   TemplateVariable = "objective_name"
 	TplVarTimestamp                       TemplateVariable = "timestamp"
 	TplVarIsoTimestamp                    TemplateVariable = "iso_timestamp"
+	TplVarAlertID                         TemplateVariable = "alert_id"
 	TplVarBackwardCompatibleObjectiveName TemplateVariable = "experience_name"
 )
 
@@ -40,5 +41,6 @@ var notificationTemplateAllowedFields = map[TemplateVariable]struct{}{
 	TplVarObjectiveName:                   {},
 	TplVarTimestamp:                       {},
 	TplVarIsoTimestamp:                    {},
+	TplVarAlertID:                         {},
 	TplVarBackwardCompatibleObjectiveName: {},
 }


### PR DESCRIPTION
## Release Notes

Added possibility to use in Webhook alert method new template variable `alert_id` which indicates a unique alert  generated by Nobl9.

## Motivation

Possibility to pass `alert_id` via Webhook alert method.

## Summary

Added `alert_id` as possible template variable.