### PR TITLE
feat: Relax MetadataAnnotations validation

### DIFF
--- a/internal/manifest/v1alphatest/metadata_annotations_validation.go
+++ b/internal/manifest/v1alphatest/metadata_annotations_validation.go
@@ -56,6 +56,12 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 			},
 			isValid: true,
 		},
+		"valid: key contains uppercase character": {
+			Annotations: v1alpha.MetadataAnnotations{
+				"nEt": "x",
+			},
+			isValid: true,
+		},
 		"invalid: key is too long": {
 			Annotations: v1alpha.MetadataAnnotations{
 				strings.Repeat("l", 256): "x",
@@ -82,16 +88,6 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 			},
 			error: testutils.ExpectedError{
 				Prop:       propertyPath + "." + "net_",
-				IsKeyError: true,
-				Code:       rules.ErrorCodeStringMatchRegexp,
-			},
-		},
-		"invalid: key contains uppercase character": {
-			Annotations: v1alpha.MetadataAnnotations{
-				"nEt": "x",
-			},
-			error: testutils.ExpectedError{
-				Prop:       propertyPath + "." + "nEt",
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},

--- a/internal/manifest/v1alphatest/metadata_annotations_validation.go
+++ b/internal/manifest/v1alphatest/metadata_annotations_validation.go
@@ -62,12 +62,18 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 			},
 			isValid: true,
 		},
+		"valid: key length limit": {
+			Annotations: v1alpha.MetadataAnnotations{
+				strings.Repeat("l", 317): "x",
+			},
+			isValid: true,
+		},
 		"invalid: key is too long": {
 			Annotations: v1alpha.MetadataAnnotations{
-				strings.Repeat("l", 256): "x",
+				strings.Repeat("l", 318): "x",
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath + "." + strings.Repeat("l", 256),
+				Prop:       propertyPath + "." + strings.Repeat("l", 318),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringLength,
 			},

--- a/manifest/v1alpha/metadata_annotations.go
+++ b/manifest/v1alpha/metadata_annotations.go
@@ -26,7 +26,7 @@ const (
 //go:embed metadata_annotations_examples.yaml
 var metadataAnnotationsExamples string
 
-var annotationKeyRegexp = regexp.MustCompile(`^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$`)
+var annotationKeyRegexp = regexp.MustCompile(`^\p{L}([_\-0-9\p{L}]*[0-9\p{L}])?$`)
 
 func MetadataAnnotationsValidationRules() govy.Validator[MetadataAnnotations] {
 	return govy.New[MetadataAnnotations](
@@ -35,13 +35,7 @@ func MetadataAnnotationsValidationRules() govy.Validator[MetadataAnnotations] {
 				rules.StringLength(minAnnotationKeyLength, maxAnnotationKeyLength),
 				rules.StringMatchRegexp(annotationKeyRegexp),
 			).
-			IncludeForValues(annotationValueValidator).
+			RulesForValues(rules.StringMaxLength(maxAnnotationValueLength)).
 			WithExamples(metadataAnnotationsExamples),
 	)
 }
-
-var annotationValueValidator = govy.New[string](
-	govy.For(govy.GetSelf[string]()).
-		Rules(
-			rules.StringMaxLength(maxAnnotationValueLength),
-		))

--- a/manifest/v1alpha/metadata_annotations.go
+++ b/manifest/v1alpha/metadata_annotations.go
@@ -18,8 +18,10 @@ type (
 )
 
 const (
-	minAnnotationKeyLength   = 1
-	maxAnnotationKeyLength   = 63
+	minAnnotationKeyLength = 1
+	// Subdomain + separator + qualified name.
+	// This way we're keeping it roughly compatible with OpenSLO.
+	maxAnnotationKeyLength   = 253 + 1 + 63
 	maxAnnotationValueLength = 1050
 )
 


### PR DESCRIPTION
## Release Notes

`v1alpha.MetadataAnnotations` now allows upper case characters in keys.