### PR TITLE
fix: Fixed e2e tests after removing AlertMethod.Status 

### DIFF
--- a/tests/v1alpha_alertmethod_test.go
+++ b/tests/v1alpha_alertmethod_test.go
@@ -108,7 +108,6 @@ func newV1alphaAlertMethod(
 func assertV1alphaAlertMethodsAreEqual(t *testing.T, expected, actual v1alphaAlertMethod.AlertMethod) {
 	t.Helper()
 	expected = deepCopyObject(t, expected)
-	actual.Status = nil
 	typ, err := expected.Spec.GetType()
 	require.NoError(t, err)
 	switch typ {


### PR DESCRIPTION
## Motivation

Error when running e2e tests:
```
# github.com/nobl9/nobl9-go/tests [github.com/nobl9/nobl9-go/tests.test]
Error: tests/v1alpha_alertmethod_test.go:111:9: actual.Status undefined (type alertmethod.AlertMethod has no field or method Status)
```

## Summary

Updated tests to don't use `Status` field, recently removed. 

## Related changes

- https://github.com/nobl9/nobl9-go/pull/595