### PR TITLE
chore: Correct end-to-end tests for v1alpha SLO

### DIFF
--- a/tests/v1alpha_slo_test.go
+++ b/tests/v1alpha_slo_test.go
@@ -149,7 +149,7 @@ func Test_Objects_V1_V1alpha_SLO(t *testing.T) {
 				slo.Spec.Service = defaultProjectService.GetName()
 				// We don't need to have these field filled,
 				// the first SLO is only here to test default project querying.
-				slo.Spec.AlertPolicies = []string{}
+				slo.Spec.AlertPolicies = nil
 				slo.Spec.AnomalyConfig = nil
 			case 1:
 				slo.Metadata.Labels["team"] = []string{"green"}
@@ -363,7 +363,7 @@ func prepareObjectsForServiceNameFilteringTests(
 			Annotations: commonAnnotations,
 		}
 		slo.Spec.Service = params.service
-		slo.Spec.AlertPolicies = []string{}
+		slo.Spec.AlertPolicies = nil
 		slo.Spec.AnomalyConfig = nil
 		slo.Spec.Indicator.MetricSource = v1alphaSLO.MetricSourceSpec{
 			Name:    agent.GetName(),


### PR DESCRIPTION
Changes introduced in https://github.com/nobl9/nobl9-go/pull/679 have caused these tests to fail.

Tests dispatch: https://github.com/nobl9/nobl9-go/actions/runs/14490771847