### PR TITLE
chore: Update golangci linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ run:
   timeout: 5m
   modules-download-mode: readonly
   skip-dirs-use-default: true
+  build-tags:
+    - e2e_test
 
 issues:
   # Enable all checks (which was as default disabled e.g. comments).

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ check: check/vet check/lint check/gosec check/spell check/trailing check/markdow
 ## Run 'go vet' on the whole project.
 check/vet:
 	$(call _print_check_step,Running go vet)
-	go vet ./...
+	go vet -tags=e2e_test ./...
 
 ## Run golangci-lint all-in-one linter with configuration defined inside .golangci.yml.
 check/lint:

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -31,18 +31,18 @@ func runTestMain(m *testing.M) int {
 	var err error
 	config, err := sdk.ReadConfig()
 	if err != nil {
-		printError("failed to read %T: %v", config, err)
+		printErrorf("failed to read %T: %v", config, err)
 		return 1
 	}
 	config.Project = defaultProject
 	config.Timeout = 1 * time.Minute
 	if client, err = sdk.NewClient(config); err != nil {
-		printError("failed to create %T: %v", client, err)
+		printErrorf("failed to create %T: %v", client, err)
 		return 1
 	}
 	org, err := client.GetOrganization(context.Background())
 	if err != nil {
-		printError("failed to get test organization: %v", err)
+		printErrorf("failed to get test organization: %v", err)
 		return 1
 	}
 	if err = client.Objects().V1().Apply(context.Background(), []manifest.Object{v1alphaProject.New(
@@ -55,7 +55,7 @@ func runTestMain(m *testing.M) int {
 			Description: objectPersistedDescription,
 		},
 	)}); err != nil {
-		printError("failed to create '%s' Project: %v", defaultProject, err)
+		printErrorf("failed to create '%s' Project: %v", defaultProject, err)
 		return 1
 	}
 	fmt.Printf("Running SDK end-to-end tests\nOrganization: %s\nAuth Server: %s\nClient ID: %s\n\n",
@@ -69,13 +69,13 @@ func runTestMain(m *testing.M) int {
 func cleanupLabels() {
 	labelID, err := getLabelIDByName(uniqueTestIdentifierLabel.Key)
 	if err != nil {
-		printError("failed to get label ID by name: %v", err)
+		printErrorf("failed to get label ID by name: %v", err)
 		return
 	}
 
 	var buf bytes.Buffer
 	if err = json.NewEncoder(&buf).Encode([]string{labelID}); err != nil {
-		printError("failed to encode cleanup labels payload: %v", err)
+		printErrorf("failed to encode cleanup labels payload: %v", err)
 		return
 	}
 	req, err := client.CreateRequest(
@@ -87,18 +87,18 @@ func cleanupLabels() {
 		&buf,
 	)
 	if err != nil {
-		printError("failed to create cleanup labels request: %v", err)
+		printErrorf("failed to create cleanup labels request: %v", err)
 		return
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		printError("failed to send cleanup labels request: %v", err)
+		printErrorf("failed to send cleanup labels request: %v", err)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		rawErr, _ := io.ReadAll(resp.Body)
-		printError("failed to cleanup labels, code: %d, body: %s", resp.StatusCode, string(rawErr))
+		printErrorf("failed to cleanup labels, code: %d, body: %s", resp.StatusCode, string(rawErr))
 		return
 	}
 }
@@ -139,6 +139,6 @@ func getLabelIDByName(name string) (string, error) {
 	return "", fmt.Errorf("label '%s' not found", name)
 }
 
-func printError(format string, a ...interface{}) {
+func printErrorf(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format+"\n", a...)
 }

--- a/tests/v1alpha_alertmethod_test.go
+++ b/tests/v1alpha_alertmethod_test.go
@@ -125,6 +125,7 @@ func assertV1alphaAlertMethodsAreEqual(t *testing.T, expected, actual v1alphaAle
 		expected.Spec.Slack.URL = "[hidden]"
 	case v1alpha.AlertMethodTypeTeams:
 		expected.Spec.Teams.URL = "[hidden]"
+	case v1alpha.AlertMethodTypeEmail:
 	case v1alpha.AlertMethodTypeWebhook:
 		expected.Spec.Webhook.URL = "[hidden]"
 		for i, header := range expected.Spec.Webhook.Headers {

--- a/tests/v1alpha_annotation_test.go
+++ b/tests/v1alpha_annotation_test.go
@@ -188,23 +188,6 @@ func Test_Objects_V1_V1alpha_Annotation(t *testing.T) {
 	}
 }
 
-func newV1alphaAnnotation(
-	t *testing.T,
-	metadata v1alphaAnnotation.Metadata,
-	variant,
-	subVariant string,
-) v1alphaAnnotation.Annotation {
-	t.Helper()
-	ap := getExample[v1alphaAnnotation.Annotation](t,
-		manifest.KindAnnotation,
-		func(example v1alphaExamples.Example) bool {
-			return example.GetVariant() == variant && example.GetSubVariant() == subVariant
-		},
-	)
-	ap.Spec.Description = objectDescription
-	return v1alphaAnnotation.New(metadata, ap.Spec)
-}
-
 func assertV1alphaAnnotationsAreEqual(t *testing.T, expected, actual v1alphaAnnotation.Annotation) {
 	t.Helper()
 	if assert.NotNil(t, actual.Status) {

--- a/tests/v1alpha_direct_test.go
+++ b/tests/v1alpha_direct_test.go
@@ -22,9 +22,7 @@ func Test_Objects_V1_V1alpha_Direct(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	project := generateV1alphaProject(t)
-	directTypes := filterSlice(v1alpha.DataSourceTypeValues(), func(typ v1alpha.DataSourceType) bool {
-		return v1alphaDirect.IsValidDirectType(typ)
-	})
+	directTypes := filterSlice(v1alpha.DataSourceTypeValues(), v1alphaDirect.IsValidDirectType)
 	allObjects := make([]manifest.Object, 0, len(directTypes)+1)
 	allObjects = append(allObjects, project)
 

--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -26,6 +26,7 @@ import (
 
 const slosPerService = 50
 
+// nolint: gocognit
 func Test_Objects_V1_V1alpha_SLO(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -264,9 +265,7 @@ func v1alphaSLODependencyAgents(t *testing.T) []manifest.Object {
 
 func v1alphaSLODependencyDirects(t *testing.T) []manifest.Object {
 	t.Helper()
-	directTypes := filterSlice(v1alpha.DataSourceTypeValues(), func(typ v1alpha.DataSourceType) bool {
-		return v1alphaDirect.IsValidDirectType(typ)
-	})
+	directTypes := filterSlice(v1alpha.DataSourceTypeValues(), v1alphaDirect.IsValidDirectType)
 	directs := make([]manifest.Object, 0, len(directTypes)+1)
 	for _, typ := range directTypes {
 		direct := newV1alphaDirect(t,


### PR DESCRIPTION
## Summary

The linter was not detecting problems with files tagged by `e2e_test`.
This PR fixes that, it also adds these tags to `go vet` invocation and addresses issues reported by the linter on these files.