### PR TITLE
fix: Solve segmentation violation errors for empty APIVersion [PC-16865]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,9 @@ require (
 	golang.org/x/time v0.11.0
 )
 
+// Remove once https://github.com/goccy/go-yaml/pull/698 is released.
+replace github.com/goccy/go-yaml v1.17.1 => github.com/goccy/go-yaml v1.17.2-0.20250508142621-500180b7b722
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
-github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/goccy/go-yaml v1.17.2-0.20250508142621-500180b7b722 h1:DHc9BORDIxpXjHd9UN4FUWmW82bTzDMokb5f05GEYA8=
+github.com/goccy/go-yaml v1.17.2-0.20250508142621-500180b7b722/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/sdk/encode_test.go
+++ b/sdk/encode_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/nobl9-go/internal/stringutils"
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	v1alphaProject "github.com/nobl9/nobl9-go/manifest/v1alpha/project"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha/slo"
 )
 
 //go:embed test_data/encode/expected_objects.json
@@ -183,4 +185,19 @@ func TestPrintObject(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "unsupported format: ObjectFormat(-1)", err.Error())
 	})
+}
+
+// Issue: https://github.com/goccy/go-yaml/pull/698
+func TestEncodeObjectBug(t *testing.T) {
+	x := slo.SLO{
+		// With APIVersion either not supplied or set explicitly to an empty string
+		// results in an internal panic in the github.com/goccy/go-yaml YAML encoder.
+		// APIVersion: "",
+		Metadata: slo.Metadata{
+			Name:    "foo",
+			Project: "bar",
+		},
+	}
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, EncodeObject(x, buf, manifest.ObjectFormatYAML))
 }


### PR DESCRIPTION
## Summary

Pinned the `go-yaml` version until https://github.com/goccy/go-yaml/pull/698 is released.

## Release Notes

Fixes segmentation violation errors when `apiVersion` was set to an empty string in any of the v1alpha objects.
