### PR TITLE
fix: PC-9592 Validate opsgenie and slack URLs at submission

### DIFF
--- a/manifest/v1alpha/alertmethod/validation_opsgenie_test.go
+++ b/manifest/v1alpha/alertmethod/validation_opsgenie_test.go
@@ -11,12 +11,21 @@ import (
 
 func TestValidate_Spec_OpsgenieAlertMethod(t *testing.T) {
 	for name, spec := range map[string]OpsgenieAlertMethod{
-		"passes with valid http url": {
-			URL:  "http://example.com",
+		"passes with valid opsgenie http url": {
+			URL:  "https://api.opsgenie.com",
 			Auth: "Basic token",
 		},
-		"passes with valid https url": {
-			URL: "https://example.com",
+		"passes with valid opsgenie eu http url": {
+			URL:  "https://api.eu.opsgenie.com",
+			Auth: "Basic token",
+		},
+		"passes with valid opsgenie http url and suffix": {
+			URL:  "https://api.opsgenie.com/test",
+			Auth: "Basic token",
+		},
+		"passes with valid opsgenie eu http url and suffix": {
+			URL:  "https://api.eu.opsgenie.com/test",
+			Auth: "Basic token",
 		},
 		"passes with undefined url": {},
 		"passes with empty url": {
@@ -52,15 +61,31 @@ func TestValidate_Spec_OpsgenieAlertMethod(t *testing.T) {
 		AlertMethod         OpsgenieAlertMethod
 	}{
 		"fails with invalid url": {
-			ExpectedErrorsCount: 1,
+			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
 					Prop: "spec.opsgenie.url",
 					Code: rules.ErrorCodeStringURL,
 				},
+				{
+					Prop: "spec.opsgenie.url",
+					Code: rules.ErrorCodeStringStartsWith,
+				},
 			},
 			AlertMethod: OpsgenieAlertMethod{
 				URL: "example.com",
+			},
+		},
+		"fails with invalid prefix": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop: "spec.opsgenie.url",
+					Code: rules.ErrorCodeStringStartsWith,
+				},
+			},
+			AlertMethod: OpsgenieAlertMethod{
+				URL: "https://opsgenie.com/test",
 			},
 		},
 		"fails with invalid auth": {

--- a/manifest/v1alpha/alertmethod/validation_slack_test.go
+++ b/manifest/v1alpha/alertmethod/validation_slack_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestValidate_Spec_SlackAlertMethod(t *testing.T) {
 	for name, spec := range map[string]SlackAlertMethod{
-		"passes with valid http url": {
-			URL: "http://example.com",
+		"passes with valid slack http url": {
+			URL: "https://hooks.slack.com/services/",
 		},
-		"passes with valid https url": {
-			URL: "https://example.com",
+		"passes with slack https url and suffix": {
+			URL: "https://hooks.slack.com/services/test",
 		},
 		"passes with undefined url": {},
 		"passes with empty url": {
@@ -41,15 +41,31 @@ func TestValidate_Spec_SlackAlertMethod(t *testing.T) {
 		AlertMethod         SlackAlertMethod
 	}{
 		"fails with invalid url": {
-			ExpectedErrorsCount: 1,
+			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
 					Prop: "spec.slack.url",
 					Code: rules.ErrorCodeStringURL,
 				},
+				{
+					Prop: "spec.slack.url",
+					Code: rules.ErrorCodeStringStartsWith,
+				},
 			},
 			AlertMethod: SlackAlertMethod{
 				URL: "example.com",
+			},
+		},
+		"fails with invalid prefix": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop: "spec.slack.url",
+					Code: rules.ErrorCodeStringStartsWith,
+				},
+			},
+			AlertMethod: SlackAlertMethod{
+				URL: "https://slack.com/services/test",
 			},
 		},
 	} {

--- a/manifest/v1alpha/alertmethod/validation_test.go
+++ b/manifest/v1alpha/alertmethod/validation_test.go
@@ -88,7 +88,7 @@ func TestValidate_Spec(t *testing.T) {
 		alertMethod := validAlertMethod()
 		alertMethod.Spec = Spec{
 			Slack: &SlackAlertMethod{
-				URL: "https://example.com",
+				URL: "https://hooks.slack.com/services/321/123/secret",
 			},
 			Teams: &TeamsAlertMethod{
 				URL: "https://example.com",
@@ -113,7 +113,7 @@ func validAlertMethod() AlertMethod {
 		},
 		Spec{
 			Slack: &SlackAlertMethod{
-				URL: "https://example.com",
+				URL: "https://hooks.slack.com/services/321/123/secret",
 			},
 		},
 	)


### PR DESCRIPTION
## Motivation

Described in [PC-9592 ](https://nobl9.atlassian.net/browse/PC-9592)

## Summary

Added validation for opsgenie and slack URLs, the validation is the same as the validation in corresponding notifications services:
* [opsgenie](https://github.com/nobl9/n9/blob/main/notifications/notificationsopsgenie/internal/notifier/notificationsopsgenie.go#L92)
* [slack](https://github.com/nobl9/n9/blob/main/notifications/notificationsslack/internal/notifier/notificationsslack.go#L83)

## Related changes

None

## Testing

-  Added unit tests

## Release Notes

Improved URL validation for Opsgenie and Slack alert methods:
* Slack URLs must now begin with `https://hooks.slack.com/services/`.
* Opsgenie URLs must start with either `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`.
