### PR TITLE
chore: Correct Go code docs - fix links

### DIFF
--- a/internal/serdeutil/raw_message.go
+++ b/internal/serdeutil/raw_message.go
@@ -4,8 +4,9 @@ import "github.com/pkg/errors"
 
 // RawMessage is a raw encoded JSON or YAML value.
 // It implements:
-// - [json.Marshaler] and [json.Unmarshaler]
-// - [yaml.BytesMarshaler] and [yaml.BytesUnmarshaler]
+//   - [json.Marshaler] and [json.Unmarshaler]
+//   - [yaml.BytesMarshaler] and [yaml.BytesUnmarshaler]
+//
 // It can be used to delay JSON/YAML decoding or precompute a JSON/YAML encoding.
 type RawMessage []byte
 

--- a/internal/testutils/assert.go
+++ b/internal/testutils/assert.go
@@ -32,13 +32,13 @@ func AssertNoError(t *testing.T, object interface{}, objErr *v1alpha.ObjectError
 }
 
 // AssertContainsErrors asserts that the given object has:
-// - the expected number of errors
-// - at least one error which matches ExpectedError
+//   - the expected number of errors
+//   - at least one error which matches ExpectedError
 //
 // ExpectedError and actual error are considered equal if they point at the same property and either:
-// - rules.ErrorCode are equal
-// - error messages re equal
-// - ExpectedError.ContainsMessage is contained in actual error message
+//   - rules.ErrorCode are equal
+//   - error messages re equal
+//   - ExpectedError.ContainsMessage is contained in actual error message
 //
 // nolint: gocognit
 func AssertContainsErrors(

--- a/manifest/doc.go
+++ b/manifest/doc.go
@@ -1,2 +1,2 @@
-// Package manifest defines the basic primitives for Nobl9 objects schema.
+// Package manifest defines the basic primitives for Nobl9 objects schema and a common [Object] contract.
 package manifest

--- a/manifest/format.go
+++ b/manifest/format.go
@@ -2,6 +2,6 @@ package manifest
 
 //go:generate ../bin/go-enum  --nocase --lower --names
 
-// ObjectFormat represents the format of Object data representation.
+// ObjectFormat represents the format of [Object] data representation.
 // ENUM(JSON = 1, YAML)
 type ObjectFormat int

--- a/manifest/kind.go
+++ b/manifest/kind.go
@@ -4,8 +4,8 @@ package manifest
 
 import "strings"
 
-// Kind represents all the object kinds available in the API to perform operations on.
-/* ENUM(
+// Kind represents all the [Object] kinds available in the API to perform operations on.
+/*ENUM(
 SLO = 1
 Service
 Agent
@@ -24,24 +24,24 @@ Report
 )*/
 type Kind int
 
-// ToLower converts the Kind to a lower case string.
+// ToLower converts the [Kind] to a lower case string.
 func (k Kind) ToLower() string {
 	return strings.ToLower(k.String())
 }
 
-// Equals returns true if the Kind is equal to the given string.
+// Equals returns true if the [Kind] is equal to the given string.
 // The comparison is case-insensitive.
 func (k Kind) Equals(s string) bool {
 	return strings.EqualFold(k.String(), s)
 }
 
-// Applicable returns true if the Kind can be applied or deleted by the user.
-// In other words, it informs whether the Kind's lifecycle is managed by the user.
+// Applicable returns true if the [Kind] can be applied or deleted by the user.
+// In other words, it informs whether the [Kind] lifecycle is managed by the user.
 func (k Kind) Applicable() bool {
 	return k != KindAlert && k != KindUserGroup
 }
 
-// ApplicableKinds returns all the Kind instances which can be applied or deleted by the user.
+// ApplicableKinds returns all the [Kind] instances which can be applied or deleted by the user.
 func ApplicableKinds() []Kind {
 	allValues := KindValues()
 	applicable := make([]Kind, 0, len(allValues)-1)
@@ -53,12 +53,12 @@ func ApplicableKinds() []Kind {
 	return applicable
 }
 
-// MarshalText implements the text encoding.TextMarshaler interface.
+// MarshalText implements the text [text/encoding.TextMarshaler] interface.
 func (k Kind) MarshalText() ([]byte, error) {
 	return []byte(k.String()), nil
 }
 
-// UnmarshalText implements the text encoding.TextUnmarshaler interface.
+// UnmarshalText implements the text [text/encoding.TextUnmarshaler] interface.
 func (k *Kind) UnmarshalText(text []byte) error {
 	tmp, err := ParseKind(string(text))
 	// We cannot fail here as we often use a partial representation of our objects.

--- a/manifest/object.go
+++ b/manifest/object.go
@@ -11,34 +11,34 @@ import (
 // Object represents a generic Nobl9 object definition.
 // All Nobl9 objects implement this interface.
 type Object interface {
-	// GetVersion returns the API version of the Object.
+	// GetVersion returns the API version of the [Object].
 	GetVersion() Version
-	// GetKind returns the Kind of the Object.
+	// GetKind returns the Kind of the [Object].
 	GetKind() Kind
-	// GetName returns the name of the Object (RFC 1123 compliant DNS).
+	// GetName returns the name of the [Object] (RFC 1123 compliant DNS).
 	GetName() string
-	// Validate performs static validation of the Object.
+	// Validate performs static validation of the [Object].
 	Validate() error
-	// GetManifestSource returns the source of the Object's manifest.
+	// GetManifestSource returns the source of the [Object] manifest.
 	GetManifestSource() string
-	// SetManifestSource sets the source of the Object's manifest.
+	// SetManifestSource sets the source of the [Object] manifest.
 	SetManifestSource(src string) Object
 }
 
-// ProjectScopedObject an Object which is tied to a specific KindProject.
-// Example of such an object is v1alpha.SLO.
-// On the other hand v1alpha.RoleBinding is an example of organization
-// scoped Object which is not tied to any KindProject.
+// ProjectScopedObject an [Object] which is tied to a specific [KindProject].
+// Example of such an object is [github.com/nobl9/nobl9-go/manifest/v1alpha/slo.SLO].
+// On the other hand [github.com/nobl9/nobl9-go/manifest/v1alpha/rolebinding.RoleBinding]
+// is an example of organization-scoped [Object] which is not tied to any [KindProject].
 type ProjectScopedObject interface {
 	Object
-	// GetProject returns the name of the project which the ProjectScopedObject belongs to.
+	// GetProject returns the name of the project which the [ProjectScopedObject] belongs to.
 	GetProject() string
-	// SetProject sets the name of the project which the ProjectScopedObject should belong to.
-	// It returns the copy of the Object with the updated Project.
+	// SetProject sets the name of the project which the [ProjectScopedObject] should belong to.
+	// It returns the copy of the [Object] with the updated project name.
 	SetProject(project string) Object
 }
 
-// FilterByKind filters Object slice and returns its subset matching the type constraint.
+// FilterByKind filters [Object] slice and returns its subset matching the type constraint.
 func FilterByKind[T Object](objects []Object) []T {
 	var filtered []T
 	for i := range objects {
@@ -68,7 +68,7 @@ func Validate(objects []Object) []error {
 }
 
 // SetDefaultProject sets the default project for each object only if the object is
-// ProjectScopedObject, and it does not yet have project assigned to it.
+// [ProjectScopedObject], and it does not yet have project assigned to it.
 func SetDefaultProject(objects []Object, project string) []Object {
 	for i := range objects {
 		v, ok := objects[i].(ProjectScopedObject)
@@ -81,7 +81,7 @@ func SetDefaultProject(objects []Object, project string) []Object {
 
 // validateObjectsUniqueness checks if all objects are uniquely named.
 // The uniqueness key consists of the objects' kind, name and project.
-// Project is only part of the key if Object does not implement ProjectScopedObject.
+// Project is only part of the key if [Object] does not implement [ProjectScopedObject].
 func validateObjectsUniqueness(objects []Object) (err error) {
 	type uniqueKey struct {
 		Kind    Kind

--- a/manifest/v1alpha/labels.go
+++ b/manifest/v1alpha/labels.go
@@ -8,8 +8,8 @@ import (
 	"github.com/nobl9/govy/pkg/rules"
 )
 
-// Labels are key-value pairs that can be attached to SLOs, services, projects, and alert policies.
-// Labels are used to select and filter Nobl9 objects.
+// Labels are key-value pairs that can be attached to certain objects.
+// Labels are used to select and filter these objects.
 type Labels map[labelKey][]labelValue
 type (
 	labelKey   = string

--- a/manifest/v1alpha/parser/parser_test.go
+++ b/manifest/v1alpha/parser/parser_test.go
@@ -137,8 +137,8 @@ func Test_ParseObject_EnsureAllKindsAreParsed(t *testing.T) {
 }
 
 // References:
-// - https://github.com/nobl9/go-yaml/pull/3 (fork)
-// - https://github.com/nobl9/go-yaml/pull/457 (upstream)
+//   - https://github.com/nobl9/go-yaml/pull/3 (fork)
+//   - https://github.com/nobl9/go-yaml/pull/457 (upstream)
 func Test_ParseObject_DoubleQuotedJSONHandling(t *testing.T) {
 	data, format := readParserTestFile(t, "cloudwatch_slo.yaml")
 	_, err := ParseObject(data, manifest.KindSLO, format)

--- a/manifest/version.go
+++ b/manifest/version.go
@@ -8,7 +8,7 @@ import "strings"
 // ENUM(v1alpha = n9/v1alpha)
 type Version string
 
-// VersionString returns the second element of the Version.
+// VersionString returns the second element of the [Version].
 // For example, given "n9/v1alpha", it returns "v1alpha".
 func (v Version) VersionString() string {
 	return strings.TrimPrefix(v.String(), "n9/")

--- a/sdk/config_file.go
+++ b/sdk/config_file.go
@@ -17,13 +17,13 @@ type FileConfig struct {
 	filePath string
 }
 
-// GetPath retrieves the file path FileConfig was loaded from.
+// GetPath retrieves the file path [FileConfig] was loaded from.
 func (f *FileConfig) GetPath() string {
 	return f.filePath
 }
 
 // Load reads the config file from the provided path.
-// If the file does not exist, it will create a default configuration file.
+// If the file does not exist, it will create a default configuration file at the provided path.
 func (f *FileConfig) Load(path string) error {
 	f.filePath = path
 	if _, err := os.Stat(path); err != nil {
@@ -40,7 +40,7 @@ func (f *FileConfig) Load(path string) error {
 	return nil
 }
 
-// Save saves FileConfig into provided path, encoding it in TOML format.
+// Save saves [FileConfig] into provided path, encoding it in TOML format.
 func (f *FileConfig) Save(path string) (err error) {
 	tmpFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 	if err != nil {

--- a/sdk/decode.go
+++ b/sdk/decode.go
@@ -18,7 +18,9 @@ import (
 var ErrNoDefinitionsFound = errors.New("no definitions in input")
 
 // DecodeObjects reads objects from the provided bytes slice.
-// It detects if the input is in JSON (manifest.RawObjectFormatJSON) or YAML (manifest.RawObjectFormatYAML format.
+// It detects if the input is in either of the formats:
+//   - JSON ([manifest.RawObjectFormatJSON])
+//   - YAML ([manifest.RawObjectFormatYAML])
 func DecodeObjects(data []byte) ([]manifest.Object, error) {
 	if isJSONBuffer(data) {
 		return decodeJSON(data)
@@ -26,7 +28,7 @@ func DecodeObjects(data []byte) ([]manifest.Object, error) {
 	return decodeYAML(data)
 }
 
-// DecodeObject returns a single, concrete object implementing manifest.Object.
+// DecodeObject returns a single, concrete object implementing [manifest.Object].
 // It expects exactly one object in the decoded byte slice.
 func DecodeObject[T manifest.Object](data []byte) (object T, err error) {
 	objects, err := DecodeObjects(data)
@@ -44,7 +46,7 @@ func DecodeObject[T manifest.Object](data []byte) (object T, err error) {
 	return object, nil
 }
 
-// processRawDefinitions function converts raw definitions to a slice of manifest.Object.
+// processRawDefinitions function converts raw definitions to a slice of [manifest.Object].
 func processRawDefinitions(rds rawDefinitions) ([]manifest.Object, error) {
 	result := make([]manifest.Object, 0, len(rds))
 	for _, rd := range rds {
@@ -62,7 +64,7 @@ func processRawDefinitions(rds rawDefinitions) ([]manifest.Object, error) {
 	return result, nil
 }
 
-// annotateWithManifestSource annotates manifest.Object with the manifest definition source.
+// annotateWithManifestSource annotates [manifest.Object] with the manifest definition source.
 func annotateWithManifestSource(object manifest.Object, source string) manifest.Object {
 	if object.GetManifestSource() == "" && source != "" {
 		object = object.SetManifestSource(source)
@@ -235,7 +237,7 @@ func getYamlIdent(data []byte) ident {
 // document separator located at the beginning of the file.
 const yamlDocSep = "\n---"
 
-// splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.
+// splitYAMLDocument is a [bufio.SplitFunc] for splitting YAML streams into individual documents.
 func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil

--- a/sdk/endpoints/authdata/v1/endpoints.go
+++ b/sdk/endpoints/authdata/v1/endpoints.go
@@ -36,7 +36,7 @@ func (e endpoints) GetDirectIAMRoleIDs(ctx context.Context, project, directName 
 	return e.getIAMRoleIDs(ctx, path.Join(apiGetDirectIAMRoleIDs, directName), project)
 }
 
-// GetAgentCredentials retrieves manifest.KindAgent credentials.
+// GetAgentCredentials retrieves [nobl9-go/manifest.KindAgent] credentials.
 func (e endpoints) GetAgentCredentials(
 	ctx context.Context,
 	project, agentsName string,

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -22,12 +22,12 @@ var (
 	}
 )
 
-// httpNonRetryableError signifies to the retryablehttp.Client that the request should not be retired.
+// httpNonRetryableError signifies to the [retryablehttp.Client] that the request should not be retired.
 type httpNonRetryableError struct{ Err error }
 
 func (n httpNonRetryableError) Error() string { return n.Err.Error() }
 
-// newRetryableHTTPClient returns http.Client with preconfigured retry feature.
+// newRetryableHTTPClient returns [http.Client] with preconfigured retry feature.
 func newRetryableHTTPClient(timeout time.Duration, rt http.RoundTripper) *http.Client {
 	rc := retryablehttp.NewClient()
 	rc.Logger = httpNoopLogger{}
@@ -91,7 +91,7 @@ func httpShouldRetryPolicy(resp *http.Response, retryErr error) (shouldRetry boo
 
 type httpNoopLogger struct{}
 
-// Printf is empty, because we only want to fulfill `retryablehttp.Logger` interface.
-// `retryablehttp.Client.Logger` makes extensive use of the logger yielding way too much info.
+// Printf is empty, because we only want to fulfill [retryablehttp.Logger] interface.
+// [retryablehttp.Client.Logger] makes extensive use of the logger yielding way too much info.
 // We silence the logger and print the info where needed.
 func (l httpNoopLogger) Printf(string, ...interface{}) {}

--- a/sdk/jwt.go
+++ b/sdk/jwt.go
@@ -43,7 +43,8 @@ type jwtClaimsProfile interface {
 
 // stringOrObject has to be used to wrap our profiles as currently
 // they can either contain the profile object or an empty string.
-// Once PC-12146 is done, it can be removed.
+//
+// TODO: Once PC-12146 is done, it can be removed.
 type stringOrObject[T jwtClaimsProfile] struct {
 	Value *T
 }
@@ -176,7 +177,7 @@ func (j *jwtParser) initKeyfunc() error {
 }
 
 // newJWKStorage is almost a direct copy of the [jwkset.NewDefaultHTTPClientCtx].
-// One notable change is that we're setting NoErrorReturnFirstHTTPReq to false,
+// One notable change is that we're setting [jwkset.HTTPClientStorageOptions.NoErrorReturnFirstHTTPReq] to false,
 // this ensures that if an error occurs when fetching keys inside the constructor,
 // it is returned immediately.
 // We also modify the timeout value.

--- a/sdk/models/replay.go
+++ b/sdk/models/replay.go
@@ -35,7 +35,7 @@ type ReplayTimeRange struct {
 	EndDate   time.Time `json:"endDate,omitempty"` // not supported yet
 }
 
-// ReplayWithStatus used for returning Replay data with status.
+// ReplayWithStatus used for returning [Replay] data with status.
 type ReplayWithStatus struct {
 	Project string       `json:"project"`
 	Slo     string       `json:"slo"`
@@ -72,7 +72,7 @@ type ReplaySourceSLOItem struct {
 	Target string `json:"target"`
 }
 
-// Variants of ReplayStatus.Status.
+// Variants of [ReplayStatus.Status].
 const (
 	ReplayStatusFailed    = "failed"
 	ReplayStatusCompleted = "completed"
@@ -83,7 +83,7 @@ type ReplayAvailability struct {
 	Reason    string `json:"reason,omitempty"`
 }
 
-// Variants of ReplayAvailability.Reason.
+// Variants of [ReplayAvailability.Reason].
 const (
 	ReplayDataSourceTypeInvalid              = "datasource_type_invalid"
 	ReplayProjectDoesNotExist                = "project_does_not_exist"
@@ -243,7 +243,7 @@ var allowedDurationUnit = []string{
 	DurationUnitDay,
 }
 
-// Duration converts unit and value to time.Duration.
+// Duration converts unit and value to [time.Duration].
 func (d ReplayDuration) Duration() (time.Duration, error) {
 	if err := ValidateReplayDurationUnit(d.Unit); err != nil {
 		return 0, err

--- a/sdk/reader.go
+++ b/sdk/reader.go
@@ -19,14 +19,14 @@ import (
 
 const APIVersionRegex = `"?apiVersion"?\s*:\s*"?n9`
 
-type (
-	// RawObjectSource may be interpreted as:
-	// - file path as [ObjectSourceTypeFile] or [ObjectSourceTypeDirectory]
-	// - glob pattern as [ObjectSourceTypeGlobPattern]
-	// - URL as [ObjectSourceTypeURL]
-	// - input provided via [io.Reader], like [os.Stdin] as [ObjectSourceTypeReader]
-	RawObjectSource = string
+// RawObjectSource may be interpreted as:
+//   - file path as [ObjectSourceTypeFile] or [ObjectSourceTypeDirectory]
+//   - glob pattern as [ObjectSourceTypeGlobPattern]
+//   - URL as [ObjectSourceTypeURL]
+//   - input provided via [io.Reader], like [os.Stdin] as [ObjectSourceTypeReader]
+type RawObjectSource = string
 
+type (
 	// rawDefinition stores both the resolved source and raw resource definition.
 	rawDefinition struct {
 		// ResolvedSource

--- a/sdk/source.go
+++ b/sdk/source.go
@@ -189,7 +189,7 @@ func resolveGlobPattern(path string) (paths []string, err error) {
 }
 
 // hasSupportedFileExtension checks if we're dealing with YAML or JSON file comparing file extension suffix.
-// It's faster to do the simple comparison strings.HasSuffix does then call filepath.Ext.
+// It's faster to do the simple comparison [strings.HasSuffix] does then call [filepath.Ext].
 func hasSupportedFileExtension(fp string) bool {
 	ext := filepath.Ext(fp)
 	for i := range supportedFileExtensions {


### PR DESCRIPTION
## Motivation

A lot of the Go code docs has invalid code links, there are also formatting issues with lists.