### PR TITLE
chore: Remove deprecated Body and Subject from Email alert method

### DIFF
--- a/internal/manifest/v1alpha/examples/alert_method.go
+++ b/internal/manifest/v1alpha/examples/alert_method.go
@@ -96,17 +96,9 @@ func (a alertMethodExample) generateVariant(am v1alphaAlertMethod.AlertMethod) v
 	switch a.typ {
 	case v1alpha.AlertMethodTypeEmail:
 		am.Spec.Email = &v1alphaAlertMethod.EmailAlertMethod{
-			To:      []string{"alerts-tests@nobl9.com"},
-			Cc:      []string{"alerts-tests+cc@nobl9.com"},
-			Bcc:     []string{"alerts-tests+bcc@nobl9.com"},
-			Subject: "Your SLO $slo_name needs attention!",
-			Body: `$alert_policy_name has triggered with the following conditions:
-  $alert_policy_conditions[]
-  Time: $timestamp
-  Severity: $severity
-  Project: $project_name
-  Service: $service_name
-  Organization: $organization`,
+			To:  []string{"alerts-tests@nobl9.com"},
+			Cc:  []string{"alerts-tests+cc@nobl9.com"},
+			Bcc: []string{"alerts-tests+bcc@nobl9.com"},
 		}
 	case v1alpha.AlertMethodTypeDiscord:
 		am.Spec.Discord = &v1alphaAlertMethod.DiscordAlertMethod{

--- a/manifest/v1alpha/alertmethod/alert_method.go
+++ b/manifest/v1alpha/alertmethod/alert_method.go
@@ -148,8 +148,4 @@ type EmailAlertMethod struct {
 	To  []string `json:"to,omitempty"`
 	Cc  []string `json:"cc,omitempty"`
 	Bcc []string `json:"bcc,omitempty"`
-	// Deprecated: Defining custom template for email alert method is now deprecated. This property is ignored.
-	Subject string `json:"subject,omitempty"`
-	// Deprecated: Defining custom template for email alert method is now deprecated. This property is ignored.
-	Body string `json:"body,omitempty"`
 }

--- a/manifest/v1alpha/alertmethod/examples/email.yaml
+++ b/manifest/v1alpha/alertmethod/examples/email.yaml
@@ -13,5 +13,3 @@ spec:
     - alerts-tests+cc@nobl9.com
     bcc:
     - alerts-tests+bcc@nobl9.com
-    subject: Your SLO $slo_name needs attention!
-    body: "$alert_policy_name has triggered with the following conditions:\n  $alert_policy_conditions[]\n  Time: $timestamp\n  Severity: $severity\n  Project: $project_name\n  Service: $service_name\n  Organization: $organization"


### PR DESCRIPTION
## Motivation

Fields are no longer used since July 2024. Those fields are not used anywhere in the application since then.

## Summary

Removed deprecated fields Subject and Body from Email alert method. Those fields are not used in application since July 2024 (see https://github.com/nobl9/nobl9-go/releases/tag/v0.18.0)

## Related changes

- https://github.com/nobl9/nobl9-go/releases/tag/v0.18.0

## Breaking Changes

Removed deprecated fields Subject and Body from Email alert method. 
