### PR TITLE
chore: Add omitempty tag to SLO alertPolicies

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -48,7 +48,7 @@ type Spec struct {
 	Objectives      []Objective  `json:"objectives"`
 	Service         string       `json:"service"`
 	TimeWindows     []TimeWindow `json:"timeWindows"`
-	AlertPolicies   []string     `json:"alertPolicies"`
+	AlertPolicies   []string     `json:"alertPolicies,omitempty"`
 	Attachments     []Attachment `json:"attachments,omitempty"`
 	// CreatedAt is the date of the [SLO] creation in RFC3339 format.
 	// Read-only field.

--- a/sdk/test_data/reader/expected/composite_v2_slo.tpl.json
+++ b/sdk/test_data/reader/expected/composite_v2_slo.tpl.json
@@ -41,8 +41,7 @@
           "end": "2024-02-28T09:58:42Z"
         }
       }
-    ],
-    "alertPolicies": null
+    ]
   },
   "manifestSrc": "{{ .ManifestSrc }}"
 }

--- a/sdk/test_data/reader/expected/slo.tpl.json
+++ b/sdk/test_data/reader/expected/slo.tpl.json
@@ -39,8 +39,7 @@
           "value": 150,
           "target": 0.50
         }
-      ],
-      "alertPolicies": null
+      ]
     },
     "manifestSrc": "{{ .ManifestSrc }}"
   }


### PR DESCRIPTION
## Motivation

While our API always returns an empty list if no alert policies were provided, when programatically creating an SLO the resulting YAML/JSON encoding is produced with `null` value for empty policies.

## Breaking Changes

SLO field `spec.alertPolicies` will no longer produce `null` value when encoding to JSON or YAML, instead, if empty (nil) it will be skipped.
