### PR TITLE
feat: Return with v1alpha.Alert silencing details 

### DIFF
--- a/internal/cmd/examplegen/main.go
+++ b/internal/cmd/examplegen/main.go
@@ -67,6 +67,7 @@ func getV1alphaExamplesConfigs() []examplesGeneratorConfig {
 		v1alphaExamples.Direct(),
 		v1alphaExamples.AlertPolicy(),
 		v1alphaExamples.AlertSilence(),
+		v1alphaExamples.Alert(),
 		v1alphaExamples.Annotation(),
 		v1alphaExamples.BudgetAdjustment(),
 		v1alphaExamples.DataExport(),

--- a/manifest/v1alpha/alert/alert.go
+++ b/manifest/v1alpha/alert/alert.go
@@ -49,6 +49,7 @@ type Spec struct {
 	Conditions                  []Condition    `json:"conditions"`
 	CoolDownStartedAtMetricTime *string        `json:"coolDownStartedAtMetricTime,omitempty"`
 	ResolutionReason            *string        `json:"resolutionReason,omitempty"`
+	Silenced                    *Silenced      `json:"silenced,omitempty"`
 }
 
 type Objective struct {
@@ -77,4 +78,9 @@ type ConditionStatus struct {
 	FirstMetMetricTime   string  `json:"firstMetMetricTime,omitempty"`
 	LastMetMetricTime    *string `json:"lastMetMetricTime,omitempty"`
 	LastForMetMetricTime *string `json:"lastsForMetMetricTime,omitempty"`
+}
+
+type Silenced struct {
+	From string `json:"from"`
+	To   string `json:"to"`
 }

--- a/manifest/v1alpha/alert/example_test.go
+++ b/manifest/v1alpha/alert/example_test.go
@@ -70,3 +70,72 @@ func ExampleAlert() {
 	//   coolDown: ""
 	//   conditions: []
 }
+
+func ExampleAlert_withSilence() {
+	alertInstance := alert.New(
+		alert.Metadata{
+			Name:    "my-silenced-alert",
+			Project: "default",
+		},
+		alert.Spec{
+			AlertPolicy: alert.ObjectMetadata{
+				Name:    "my-alert-policy",
+				Project: "default",
+			},
+			Service: alert.ObjectMetadata{
+				Name:    "my-service",
+				Project: "default",
+			},
+			SLO: alert.ObjectMetadata{
+				Name:    "my-slo",
+				Project: "default",
+			},
+			Objective: alert.Objective{
+				Name:        "availability",
+				DisplayName: "Availability",
+				Value:       99.9,
+			},
+			Severity:           "High",
+			Status:             "Triggered",
+			TriggeredClockTime: "2024-01-15T14:00:00Z",
+			Silenced: &alert.Silenced{
+				From: "2024-01-15T14:00:00Z",
+				To:   "2024-01-15T16:00:00Z",
+			},
+		},
+	)
+	// Apply the object:
+	client := examples.GetOfflineEchoClient()
+	if err := client.Objects().V1().Apply(context.Background(), []manifest.Object{alertInstance}); err != nil {
+		log.Fatal("failed to apply alert err: %w", err)
+	}
+	// Output:
+	// apiVersion: n9/v1alpha
+	// kind: Alert
+	// metadata:
+	//   name: my-silenced-alert
+	//   project: default
+	// spec:
+	//   alertPolicy:
+	//     name: my-alert-policy
+	//     project: default
+	//   slo:
+	//     name: my-slo
+	//     project: default
+	//   service:
+	//     name: my-service
+	//     project: default
+	//   objective:
+	//     value: 99.9
+	//     name: availability
+	//     displayName: Availability
+	//   severity: High
+	//   status: Triggered
+	//   triggeredMetricTime: ""
+	//   triggeredClockTime: "2024-01-15T14:00:00Z"
+	//   coolDown: ""
+	//   conditions: []
+	//   silenced:
+	//     from: "2024-01-15T14:00:00Z"
+	//     to: "2024-01-15T16:00:00Z"
+}

--- a/manifest/v1alpha/alert/examples/alert-with-silence.yaml
+++ b/manifest/v1alpha/alert/examples/alert-with-silence.yaml
@@ -1,0 +1,38 @@
+apiVersion: n9/v1alpha
+kind: Alert
+metadata:
+  name: silenced-alert-example
+  project: default
+spec:
+  alertPolicy:
+    name: my-alert-policy
+    displayName: My Alert Policy
+    project: default
+  slo:
+    name: my-slo
+    displayName: My SLO
+    project: default
+  service:
+    name: my-service
+    displayName: My Service
+    project: default
+  objective:
+    value: 0.99
+    name: availability-objective
+    displayName: Availability Objective
+  severity: Medium
+  status: Triggered
+  triggeredMetricTime: "2024-01-15T14:00:00Z"
+  triggeredClockTime: "2024-01-15T14:01:00Z"
+  coolDown: 10m0s
+  conditions:
+  - measurement: burnRate
+    value: 5.2
+    alertingWindow: 30m
+    lastsFor: 2m
+    op: gt
+    status:
+      firstMetMetricTime: "2024-01-15T13:58:00Z"
+  silenced:
+    from: "2024-01-15T14:00:00Z"
+    to: "2024-01-15T16:00:00Z"

--- a/manifest/v1alpha/alert/examples/alert-without-silence.yaml
+++ b/manifest/v1alpha/alert/examples/alert-without-silence.yaml
@@ -1,0 +1,35 @@
+apiVersion: n9/v1alpha
+kind: Alert
+metadata:
+  name: alert-example
+  project: default
+spec:
+  alertPolicy:
+    name: my-alert-policy
+    displayName: My Alert Policy
+    project: default
+  slo:
+    name: my-slo
+    displayName: My SLO
+    project: default
+  service:
+    name: my-service
+    displayName: My Service
+    project: default
+  objective:
+    value: 0.95
+    name: latency-objective
+    displayName: Latency Objective
+  severity: High
+  status: Triggered
+  triggeredMetricTime: "2024-01-15T10:30:00Z"
+  triggeredClockTime: "2024-01-15T10:31:00Z"
+  coolDown: 5m0s
+  conditions:
+  - measurement: timeToBurnBudget
+    value: 2h30m
+    alertingWindow: 1h
+    lastsFor: 5m
+    op: lt
+    status:
+      firstMetMetricTime: "2024-01-15T10:25:00Z"

--- a/manifest/v1alpha/alert/validation_test.go
+++ b/manifest/v1alpha/alert/validation_test.go
@@ -75,6 +75,10 @@ func validAlert() Alert {
 					Operator:         "lt",
 				},
 			},
+			Silenced: &Silenced{
+				From: "2024-01-11T16:00:00Z",
+				To:   "2024-01-11T17:00:00Z",
+			},
 		},
 	}
 }

--- a/manifest/v1alpha/examples/alert.go
+++ b/manifest/v1alpha/examples/alert.go
@@ -1,0 +1,108 @@
+package v1alphaExamples
+
+import "github.com/nobl9/nobl9-go/manifest/v1alpha/alert"
+
+func Alert() []Example {
+	return newExampleSlice(
+		standardExample{
+			Variant: "Alert without silence",
+			Object: alert.New(
+				alert.Metadata{
+					Name:    "alert-example",
+					Project: "default",
+				},
+				alert.Spec{
+					AlertPolicy: alert.ObjectMetadata{
+						Name:        "my-alert-policy",
+						DisplayName: "My Alert Policy",
+						Project:     "default",
+					},
+					SLO: alert.ObjectMetadata{
+						Name:        "my-slo",
+						DisplayName: "My SLO",
+						Project:     "default",
+					},
+					Service: alert.ObjectMetadata{
+						Name:        "my-service",
+						DisplayName: "My Service",
+						Project:     "default",
+					},
+					Objective: alert.Objective{
+						Value:       0.95,
+						Name:        "latency-objective",
+						DisplayName: "Latency Objective",
+					},
+					Severity:            "High",
+					Status:              "Triggered",
+					TriggeredMetricTime: "2024-01-15T10:30:00Z",
+					TriggeredClockTime:  "2024-01-15T10:31:00Z",
+					CoolDown:            "5m0s",
+					Conditions: []alert.Condition{
+						{
+							Measurement:      "timeToBurnBudget",
+							Value:            "2h30m",
+							AlertingWindow:   "1h",
+							LastsForDuration: "5m",
+							Operator:         "lt",
+							Status: &alert.ConditionStatus{
+								FirstMetMetricTime: "2024-01-15T10:25:00Z",
+							},
+						},
+					},
+				},
+			),
+		},
+		standardExample{
+			Variant: "Alert with silence",
+			Object: alert.New(
+				alert.Metadata{
+					Name:    "silenced-alert-example",
+					Project: "default",
+				},
+				alert.Spec{
+					AlertPolicy: alert.ObjectMetadata{
+						Name:        "my-alert-policy",
+						DisplayName: "My Alert Policy",
+						Project:     "default",
+					},
+					SLO: alert.ObjectMetadata{
+						Name:        "my-slo",
+						DisplayName: "My SLO",
+						Project:     "default",
+					},
+					Service: alert.ObjectMetadata{
+						Name:        "my-service",
+						DisplayName: "My Service",
+						Project:     "default",
+					},
+					Objective: alert.Objective{
+						Value:       0.99,
+						Name:        "availability-objective",
+						DisplayName: "Availability Objective",
+					},
+					Severity:            "Medium",
+					Status:              "Triggered",
+					TriggeredMetricTime: "2024-01-15T14:00:00Z",
+					TriggeredClockTime:  "2024-01-15T14:01:00Z",
+					CoolDown:            "10m0s",
+					Conditions: []alert.Condition{
+						{
+							Measurement:      "burnRate",
+							Value:            5.2,
+							AlertingWindow:   "30m",
+							LastsForDuration: "2m",
+							Operator:         "gt",
+							Status: &alert.ConditionStatus{
+								FirstMetMetricTime: "2024-01-15T13:58:00Z",
+							},
+						},
+					},
+					Silenced: &alert.Silenced{
+						From: "2024-01-15T14:00:00Z",
+						To:   "2024-01-15T16:00:00Z",
+					},
+				},
+			),
+		},
+	)
+}


### PR DESCRIPTION
## Motivation

The returned `v1alpha.Alert` now includes information about active alert silencing at the time the alert was detected. This allows users to understand why the alert was or wasn't sent.

## Summary

Added an optional section `v1alpha.Alert.Spec.Silenced`, which contains two fields: `From` and `To`. This new section represents the time period during which the given combination of alert policy and SLO was silenced.

```yaml
silenced:
    from: "2024-01-15T14:00:00Z"
    to: "2024-01-15T16:00:00Z"
```

## Testing

Apply alert silencing on some SLO and Alert Policy and confirm that new section is available for newly triggered alert.

## Release Notes

The returned `v1alpha.Alert` now includes information about active alert silencing at the time the alert was detected. This allows users to understand why the alert was or wasn't sent.
