### PR TITLE
chore: Improve sdk.ReadObjects docs [PC-15261]

### DIFF
--- a/sdk/reader.go
+++ b/sdk/reader.go
@@ -20,11 +20,11 @@ import (
 const APIVersionRegex = `"?apiVersion"?\s*:\s*"?n9`
 
 type (
-	// RawObjectSource may be interpreted as (with interpretation):
-	// - file path  (ObjectSourceTypeFile or ObjectSourceTypeDirectory)
-	// - glob pattern (ObjectSourceTypeGlobPattern)
-	// - URL (ObjectSourceTypeURL)
-	// - input provided via io.Reader, like os.Stdin (ObjectSourceTypeReader)
+	// RawObjectSource may be interpreted as:
+	// - file path as [ObjectSourceTypeFile] or [ObjectSourceTypeDirectory]
+	// - glob pattern as [ObjectSourceTypeGlobPattern]
+	// - URL as [ObjectSourceTypeURL]
+	// - input provided via [io.Reader], like [os.Stdin] as [ObjectSourceTypeReader]
 	RawObjectSource = string
 
 	// rawDefinition stores both the resolved source and raw resource definition.
@@ -38,8 +38,10 @@ type (
 	rawDefinitions = map[ /* raw definition hash */ string]rawDefinition
 )
 
-// ReadObjects resolves the RawObjectSource(s) it receives and calls
-// ReadObjectsFromSources on the resolved ObjectSource(s).
+// ReadObjects resolves the [RawObjectSource] it receives
+// and reads all [manifest.Object] from the resolved [ObjectSource].
+//
+// Refer to [ReadObjectsFromSources] for more details on the objects' reading logic.
 func ReadObjects(ctx context.Context, rawSources ...RawObjectSource) ([]manifest.Object, error) {
 	sources, err := ResolveObjectSources(rawSources...)
 	if err != nil {
@@ -50,16 +52,39 @@ func ReadObjects(ctx context.Context, rawSources ...RawObjectSource) ([]manifest
 
 const unknownSource = "-"
 
-// ReadObjectsFromSources reads from the provided ObjectSource(s) based on the
-// ObjectSourceType. For ObjectSourceTypeReader it will read directly from ObjectSource.Reader,
-// otherwise it reads from all the ObjectSource.Paths. It calculates a sum for
-// each definition read from ObjectSource and won't create duplicates. This
-// allows the user to combine ObjectSource(s) with possibly overlapping paths.
-// If the same exact definition is identified with multiple sources, it
-// will choose the first ObjectSource path it encounters. If the ObjectSource is of
-// type ObjectSourceTypeGlobPattern or ObjectSourceTypeDirectory and a file does not
-// contain the required APIVersionRegex, it is skipped. However in case
-// of ObjectSourceTypeFile, it will thrown ErrInvalidFile error.
+// ReadObjectsFromSources reads from the provided [ObjectSource] based on the [ObjectSourceType].
+// It calculates a sum for each definition read from [ObjectSource] and won't create duplicates.
+// This allows the user to combine [ObjectSource] with potentially overlapping paths.
+// If the same exact definition is identified with multiple sources,
+// it will pick the first [ObjectSource] path it encounters.
+//
+// If the [ObjectSource] is of type [ObjectSourceTypeGlobPattern] or [ObjectSourceTypeDirectory]
+// and a file does not contain the required [APIVersionRegex], it is skipped.
+// However, in case of [ObjectSourceTypeFile], it will throw [ErrInvalidFile] error.
+//
+// Each [ObjectSourceType] is handled according to the following logic:
+//
+//  1. [ObjectSourceTypeFile] and [ObjectSourceTypeDirectory]
+//     The path can point to a single file or a directory.
+//     If it's a directory, all files with the supported extension will be read.
+//
+//  2. [ObjectSourceTypeGlobPattern]
+//     All files matching the pattern will be read.
+//     On top of what is supported by [filepath.Match],
+//     the pattern may contain double star '**' wildcard placeholders.
+//     The double start will be interpreted as a recursive directory search.
+//
+//  3. [ObjectSourceTypeURL]
+//     The URL to fetch object definitions from.
+//     The endpoint at the provided URL should handle GET request by responding
+//     with status code 200 and JSON or YAML encoded representation of [manifest.Object].
+//
+//     Note: This URL is not designed to fetch [manifest.Object] from the Nobl9 API.
+//     It can be used, for instance, to fetch the objects from the users internal repository.
+//     In order to read [manifest.Object] from the Nobl9 API, use [Client.Objects] API.
+//
+//  4. [ObjectSourceTypeReader]
+//     The [ObjectSource.Reader] is read directly and [ObjectSource.Paths] is ignored.
 func ReadObjectsFromSources(ctx context.Context, sources ...*ObjectSource) ([]manifest.Object, error) {
 	sort.Slice(sources, func(i, j int) bool {
 		return sources[i].Raw > sources[j].Raw

--- a/sdk/source.go
+++ b/sdk/source.go
@@ -11,8 +11,8 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// ResolveObjectSources calls ResolveObjectSource on all supplied RawObjectSource(s)
-// and aggregates the resolved ObjectSource(s).
+// ResolveObjectSources calls [ResolveObjectSource] on all supplied [RawObjectSource]
+// and aggregates the resolved [ObjectSource].
 // It fails fast on the first encountered error.
 func ResolveObjectSources(rawSources ...RawObjectSource) ([]*ObjectSource, error) {
 	sources := make([]*ObjectSource, 0, len(rawSources))
@@ -26,10 +26,11 @@ func ResolveObjectSources(rawSources ...RawObjectSource) ([]*ObjectSource, error
 	return sources, nil
 }
 
-// ResolveObjectSource attempts to resolve a single RawObjectSource producing a ObjectSource
-// instance read to be passed to ReadObjectsFromSources.
-// It interprets the provided URI and associates it with a specific ObjectSourceType.
-// If you wish to create a ObjectSourceTypeReader ObjectSource you should use a separate method: NewObjectSourceReader.
+// ResolveObjectSource attempts to resolve a single [RawObjectSource] producing an [ObjectSource]
+// instance read to be passed to [ReadObjectsFromSources].
+// It interprets the provided URI and associates it with a specific [ObjectSourceType].
+// If you wish to create an [ObjectSource] of type [ObjectSourceTypeReader]
+// you should use a separate method: [NewObjectSourceReader].
 func ResolveObjectSource(rawSource RawObjectSource) (src *ObjectSource, err error) {
 	src = &ObjectSource{Raw: rawSource}
 	switch {
@@ -45,8 +46,8 @@ func ResolveObjectSource(rawSource RawObjectSource) (src *ObjectSource, err erro
 	return src, err
 }
 
-// NewObjectSourceReader creates a special instance of ObjectSource with ObjectSourceTypeReader.
-// ReadObjectsFromSources will process the ObjectSource by reading form the provided io.Reader.
+// NewObjectSourceReader creates a special instance of [ObjectSource] with [ObjectSourceTypeReader].
+// [ReadObjectsFromSources] will process the ObjectSource by reading form the provided io.Reader.
 func NewObjectSourceReader(r io.Reader, source RawObjectSource) *ObjectSource {
 	return &ObjectSource{
 		Type:   ObjectSourceTypeReader,
@@ -58,25 +59,26 @@ func NewObjectSourceReader(r io.Reader, source RawObjectSource) *ObjectSource {
 
 // ObjectSource represents a single resource definition source.
 type ObjectSource struct {
-	// Type defines how the ObjectSource should be read when passed to ReadObjectsFromSources.
+	// Type defines how the [ObjectSource] should be read when passed to [ReadObjectsFromSources].
 	Type ObjectSourceType
-	// Paths lists all resolved URIs the ObjectSource points at.
+	// Paths lists all resolved URIs the [ObjectSource] points at.
 	Paths []string
-	// Reader may be optionally provided with ObjectSourceTypeReader for ReadObjectsFromSources to read from the io.Reader.
+	// Reader may be optionally provided with [ObjectSourceTypeReader]
+	// for [ReadObjectsFromSources] to read from the [io.Reader].
 	Reader io.Reader
-	// Raw is the original, unresolved RawObjectSource, an example might be a relative path
-	// which was resolved to its absolute form.
+	// Raw is the original, unresolved [RawObjectSource].
+	// Example: a relative path which was resolved to its absolute form.
 	Raw RawObjectSource
 }
 
-// String implements fmt.Stringer interface.
+// String implements [fmt.Stringer] interface.
 func (o ObjectSource) String() string {
 	return fmt.Sprintf("{ObjectSourceType: %s, Raw: %s}", o.Type, o.Raw)
 }
 
 //go:generate ../bin/go-enum --names
 
-// ObjectSourceType represents the origin (where does it come from) of manifest.Object definition.
+// ObjectSourceType represents the source (where does it come from) of the [manifest.Object] definition.
 /* ENUM(
 File = 1
 Directory
@@ -132,12 +134,12 @@ func resolveFSPath(path string) (typ ObjectSourceType, paths []string, err error
 	return typ, paths, nil
 }
 
-// resolveGlobPattern evaluates patterns defined in filepath.Match documentation.
-// It supports double '**' wildcards directory expansion via a 3rd party library:
-// https://github.com/bmatcuk/doublestar. The library is a pure (no dependencies)
-// implementation of glob patterns with double wildcard support.
+// resolveGlobPattern evaluates patterns defined in [filepath.Match] documentation.
+// It supports double '**' wildcards directory expansion via a 3rd party library: [doublestar].
+// The library is a pure (no dependencies) implementation of glob patterns with double wildcard support.
 // Whenever a double wildcard is detected doublestar.Glob is used, otherwise we
-// use filepath.Glob to minimize the impact of potential bugs in doublestar.Glob.
+// use [filepath.Glob] to minimize the impact of potential bugs in [doublestar.Glob].
+//
 // The reasons for Go's lack of '**' support are outlined in this issue:
 // https://github.com/golang/go/issues/11862.
 func resolveGlobPattern(path string) (paths []string, err error) {
@@ -205,7 +207,7 @@ func hasURLSchema(path string) bool {
 	return strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://")
 }
 
-// hasGlobMeta reports whether path contains any of the magic characters recognized by filepath.Match.
+// hasGlobMeta reports whether path contains any of the magic characters recognized by [filepath.Match].
 // Copied from filepath/match.go.
 func hasGlobMeta(path string) bool {
 	magicChars := `*?[`


### PR DESCRIPTION
## Motivation

It can be unclear how the `sdk.ObjectSourceTypeURL` is interpreted, we should make the constraints it operates within clear.

## Summary

Improved linking of the Go docs.