### PR TITLE
chore: fix v1alpha.Agent and v1alpha.Direct e2e tests [PC-16874]

### DIFF
--- a/internal/manifest/v1alpha/examples/agent.go
+++ b/internal/manifest/v1alpha/examples/agent.go
@@ -45,6 +45,7 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.CloudWatch,
 	// Support for Replay only in beta.
 	v1alpha.Elasticsearch,
+	v1alpha.ThousandEyes,
 }
 
 func (a agentExample) Generate() v1alphaAgent.Agent {

--- a/internal/manifest/v1alpha/examples/direct.go
+++ b/internal/manifest/v1alpha/examples/direct.go
@@ -48,6 +48,7 @@ var betaChannelDirects = []v1alpha.DataSourceType{
 	v1alpha.LogicMonitor,
 	v1alpha.GoogleCloudMonitoring,
 	v1alpha.AzurePrometheus,
+	v1alpha.ThousandEyes,
 }
 
 func (d directExample) Generate() v1alphaDirect.Direct {

--- a/manifest/v1alpha/agent/examples/thousand-eyes.yaml
+++ b/manifest/v1alpha/agent/examples/thousand-eyes.yaml
@@ -11,7 +11,7 @@ metadata:
     team: sales
 spec:
   description: Example ThousandEyes Agent
-  releaseChannel: stable
+  releaseChannel: beta
   thousandEyes: {}
   historicalDataRetrieval:
     maxDuration:

--- a/manifest/v1alpha/direct/examples/thousand-eyes.yaml
+++ b/manifest/v1alpha/direct/examples/thousand-eyes.yaml
@@ -11,7 +11,7 @@ metadata:
     team: sales
 spec:
   description: Example ThousandEyes Direct
-  releaseChannel: stable
+  releaseChannel: beta
   thousandEyes:
     oauthBearerToken: "[secret]"
   historicalDataRetrieval:

--- a/tests/v1alpha_agent_test.go
+++ b/tests/v1alpha_agent_test.go
@@ -122,6 +122,9 @@ func assertV1alphaAgentsAreEqual(t *testing.T, expected, actual v1alphaAgent.Age
 	actual.Spec.Timeout = nil
 	actual.Spec.Jitter = nil
 	if expected.Spec.HistoricalDataRetrieval != nil {
+		if !assert.NotEmpty(t, actual.Spec.HistoricalDataRetrieval) {
+			actual.Spec.HistoricalDataRetrieval = &v1alpha.HistoricalDataRetrieval{}
+		}
 		assert.NotEmpty(t, actual.Spec.HistoricalDataRetrieval.MinimumAgentVersion)
 		actual.Spec.HistoricalDataRetrieval.MinimumAgentVersion = ""
 	}


### PR DESCRIPTION
## Motivation

Update end-to-end tests after adding historical data retrieval settings to ThousandEyes Agent and Direct types.

## Summary
![image](https://github.com/user-attachments/assets/d3c79322-e733-4e97-b68d-a8130c92f5c1)
![image](https://github.com/user-attachments/assets/3d94f540-efda-4960-af88-680dac7be184)


## Related changes

https://github.com/nobl9/nobl9-go/pull/715
