### PR TITLE
feat: PC-14241 budget adjustment spec duration should not have precision set to 1 m

### DIFF
--- a/manifest/v1alpha/budgetadjustment/validation.go
+++ b/manifest/v1alpha/budgetadjustment/validation.go
@@ -1,6 +1,7 @@
 package budgetadjustment
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -46,7 +47,7 @@ var specValidation = govy.New[Spec](
 	govy.Transform(func(s Spec) string { return s.Duration }, time.ParseDuration).
 		WithName("duration").
 		Required().
-		Rules(rules.DurationPrecision(time.Minute)),
+		Rules(durationPrecision),
 	govy.Transform(func(s Spec) string { return s.Rrule }, rrule.StrToRRule).
 		WithName("rrule").
 		Rules(atLeastHourlyFreq),
@@ -103,6 +104,18 @@ var atLeastHourlyFreq = govy.NewRule(func(rule *rrule.RRule) error {
 var secondTimePrecision = govy.NewRule(func(t time.Time) error {
 	if t.Nanosecond() != 0 {
 		return errors.New("time must be defined with 1s precision")
+	}
+
+	return nil
+})
+
+var durationPrecision = govy.NewRule(func(t time.Duration) error {
+	fmt.Println(t.Nanoseconds())
+	if t.Minutes() < 1 {
+		return errors.New("duration must be at least 1 minute")
+	}
+	if t.Nanoseconds()%int64(time.Second) != 0 {
+		return errors.New("duration must be defined with 1s precision")
 	}
 
 	return nil

--- a/manifest/v1alpha/budgetadjustment/validation.go
+++ b/manifest/v1alpha/budgetadjustment/validation.go
@@ -1,7 +1,6 @@
 package budgetadjustment
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -110,7 +109,6 @@ var secondTimePrecision = govy.NewRule(func(t time.Time) error {
 })
 
 var durationPrecision = govy.NewRule(func(t time.Duration) error {
-	fmt.Println(t.Nanoseconds())
 	if t.Minutes() < 1 {
 		return errors.New("duration must be at least 1 minute")
 	}

--- a/manifest/v1alpha/budgetadjustment/validation_test.go
+++ b/manifest/v1alpha/budgetadjustment/validation_test.go
@@ -590,6 +590,11 @@ func TestDurationPrecision(t *testing.T) {
 		expectedError string
 	}{
 		{
+			name:          "59ns returns error",
+			duration:      time.Nanosecond * 59,
+			expectedError: "duration must be at least 1 minute",
+		},
+		{
 			name:          "59s returns error",
 			duration:      time.Second * 59,
 			expectedError: "duration must be at least 1 minute",
@@ -598,6 +603,11 @@ func TestDurationPrecision(t *testing.T) {
 			name:          "1m no error",
 			duration:      time.Minute,
 			expectedError: "",
+		},
+		{
+			name:          "1m60ns returns error",
+			duration:      time.Minute + 60*time.Nanosecond,
+			expectedError: "duration must be defined with 1s precision",
 		},
 		{
 			name:          "1m1s no error",
@@ -616,8 +626,13 @@ func TestDurationPrecision(t *testing.T) {
 		},
 		{
 			name:          "1h1m1s returns no error",
-			duration:      time.Hour + time.Second,
+			duration:      time.Hour + time.Minute + time.Second,
 			expectedError: "",
+		},
+		{
+			name:          "1h1m1ns returns error",
+			duration:      time.Hour + time.Minute + time.Nanosecond,
+			expectedError: "duration must be defined with 1s precision",
 		},
 	}
 

--- a/manifest/v1alpha/budgetadjustment/validation_test.go
+++ b/manifest/v1alpha/budgetadjustment/validation_test.go
@@ -582,3 +582,53 @@ func TestAtLeastSecondTimeResolution(t *testing.T) {
 		})
 	}
 }
+
+func TestDurationPrecision(t *testing.T) {
+	tests := []struct {
+		name          string
+		duration      time.Duration
+		expectedError string
+	}{
+		{
+			name:          "59s returns error",
+			duration:      time.Second * 59,
+			expectedError: "duration must be at least 1 minute",
+		},
+		{
+			name:          "1m no error",
+			duration:      time.Minute,
+			expectedError: "",
+		},
+		{
+			name:          "1m1s no error",
+			duration:      time.Minute + time.Second,
+			expectedError: "",
+		},
+		{
+			name:          "1h returns no error",
+			duration:      time.Hour,
+			expectedError: "",
+		},
+		{
+			name:          "1h1s no error",
+			duration:      time.Hour + time.Second,
+			expectedError: "",
+		},
+		{
+			name:          "1h1m1s returns no error",
+			duration:      time.Hour + time.Second,
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := durationPrecision.Validate(tt.duration)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}

--- a/manifest/v1alpha/budgetadjustment/validation_test.go
+++ b/manifest/v1alpha/budgetadjustment/validation_test.go
@@ -139,8 +139,8 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: "spec.duration",
-					Code: rules.ErrorCodeDurationPrecision,
+					Prop:    "spec.duration",
+					Message: "duration must be at least 1 minute",
 				},
 			},
 		},
@@ -156,12 +156,7 @@ func TestValidate_Spec(t *testing.T) {
 					}},
 				},
 			},
-			expectedErrors: []testutils.ExpectedError{
-				{
-					Prop: "spec.duration",
-					Code: rules.ErrorCodeDurationPrecision,
-				},
-			},
+			expectedErrors: nil,
 		},
 		{
 			name: "slo is defined without name",


### PR DESCRIPTION
## Motivation

Due to customer question we have to set duration precision to one second with minimum one minute limit.