### PR TITLE
fix: Correct Report timeFrame paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ check/format:
 	$(call _print_check_step,Checking if files are formatted)
 	./scripts/check-formatting.sh
 
-.PHONY: generate generate/code generate/examples
+.PHONY: generate generate/code generate/examples generate/docs
 ## Auto generate files.
-generate: generate/code generate/examples
+generate: generate/code generate/examples generate/docs
 
 ## Generate Golang code.
 generate/code:
@@ -126,6 +126,11 @@ generate/code:
 generate/examples:
 	echo "Generating examples..."
 	go run internal/cmd/examplegen/main.go
+
+## Generate documentation.
+generate/docs:
+	echo "Generating documentation..."
+	go run internal/cmd/docgen/*
 
 .PHONY: format format/go format/cspell
 ## Format files.

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ check/format:
 	$(call _print_check_step,Checking if files are formatted)
 	./scripts/check-formatting.sh
 
-.PHONY: generate generate/code generate/examples generate/docs
+.PHONY: generate generate/code generate/examples
 ## Auto generate files.
-generate: generate/code generate/examples generate/docs
+generate: generate/code generate/examples
 
 ## Generate Golang code.
 generate/code:
@@ -126,11 +126,6 @@ generate/code:
 generate/examples:
 	echo "Generating examples..."
 	go run internal/cmd/examplegen/main.go
-
-## Generate documentation.
-generate/docs:
-	echo "Generating documentation..."
-	go run internal/cmd/docgen/*
 
 .PHONY: format format/go format/cspell
 ## Format files.

--- a/manifest/v1alpha/report/validation_slo_history.go
+++ b/manifest/v1alpha/report/validation_slo_history.go
@@ -10,26 +10,28 @@ import (
 )
 
 var sloHistoryValidation = govy.New[SLOHistoryConfig](
-	govy.For(func(s SLOHistoryConfig) string { return s.TimeFrame.TimeZone }).
-		WithName("timeZone").
-		Required().
-		Rules(govy.NewRule(func(v string) error {
-			if _, err := time.LoadLocation(v); err != nil {
-				return errors.Wrap(err, "not a valid time zone")
-			}
-			return nil
-		})),
 	govy.For(func(s SLOHistoryConfig) SLOHistoryTimeFrame { return s.TimeFrame }).
 		WithName("timeFrame").
 		Required().
 		Rules(rules.MutuallyExclusive(true, map[string]func(t SLOHistoryTimeFrame) any{
 			"rolling":  func(t SLOHistoryTimeFrame) any { return t.Rolling },
 			"calendar": func(t SLOHistoryTimeFrame) any { return t.Calendar },
-		})),
-	govy.ForPointer(func(s SLOHistoryConfig) *RollingTimeFrame { return s.TimeFrame.Rolling }).
-		WithName("rolling").
-		Include(rollingTimeFrameValidation),
-	govy.ForPointer(func(s SLOHistoryConfig) *CalendarTimeFrame { return s.TimeFrame.Calendar }).
-		WithName("calendar").
-		Include(calendarTimeFrameValidation),
+		})).
+		Include(govy.New[SLOHistoryTimeFrame](
+			govy.For(func(s SLOHistoryTimeFrame) string { return s.TimeZone }).
+				WithName("timeZone").
+				Required().
+				Rules(govy.NewRule(func(v string) error {
+					if _, err := time.LoadLocation(v); err != nil {
+						return errors.Wrap(err, "not a valid time zone")
+					}
+					return nil
+				})),
+			govy.ForPointer(func(s SLOHistoryTimeFrame) *RollingTimeFrame { return s.Rolling }).
+				WithName("rolling").
+				Include(rollingTimeFrameValidation),
+			govy.ForPointer(func(s SLOHistoryTimeFrame) *CalendarTimeFrame { return s.Calendar }).
+				WithName("calendar").
+				Include(calendarTimeFrameValidation),
+		)),
 )

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -385,15 +385,15 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 3,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.rolling.unit",
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: "spec.sloHistory.rolling.count",
+					Prop: "spec.sloHistory.timeFrame.rolling.count",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    "spec.sloHistory.rolling",
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -406,11 +406,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.rolling.count",
+					Prop: "spec.sloHistory.timeFrame.rolling.count",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    "spec.sloHistory.rolling",
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -427,11 +427,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.rolling.unit",
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    "spec.sloHistory.rolling",
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -448,11 +448,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.rolling.unit",
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop:    "spec.sloHistory.rolling",
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -470,7 +470,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.rolling",
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -488,7 +488,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.timeZone",
+					Prop: "spec.sloHistory.timeFrame.timeZone",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -505,7 +505,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.timeZone",
+					Prop:    "spec.sloHistory.timeFrame.timeZone",
 					Message: "not a valid time zone: unknown time zone x",
 				},
 			},
@@ -523,7 +523,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.calendar",
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validCalendarPairs,
 				},
 			},
@@ -536,7 +536,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.calendar",
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validCalendarPairs,
 				},
 			},
@@ -553,11 +553,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.sloHistory.calendar.unit",
+					Prop: "spec.sloHistory.timeFrame.calendar.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop:    "spec.sloHistory.calendar",
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validUnitAndCountCalendarPairs,
 				},
 			},
@@ -575,7 +575,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.calendar",
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validUnitAndCountCalendarPairs,
 				},
 			},
@@ -593,7 +593,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    "spec.sloHistory.calendar",
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: "dates must be in the past",
 				},
 			},


### PR DESCRIPTION
## Release Notes

Corrected paths reported by object's validation for Report kind under `spec.sloHistory.timeFrame`.
