### PR TITLE
feat: PC-15221 Add EndTime to replay

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -219,6 +219,7 @@ type ProcessStatus struct {
 	Unit        string `json:"unit"`
 	Value       int    `json:"value"`
 	StartTime   string `json:"startTime"`
+	EndTime     string `json:"endTime,omitempty"`
 }
 
 // TargetSloStatus represents the status of Replay  a target SLO process.

--- a/sdk/models/replay.go
+++ b/sdk/models/replay.go
@@ -49,6 +49,7 @@ type ReplayStatus struct {
 	Unit        string `json:"unit"`
 	Value       int    `json:"value"`
 	StartTime   string `json:"startTime"`
+	EndTime     string `json:"endTime,omitempty"`
 }
 
 func ToProcessStatus(status ReplayStatus) slo.ProcessStatus {
@@ -58,6 +59,7 @@ func ToProcessStatus(status ReplayStatus) slo.ProcessStatus {
 		Unit:        status.Unit,
 		Value:       status.Value,
 		StartTime:   status.StartTime,
+		EndTime:     status.EndTime,
 	}
 }
 


### PR DESCRIPTION
## Motivation

With replay queues we now save end time to be more precise than Duration (as a replay can wait in queue before it is started).

## Summary

Changed ReplayStatus and ProcessStatus structs

## Testing

Test in sloctl and in UI.

## Release Notes

End time is now returned for new replays in progress and finished.
