### PR TITLE
fix: Use beta elasticsearch in tests

### DIFF
--- a/internal/manifest/v1alpha/examples/agent.go
+++ b/internal/manifest/v1alpha/examples/agent.go
@@ -43,6 +43,8 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.GCM,
 	// In order to use AWS cross-account o11y.
 	v1alpha.CloudWatch,
+	// Support for Replay only in beta.
+	v1alpha.Elasticsearch,
 }
 
 func (a agentExample) Generate() v1alphaAgent.Agent {

--- a/manifest/v1alpha/agent/examples/elasticsearch.yaml
+++ b/manifest/v1alpha/agent/examples/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
   project: default
 spec:
   description: Example Elasticsearch Agent
-  releaseChannel: stable
+  releaseChannel: beta
   elasticsearch:
     url: http://elasticsearch-main.elasticsearch:9200
   historicalDataRetrieval:


### PR DESCRIPTION
## Motivation

Replay support has been added to Elasticsearch only on BETA channels. This configuration implies the use of Historical Retrieval defaults and max durations, which are only available on BETA.

## Summary

Use Beta Elasticsearch in e2e tests.

## Testing

Run `Test_Objects_V1_V1alpha_Agent` on any environment

## Before

![image](https://github.com/user-attachments/assets/b8a36305-8445-4c1a-8c58-1ac7ef1f5cc4)

## After

![image](https://github.com/user-attachments/assets/cfa99c88-ce89-4060-82ef-221a326083ab)