### PR TITLE
feat: Add GetUserID and GetUserEmail methods

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -167,8 +167,13 @@ func (c *Client) GetOrganization(ctx context.Context) (string, error) {
 	return c.credentials.GetOrganization(ctx)
 }
 
-// GetUser returns the email of the user associated with the access token used by [Client].
-func (c *Client) GetUser(ctx context.Context) (string, error) {
+// GetUserID returns the user ID associated with the access token used by [Client].
+func (c *Client) GetUserID(ctx context.Context) (string, error) {
+	return c.credentials.GetUser(ctx)
+}
+
+// GetUserEmail returns the email of the user associated with the access token used by [Client].
+func (c *Client) GetUserEmail(ctx context.Context) (string, error) {
 	userDataFromToken, err := c.credentials.GetUser(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get user data from token")
@@ -187,6 +192,13 @@ func (c *Client) GetUser(ctx context.Context) (string, error) {
 	}
 
 	return user.Email, nil
+}
+
+// GetUser returns the email of the user associated with the access token used by [Client].
+//
+// Deprecated: Use [GetUserEmail] instead.
+func (c *Client) GetUser(ctx context.Context) (string, error) {
+	return c.GetUserEmail(ctx)
 }
 
 // SetUserAgent will set [HeaderUserAgent] to the provided value.


### PR DESCRIPTION
## Motivation

To make things clearer `GetUser` is deprecated and renamed to `GetUserEmail`.
In order to allow users to access the user ID directly `GetUserID` is being added. 

## Release Notes

Added `sdk.Client.GetUserID` which returns ID of the user associated with the access token used by `sdk.Client`.
Added `sdk.Client.GetUserEmail` which is a rename of `sdk.Client.GetUser` function.

## Breaking Changes

`sdk.Client.GetUser` is now deprecated and will be removed in the future. Use `sdk.Client.GetUserEmail` instead.
