### PR TITLE
feat: Improve FileConfig handling

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -165,7 +165,7 @@ func prepareTestClient(t *testing.T, endpoint endpointConfig) (client *Client, s
 		"exp": time.Now().Add(time.Hour).Unix(),
 		"iat": time.Now().Add(-time.Hour).Unix(),
 		"nbf": time.Now().Add(-time.Hour).Unix(),
-		"m2mProfile": map[string]interface{}{
+		"m2mProfile": map[string]any{
 			"environment":  authServerURL.Host, // We're using the same server to serve responses for all endpoints.
 			"organization": organization,
 			"user":         "test@nobl9.com",

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -190,7 +190,7 @@ func (o optionsConfig) IsNoConfigFile() bool {
 var (
 	errFmtConfigNoContextFoundInFile = `Context '%s' was not set in the '%s' configuration file.
 At least one context must be provided and set as default.`
-	// #nosec G101
+	// nolint: lll
 	credentialsNotFoundErrTpl = template.Must(template.New("").Parse(`Both client id and client secret must be provided.
 Either set them in {{ if .ConfigPath }}'{{ .ConfigPath }}' {{ end }}configuration file or provide them through env variables:
  - {{ .EnvPrefix }}CLIENT_ID

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -229,7 +229,7 @@ func (c *Config) Verify() error {
 		EnvPrefix  string
 	}{
 		ConfigPath: path,
-		EnvPrefix:  EnvPrefix,
+		EnvPrefix:  c.options.envPrefix,
 	})
 	return errors.New(buf.String())
 }

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -401,7 +401,7 @@ func TestReadConfig_Verify(t *testing.T) {
 		require.Error(t, err)
 		errMsg := fmt.Sprintf("Both client id and client secret must be provided.\n"+
 			"Either set them in '%s' configuration file or provide them through env variables:"+
-			"\n - NOBL9_SDK_CLIENT_ID\n - NOBL9_SDK_CLIENT_SECRET", configPath)
+			"\n - CLIENT_ID\n - CLIENT_SECRET", configPath)
 		assert.EqualError(t, err, errMsg)
 	})
 
@@ -415,7 +415,7 @@ func TestReadConfig_Verify(t *testing.T) {
 		require.Error(t, err)
 		assert.EqualError(t, err, "Both client id and client secret must be provided."+
 			"\nEither set them in configuration file or provide them through env variables:"+
-			"\n - NOBL9_SDK_CLIENT_ID\n - NOBL9_SDK_CLIENT_SECRET")
+			"\n - CLIENT_ID\n - CLIENT_SECRET")
 	})
 }
 


### PR DESCRIPTION
## Motivation

Currently it's hard to tell if file config has been loaded or not.
This PR changes the `GetFileConfig`contract to return a nil pointer if no file config was loaded.
Previously, the function was returning only a shallow copy of `FileConfig`, now it returns a proper deep copy.

## Breaking Changes

`sdk.Config.GetFileConfig` now returns a pointer.
