### PR TITLE
feat: PC-14959 Extend kind SLO with QueryValidationStatus

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -97,6 +97,7 @@ words:
   - httpurls
   - ifacemaker
   - instana
+  - invalidjson
   - iowait
   - jsonyaml
   - jwks
@@ -107,6 +108,7 @@ words:
   - logql
   - mapstructure
   - memstats
+  - Metricname
   - mktemp
   - mockgen
   - mprofile

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -41,6 +41,7 @@ words:
   - DTSTART
   - DzpxcSRh
   - MAXRTT
+  - Metricname
   - TIMEMAX
   - aggs
   - alertmethod
@@ -108,7 +109,6 @@ words:
   - logql
   - mapstructure
   - memstats
-  - Metricname
   - mktemp
   - mockgen
   - mprofile

--- a/manifest/v1alpha/slo/metrics.go
+++ b/manifest/v1alpha/slo/metrics.go
@@ -365,7 +365,6 @@ func (m *MetricSpec) Query() interface{} {
 	}
 }
 
-// TODO: use this in ts.go
 func (m *MetricSpec) FormatQuery(query json.RawMessage) *string {
 	switch m.DataSourceType() {
 	case v1alpha.Dynatrace:

--- a/manifest/v1alpha/slo/metrics.go
+++ b/manifest/v1alpha/slo/metrics.go
@@ -7,9 +7,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 )
 
 // CountMetricsSpec represents set of two time series of good and total counts

--- a/manifest/v1alpha/slo/metrics_test.go
+++ b/manifest/v1alpha/slo/metrics_test.go
@@ -21,3 +21,41 @@ func TestQuery(t *testing.T) {
 		assert.NotEmpty(t, spec)
 	}
 }
+
+func TestFormatRawJSONMetricQueryToString(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			"empty string",
+			``,
+			``,
+		},
+		{
+			"empty string",
+			`invalidjson:"`,
+			``,
+		},
+		{
+			"cloudwatch standard",
+			`{"stat": "Average", "region": "eu-central-1", "namespace": "asd", "dimensions": [{"name": "asd", "value": "zcx"}], "metricName": "ads"}`,
+			"Dimensions: \n 1:\n  Name: asd\n  Value: zcx\nMetricname: ads\nNamespace: asd\nRegion: eu-central-1\nStat: Average\n",
+		},
+		{
+			"cloudwatch json",
+			`{"json": "[\n    {\n        \"Id\": \"e1\",\n        \"Expression\": \"m1 / m2\",\n        \"Period\": 60\n    },\n    {\n        \"Id\": \"m1\",\n        \"MetricStat\": {\n            \"Metric\": {\n                \"Namespace\": \"AWS/ApplicationELB\",\n                \"MetricName\": \"HTTPCode_Target_2XX_Count\",\n                \"Dimensions\": [\n                    {\n                        \"Name\": \"LoadBalancer\",\n                        \"Value\": \"app/main-default-appingress-350b/904311bedb964754\"\n                    }\n                ]\n            },\n            \"Period\": 60,\n            \"Stat\": \"SampleCount\"\n        },\n        \"ReturnData\": false\n    },\n    {\n        \"Id\": \"m2\",\n        \"MetricStat\": {\n            \"Metric\": {\n                \"Namespace\": \"AWS/ApplicationELB\",\n                \"MetricName\": \"RequestCount\",\n                \"Dimensions\": [\n                    {\n                        \"Name\": \"LoadBalancer\",\n                        \"Value\": \"app/main-default-appingress-350b/904311bedb964754\"\n                    }\n                ]\n            },\n            \"Period\": 60,\n            \"Stat\": \"SampleCount\"\n        },\n        \"ReturnData\": false\n    }\n]", "region": "eu-central-1"}`,
+			"Json: [\n    {\n        \"Id\": \"e1\",\n        \"Expression\": \"m1 / m2\",\n        \"Period\": 60\n    },\n    {\n        \"Id\": \"m1\",\n        \"MetricStat\": {\n            \"Metric\": {\n                \"Namespace\": \"AWS/ApplicationELB\",\n                \"MetricName\": \"HTTPCode_Target_2XX_Count\",\n                \"Dimensions\": [\n                    {\n                        \"Name\": \"LoadBalancer\",\n                        \"Value\": \"app/main-default-appingress-350b/904311bedb964754\"\n                    }\n                ]\n            },\n            \"Period\": 60,\n            \"Stat\": \"SampleCount\"\n        },\n        \"ReturnData\": false\n    },\n    {\n        \"Id\": \"m2\",\n        \"MetricStat\": {\n            \"Metric\": {\n                \"Namespace\": \"AWS/ApplicationELB\",\n                \"MetricName\": \"RequestCount\",\n                \"Dimensions\": [\n                    {\n                        \"Name\": \"LoadBalancer\",\n                        \"Value\": \"app/main-default-appingress-350b/904311bedb964754\"\n                    }\n                ]\n            },\n            \"Period\": 60,\n            \"Stat\": \"SampleCount\"\n        },\n        \"ReturnData\": false\n    }\n]\nRegion: eu-central-1\n",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatRawJSONMetricQueryToString([]byte(tc.input))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/manifest/v1alpha/slo/metrics_test.go
+++ b/manifest/v1alpha/slo/metrics_test.go
@@ -22,6 +22,7 @@ func TestQuery(t *testing.T) {
 	}
 }
 
+// nolint:lll
 func TestFormatRawJSONMetricQueryToString(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -1,6 +1,8 @@
 package slo
 
 import (
+	"time"
+
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 )
@@ -172,13 +174,43 @@ type AnomalyConfigAlertMethod struct {
 // Status holds dynamic fields returned when the Service is fetched from Nobl9 platform.
 // Status is not part of the static object definition.
 type Status struct {
-	UpdatedAt             string           `json:"updatedAt,omitempty"`
-	CompositeSLO          *ProcessStatus   `json:"compositeSlo,omitempty"`
-	ErrorBudgetAdjustment *ProcessStatus   `json:"errorBudgetAdjustment,omitempty"`
-	Replay                *ProcessStatus   `json:"replay,omitempty"`
-	TargetSLO             *TargetSloStatus `json:"targetSlo,omitempty"`
+	UpdatedAt                    string                                `json:"updatedAt,omitempty"`
+	CompositeSLO                 *ProcessStatus                        `json:"compositeSlo,omitempty"`
+	ErrorBudgetAdjustment        *ProcessStatus                        `json:"errorBudgetAdjustment,omitempty"`
+	Replay                       *ProcessStatus                        `json:"replay,omitempty"`
+	TargetSLO                    *TargetSloStatus                      `json:"targetSlo,omitempty"`
+	ObjectiveIndicatorValidation []*ObjectiveIndicatorValidationStatus `json:"objectiveIndicatorValidation,omitempty"`
 	// Deprecated: use Status.Replay instead.
 	ReplayStatus *ReplayStatus `json:"timeTravel,omitempty"`
+}
+
+type ObjectiveIndicatorValidationStatus struct {
+	ObjectiveName string `json:"objectiveName"`
+	QueryValidationStatus
+}
+
+type QueryValidationStatus struct {
+	ValidationStatus `json:"validationStatus"`
+}
+
+type ValidationStatus struct {
+	GoodMetricValidation  *ValidationDetails `json:"goodMetric,omitempty"`
+	BadMetricValidation   *ValidationDetails `json:"badMetric,omitempty"`
+	TotalMetricValidation *ValidationDetails `json:"totalMetric,omitempty"`
+	RawMetricValidation   *ValidationDetails `json:"rawMetric,omitempty"`
+}
+
+type ErrorDetails struct {
+	Message          *string    `json:"message"`
+	ValidationResult string     `json:"validationResult"`
+	LogTimestamp     *time.Time `json:"logTimestamp"`
+	HTTPStatusCode   *int       `json:"httpStatusCode"`
+	Query            string     `json:"query"`
+}
+
+type ValidationDetails struct {
+	*ErrorDetails
+	*MetricSpec
 }
 
 type ProcessStatus struct {


### PR DESCRIPTION
## Motivation

In certain cases we want to include query validation status per objective in SLO status itself.

## Summary

This PR adds `QueryValidationStatus` definition to kind SLO `status` field. For now, it's availability will be limited in the API.

## Release Notes

Add `QueryValidationStatus` definition to kind SLO `status` field.