### PR TITLE
fix: E2E tests are failing for composite SLOs

### DIFF
--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -234,18 +234,6 @@ func Test_Objects_V1_V1alpha_SLO(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual, err := client.Objects().V1().GetV1alphaSLOs(ctx, test.request)
-			var actualComposites []v1alphaSLO.SLO
-			for _, slo := range actual {
-				if slo.Spec.HasCompositeObjectives() {
-					actualComposites = append(actualComposites, slo)
-				}
-			}
-			var expectedComposites []v1alphaSLO.SLO
-			for _, slo := range test.expected {
-				if slo.Spec.HasCompositeObjectives() {
-					expectedComposites = append(expectedComposites, slo)
-				}
-			}
 			require.NoError(t, err)
 			if !test.returnsAll {
 				require.Equal(t, len(actual), len(test.expected),

--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -234,6 +234,18 @@ func Test_Objects_V1_V1alpha_SLO(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual, err := client.Objects().V1().GetV1alphaSLOs(ctx, test.request)
+			var actualComposites []v1alphaSLO.SLO
+			for _, slo := range actual {
+				if slo.Spec.HasCompositeObjectives() {
+					actualComposites = append(actualComposites, slo)
+				}
+			}
+			var expectedComposites []v1alphaSLO.SLO
+			for _, slo := range test.expected {
+				if slo.Spec.HasCompositeObjectives() {
+					expectedComposites = append(expectedComposites, slo)
+				}
+			}
 			require.NoError(t, err)
 			if !test.returnsAll {
 				require.Equal(t, len(actual), len(test.expected),
@@ -292,8 +304,5 @@ func assertV1alphaSLOsAreEqual(t *testing.T, expected, actual v1alphaSLO.SLO) {
 	actual.Spec.CreatedBy = ""
 	actual.Status = nil
 	actual.Spec.TimeWindows[0].Period = nil
-	if actual.Spec.Objectives[0].Value == nil {
-		actual.Spec.Objectives[0].Value = ptr(0.0)
-	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Motivation

E2E tests are failing because we recently introduced a change the behavior of API regarding a `value` field in composite SLO objective. Before that change, there was an update to make a test assertion forward-compatible. We forgot to remove that change in the test when merging an actual change.

## Summary

Updated test assertion for the new behavior.

## Related changes

https://github.com/nobl9/nobl9-go/pull/549
https://github.com/nobl9/nobl9-go/pull/551