### PR TITLE
chore: Remove Status from kind AlertMethod

### DIFF
--- a/manifest/v1alpha/alertmethod/alert_method.go
+++ b/manifest/v1alpha/alertmethod/alert_method.go
@@ -26,7 +26,6 @@ type AlertMethod struct {
 	Kind       manifest.Kind    `json:"kind"`
 	Metadata   Metadata         `json:"metadata"`
 	Spec       Spec             `json:"spec"`
-	Status     *Status          `json:"status,omitempty"`
 
 	Organization   string `json:"organization,omitempty"`
 	ManifestSource string `json:"manifestSrc,omitempty"`
@@ -37,12 +36,6 @@ type Metadata struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName,omitempty"`
 	Project     string `json:"project,omitempty"`
-}
-
-// Status represents content of Status optional for AlertMethod Object
-type Status struct {
-	LastTestDate       string `json:"lastTestDate,omitempty"`
-	NextTestPossibleAt string `json:"nextTestPossibleAt,omitempty"`
 }
 
 // Spec holds detailed information specific to AlertMethod.


### PR DESCRIPTION
## Motivation

Those fields are not needed anymore. Alert method `Status` section contains only timestamps when alert method was tested on UI, which is handled in another way. Those fields are not used anymore.

## Summary

Removed `Status` section from kind `AlertMethod`.

## Breaking Changes

Removed `Status` section from kind `AlertMethod`.