### PR TITLE
fix: Adjust validation for missing metric spec [PC-15176]

### DIFF
--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -149,6 +149,13 @@ var singleQueryMetricSpecValidation = govy.New[MetricSpec](
 )
 
 var metricSpecValidation = govy.New[MetricSpec](
+	govy.For(govy.GetSelf[MetricSpec]()).
+		Rules(govy.NewRule(func(m MetricSpec) error {
+			if m == (MetricSpec{}) {
+				return errors.New("exactly one valid metric spec has to be provided (e.g. 'prometheus')")
+			}
+			return nil
+		})),
 	govy.ForPointer(func(m MetricSpec) *AppDynamicsMetric { return m.AppDynamics }).
 		WithName("appDynamics").
 		Include(appDynamicsValidation),
@@ -402,9 +409,6 @@ func validateExactlyOneMetricSpecType(metrics ...*MetricSpec) error {
 				return err
 			}
 		}
-	}
-	if onlyType == 0 {
-		return errors.New("must have exactly one metric spec type, none were provided")
 	}
 	return nil
 }

--- a/manifest/v1alpha/slo/validation.go
+++ b/manifest/v1alpha/slo/validation.go
@@ -167,9 +167,6 @@ var specValidation = govy.New[Spec](
 		RulesForEach(timeWindowValidationRule()),
 	govy.ForSlice(func(s Spec) []Objective { return s.Objectives }).
 		WithName("objectives").
-		RulesForEach(),
-	govy.ForSlice(func(s Spec) []Objective { return s.Objectives }).
-		WithName("objectives").
 		Cascade(govy.CascadeModeStop).
 		When(
 			func(s Spec) bool { return !s.HasCompositeObjectives() },


### PR DESCRIPTION
## Release Notes

When an SLO is defined with missing metric spec for either count or raw metrics, the SDK validation will now return an error.
