### PR TITLE
feat: service review cycle

### DIFF
--- a/manifest/v1alpha/service/example_test.go
+++ b/manifest/v1alpha/service/example_test.go
@@ -6,24 +6,23 @@ import (
 
 	"github.com/nobl9/nobl9-go/internal/examples"
 	"github.com/nobl9/nobl9-go/manifest"
-	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 )
 
 func ExampleService() {
-	// Create the object:
+	// Create a new service:
 	myService := service.New(
 		service.Metadata{
 			Name:        "my-service",
 			DisplayName: "My Service",
 			Project:     "default",
-			Labels: v1alpha.Labels{
-				"team":   []string{"green", "orange"},
-				"region": []string{"eu-central-1"},
-			},
 		},
 		service.Spec{
 			Description: "Example service",
+			ReviewCycle: &service.ReviewCycle{
+				StartDate: "2025-01-01T00:00:00Z",
+				RRule:     "FREQ=MONTHLY;INTERVAL=1",
+			},
 		},
 	)
 	// Verify the object:
@@ -39,15 +38,12 @@ func ExampleService() {
 	// apiVersion: n9/v1alpha
 	// kind: Service
 	// metadata:
-	//   name: my-service
-	//   displayName: My Service
+	//   name: my-service-with-review
+	//   displayName: My Service with Review Cycle
 	//   project: default
-	//   labels:
-	//     region:
-	//     - eu-central-1
-	//     team:
-	//     - green
-	//     - orange
 	// spec:
-	//   description: Example service
+	//   description: Example service with review cycle
+	//   reviewCycle:
+	//     startDate: "2025-01-01T00:00:00Z"
+	//     rrule: "FREQ=MONTHLY;INTERVAL=1"
 }

--- a/manifest/v1alpha/service/example_test.go
+++ b/manifest/v1alpha/service/example_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleService() {
-	// Create a new service:
+	// Create the object:
 	myService := service.New(
 		service.Metadata{
 			Name:        "my-service",
@@ -20,7 +20,8 @@ func ExampleService() {
 		service.Spec{
 			Description: "Example service",
 			ReviewCycle: &service.ReviewCycle{
-				StartDate: "2025-01-01T00:00:00Z",
+				StartTime: "2025-01-01T10:00:00",
+				TimeZone:  "America/New_York",
 				RRule:     "FREQ=MONTHLY;INTERVAL=1",
 			},
 		},
@@ -38,12 +39,13 @@ func ExampleService() {
 	// apiVersion: n9/v1alpha
 	// kind: Service
 	// metadata:
-	//   name: my-service-with-review
-	//   displayName: My Service with Review Cycle
+	//   name: my-service
+	//   displayName: My Service
 	//   project: default
 	// spec:
-	//   description: Example service with review cycle
+	//   description: Example service
 	//   reviewCycle:
-	//     startDate: "2025-01-01T00:00:00Z"
-	//     rrule: "FREQ=MONTHLY;INTERVAL=1"
+	//     startTime: 2025-01-01T10:00:00
+	//     timeZone: America/New_York
+	//     rrule: FREQ=MONTHLY;INTERVAL=1
 }

--- a/manifest/v1alpha/service/example_test.go
+++ b/manifest/v1alpha/service/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nobl9/nobl9-go/internal/examples"
 	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 )
 
@@ -16,6 +17,10 @@ func ExampleService() {
 			Name:        "my-service",
 			DisplayName: "My Service",
 			Project:     "default",
+			Labels: v1alpha.Labels{
+				"team":   []string{"green", "orange"},
+				"region": []string{"eu-central-1"},
+			},
 		},
 		service.Spec{
 			Description: "Example service",
@@ -42,6 +47,12 @@ func ExampleService() {
 	//   name: my-service
 	//   displayName: My Service
 	//   project: default
+	//   labels:
+	//     region:
+	//     - eu-central-1
+	//     team:
+	//     - green
+	//     - orange
 	// spec:
 	//   description: Example service
 	//   reviewCycle:

--- a/manifest/v1alpha/service/service.go
+++ b/manifest/v1alpha/service/service.go
@@ -52,6 +52,8 @@ type Status struct {
 type ReviewCycleStatus struct {
 	// Next is the next scheduled review date in RFC3339 format.
 	Next string `json:"next,omitempty"`
+	// Previous is the last scheduled review date in RFC3339 format.
+	Previous string `json:"previous,omitempty"`
 }
 
 // Spec holds detailed information specific to Service.

--- a/manifest/v1alpha/service/service.go
+++ b/manifest/v1alpha/service/service.go
@@ -52,8 +52,6 @@ type Status struct {
 type ReviewCycleStatus struct {
 	// Next is the next scheduled review date in RFC3339 format.
 	Next string `json:"next,omitempty"`
-	// Previous is the last scheduled review date in RFC3339 format.
-	Previous string `json:"previous,omitempty"`
 }
 
 // Spec holds detailed information specific to Service.

--- a/manifest/v1alpha/service/service.go
+++ b/manifest/v1alpha/service/service.go
@@ -44,10 +44,27 @@ type Metadata struct {
 // Status holds dynamic fields returned when the Service is fetched from Nobl9 platform.
 // Status is not part of the static object definition.
 type Status struct {
-	SloCount int `json:"sloCount"`
+	SloCount    int                `json:"sloCount"`
+	ReviewCycle *ReviewCycleStatus `json:"reviewCycle,omitempty"`
+}
+
+// ReviewCycleStatus represents the dynamic status of a review cycle.
+type ReviewCycleStatus struct {
+	// Next is the next scheduled review date in RFC3339 format.
+	Next string `json:"next,omitempty"`
 }
 
 // Spec holds detailed information specific to Service.
 type Spec struct {
-	Description string `json:"description" validate:"description" example:"Bleeding edge web app"`
+	Description string       `json:"description" validate:"description" example:"Bleeding edge web app"`
+	ReviewCycle *ReviewCycle `json:"reviewCycle,omitempty"`
+}
+
+// ReviewCycle defines the schedule for regular service reviews.
+type ReviewCycle struct {
+	// StartDate is the initial date for the review cycle in RFC3339 format.
+	StartDate string `json:"startDate" example:"2025-01-01T00:00:00Z"`
+	// RRule is a simplified recurrence rule following the RFC5545 standard for defining recurring events.
+	// The minimum frequency is daily.
+	RRule string `json:"rrule" example:"FREQ=MONTHLY;INTERVAL=1"`
 }

--- a/manifest/v1alpha/service/service.go
+++ b/manifest/v1alpha/service/service.go
@@ -62,8 +62,10 @@ type Spec struct {
 
 // ReviewCycle defines the schedule for regular service reviews.
 type ReviewCycle struct {
-	// StartDate is the initial date for the review cycle in RFC3339 format.
-	StartDate string `json:"startDate" example:"2025-01-01T00:00:00Z"`
+	// StartTime is the initial date and time for the review cycle in RFC3339 format without timezone.
+	StartTime string `json:"startTime" example:"2020-01-21T12:30:00"`
+	// TimeZone is the IANA Time Zone Database name for the review cycle.
+	TimeZone string `json:"timeZone" example:"America/New_York"`
 	// RRule is a simplified recurrence rule following the RFC5545 standard for defining recurring events.
 	// The minimum frequency is daily.
 	RRule string `json:"rrule" example:"FREQ=MONTHLY;INTERVAL=1"`

--- a/manifest/v1alpha/service/validation.go
+++ b/manifest/v1alpha/service/validation.go
@@ -27,9 +27,9 @@ var atLeastDailyFreq = govy.NewRule(func(rule *rrule.RRule) error {
 	}
 
 	// Only allow daily, weekly, monthly, and yearly frequencies
-	allowedFreqs := []rrule.Frequency{rrule.DAILY, rrule.WEEKLY, rrule.MONTHLY, rrule.YEARLY}
+	allowedFrequencies := []rrule.Frequency{rrule.DAILY, rrule.WEEKLY, rrule.MONTHLY, rrule.YEARLY}
 	isAllowed := false
-	for _, freq := range allowedFreqs {
+	for _, freq := range allowedFrequencies {
 		if rule.Options.Freq == freq {
 			isAllowed = true
 			break

--- a/manifest/v1alpha/service/validation.go
+++ b/manifest/v1alpha/service/validation.go
@@ -1,7 +1,13 @@
 package service
 
 import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/teambition/rrule-go"
+
 	"github.com/nobl9/govy/pkg/govy"
+	"github.com/nobl9/govy/pkg/rules"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
 	"github.com/nobl9/nobl9-go/manifest"
@@ -11,6 +17,51 @@ import (
 func validate(s Service) *v1alpha.ObjectError {
 	return v1alpha.ValidateObject(validator, s, manifest.KindService)
 }
+
+// validateRFC3339 validates that a string is in RFC3339 format
+func validateRFC3339(value string) error {
+	_, err := time.Parse(time.RFC3339, value)
+	return err
+}
+
+// atLeastDailyFreq validates that RRULE frequency is daily or higher (weekly, monthly, yearly)
+var atLeastDailyFreq = govy.NewRule(func(rule *rrule.RRule) error {
+	if rule == nil {
+		return nil
+	}
+
+	if rule.Options.Count == 1 {
+		return nil
+	}
+
+	// Only allow daily, weekly, monthly, and yearly frequencies
+	allowedFreqs := []rrule.Frequency{rrule.DAILY, rrule.WEEKLY, rrule.MONTHLY, rrule.YEARLY}
+	isAllowed := false
+	for _, freq := range allowedFreqs {
+		if rule.Options.Freq == freq {
+			isAllowed = true
+			break
+		}
+	}
+
+	if !isAllowed {
+		return errors.New("frequency must be daily, weekly, monthly, or yearly")
+	}
+
+	return nil
+})
+
+var reviewCycleValidation = govy.New[ReviewCycle](
+	govy.For(func(rc ReviewCycle) string { return rc.StartDate }).
+		WithName("startDate").
+		Required().
+		Rules(rules.StringNotEmpty()).
+		Rules(govy.NewRule(validateRFC3339).WithErrorCode("invalid_rfc3339")),
+	govy.Transform(func(rc ReviewCycle) string { return rc.RRule }, rrule.StrToRRule).
+		WithName("rrule").
+		Required().
+		Rules(atLeastDailyFreq),
+)
 
 var validator = govy.New[Service](
 	validationV1Alpha.FieldRuleAPIVersion(func(s Service) manifest.Version { return s.APIVersion }),
@@ -23,4 +74,7 @@ var validator = govy.New[Service](
 		return s.Metadata.Annotations
 	}),
 	validationV1Alpha.FieldRuleSpecDescription(func(s Service) string { return s.Spec.Description }),
+	govy.ForPointer(func(s Service) *ReviewCycle { return s.Spec.ReviewCycle }).
+		WithName("spec.reviewCycle").
+		Include(reviewCycleValidation),
 )

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -168,6 +168,20 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		})
 	})
 
+	t.Run("invalid rrule - missing FREQ", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop: "spec.reviewCycle.rrule",
+			Code: "transform",
+		})
+	})
+
 	t.Run("empty rrule", func(t *testing.T) {
 		svc := validService()
 		svc.Spec.ReviewCycle = &ReviewCycle{
@@ -182,293 +196,94 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		})
 	})
 
-	t.Run("rrule frequency validation", func(t *testing.T) {
-		tests := []struct {
-			name        string
-			rrule       string
-			expectError bool
-			expectedMsg string
-		}{
-			{
-				name:        "missing FREQ",
-				rrule:       "INTERVAL=1",
-				expectError: true,
-				expectedMsg: "RRULE property FREQ is required",
-			},
-			{
-				name:        "hourly frequency not allowed",
-				rrule:       "FREQ=HOURLY;INTERVAL=1",
-				expectError: true,
-				expectedMsg: "frequency must be DAILY, WEEKLY, MONTHLY, or YEARLY",
-			},
-			{
-				name:        "minutely frequency not allowed",
-				rrule:       "FREQ=MINUTELY;INTERVAL=60",
-				expectError: true,
-				expectedMsg: "frequency must be DAILY, WEEKLY, MONTHLY, or YEARLY",
-			},
-			{
-				name:        "daily frequency allowed",
-				rrule:       "FREQ=DAILY;INTERVAL=1",
-				expectError: false,
-			},
-			{
-				name:        "weekly frequency allowed",
-				rrule:       "FREQ=WEEKLY;INTERVAL=1",
-				expectError: false,
-			},
-			{
-				name:        "monthly frequency allowed",
-				rrule:       "FREQ=MONTHLY;INTERVAL=1",
-				expectError: false,
-			},
-			{
-				name:        "yearly frequency allowed",
-				rrule:       "FREQ=YEARLY;INTERVAL=1",
-				expectError: false,
-			},
-			{
-				name:        "single occurrence with any frequency not allowed",
-				rrule:       "FREQ=HOURLY;COUNT=1",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "single occurrence with daily frequency not allowed",
-				rrule:       "FREQ=DAILY;COUNT=1",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "multiple limited occurrences not allowed",
-				rrule:       "FREQ=WEEKLY;COUNT=5",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "zero interval not allowed",
-				rrule:       "FREQ=DAILY;INTERVAL=0",
-				expectError: false, // rrule library accepts 0 and converts to 1
-			},
-			{
-				name:        "negative interval not allowed",
-				rrule:       "FREQ=WEEKLY;INTERVAL=-1",
-				expectError: true,
-				expectedMsg: "interval must be greater than 0",
-			},
-			{
-				name:        "secondly frequency not allowed",
-				rrule:       "FREQ=SECONDLY;INTERVAL=1",
-				expectError: true,
-				expectedMsg: "frequency must be DAILY, WEEKLY, MONTHLY, or YEARLY",
-			},
+	t.Run("invalid rrule - hourly frequency not allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=HOURLY;INTERVAL=1",
 		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				svc := validService()
-				svc.Spec.ReviewCycle = &ReviewCycle{
-					StartTime: "2023-01-01T00:00:00",
-					TimeZone:  "UTC",
-					RRule:     tt.rrule,
-				}
-				err := validate(svc)
-
-				if tt.expectError {
-					testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-						Prop:    "spec.reviewCycle.rrule",
-						Message: tt.expectedMsg,
-					})
-				} else {
-					testutils.AssertNoError(t, svc, err)
-				}
-			})
-		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop:    "spec.reviewCycle.rrule",
+			Message: "rrule frequency must be at least DAILY",
+		})
 	})
 
-	t.Run("rrule complex validation scenarios", func(t *testing.T) {
-		tests := []struct {
-			name        string
-			rrule       string
-			expectError bool
-			expectedMsg string
-		}{
-			{
-				name:        "daily with complex by-rules allowed",
-				rrule:       "FREQ=DAILY;BYHOUR=9,17;BYMINUTE=0",
-				expectError: false,
-			},
-			{
-				name:        "weekly with multiple weekdays allowed",
-				rrule:       "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=10;BYMINUTE=30",
-				expectError: false,
-			},
-			{
-				name:        "monthly with specific month days allowed",
-				rrule:       "FREQ=MONTHLY;BYMONTHDAY=1,15;BYHOUR=14;BYMINUTE=0",
-				expectError: false,
-			},
-			{
-				name:        "yearly with specific month and day allowed",
-				rrule:       "FREQ=YEARLY;BYMONTH=1,6,12;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0",
-				expectError: false,
-			},
-			{
-				name:        "daily with high interval allowed",
-				rrule:       "FREQ=DAILY;INTERVAL=30",
-				expectError: false,
-			},
-			{
-				name:        "weekly with high interval allowed",
-				rrule:       "FREQ=WEEKLY;INTERVAL=12;BYDAY=MO",
-				expectError: false,
-			},
-			{
-				name:        "monthly with high interval allowed",
-				rrule:       "FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=15",
-				expectError: false,
-			},
-			{
-				name:        "yearly with interval allowed",
-				rrule:       "FREQ=YEARLY;INTERVAL=2;BYMONTH=6;BYMONTHDAY=1",
-				expectError: false,
-			},
-			{
-				name:        "hourly with until date not allowed",
-				rrule:       "FREQ=HOURLY;UNTIL=20251231T235959Z",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "daily with until date not allowed",
-				rrule:       "FREQ=DAILY;UNTIL=20251231T235959Z",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "weekly with until and count not allowed",
-				rrule:       "FREQ=WEEKLY;UNTIL=20251231T235959Z;COUNT=10",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "monthly with count and no until not allowed",
-				rrule:       "FREQ=MONTHLY;COUNT=12;BYMONTHDAY=1",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "complex daily pattern without count allowed",
-				rrule:       "FREQ=DAILY;INTERVAL=2;BYHOUR=9,13,17;BYMINUTE=0,30",
-				expectError: false,
-			},
-			{
-				name:        "complex weekly pattern without count allowed",
-				rrule:       "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9;BYMINUTE=0",
-				expectError: false,
-			},
+	t.Run("invalid rrule - minutely frequency not allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=MINUTELY;INTERVAL=60",
 		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				svc := validService()
-				svc.Spec.ReviewCycle = &ReviewCycle{
-					StartTime: "2023-01-01T00:00:00",
-					TimeZone:  "UTC",
-					RRule:     tt.rrule,
-				}
-				err := validate(svc)
-
-				if tt.expectError {
-					testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-						Prop:    "spec.reviewCycle.rrule",
-						Message: tt.expectedMsg,
-					})
-				} else {
-					testutils.AssertNoError(t, svc, err)
-				}
-			})
-		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop:    "spec.reviewCycle.rrule",
+			Message: "rrule frequency must be at least DAILY",
+		})
 	})
 
-	t.Run("rrule edge cases and boundary conditions", func(t *testing.T) {
-		tests := []struct {
-			name        string
-			rrule       string
-			expectError bool
-			expectedMsg string
-		}{
-			{
-				name:        "malformed rrule",
-				rrule:       "INVALID_RRULE_FORMAT",
-				expectError: true,
-				expectedMsg: "wrong format",
-			},
-			{
-				name:        "empty frequency value",
-				rrule:       "FREQ=;INTERVAL=1",
-				expectError: true,
-				expectedMsg: "FREQ option has no value",
-			},
-			{
-				name:        "invalid frequency value",
-				rrule:       "FREQ=INVALID;INTERVAL=1",
-				expectError: true,
-				expectedMsg: "undefined frequency: INVALID",
-			},
-			{
-				name:        "count with zero value not allowed",
-				rrule:       "FREQ=DAILY;COUNT=0",
-				expectError: false, // rrule library accepts 0 but our validator should catch positive count
-			},
-			{
-				name:        "count with negative value not allowed",
-				rrule:       "FREQ=WEEKLY;COUNT=-5",
-				expectError: false, // rrule library may handle this differently
-			},
-			{
-				name:        "count with positive value not allowed",
-				rrule:       "FREQ=DAILY;COUNT=10",
-				expectError: true,
-				expectedMsg: "rrule must have continuous occurrences",
-			},
-			{
-				name:        "very high interval allowed",
-				rrule:       "FREQ=YEARLY;INTERVAL=100",
-				expectError: false,
-			},
-			{
-				name:        "daily with valid bysetpos",
-				rrule:       "FREQ=DAILY;BYSETPOS=1;BYHOUR=9;BYMINUTE=0",
-				expectError: false,
-			},
-			{
-				name:        "weekly with valid wkst",
-				rrule:       "FREQ=WEEKLY;WKST=MO;BYDAY=FR",
-				expectError: false,
-			},
+	t.Run("valid rrule - daily frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=DAILY;INTERVAL=1",
 		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				svc := validService()
-				svc.Spec.ReviewCycle = &ReviewCycle{
-					StartTime: "2023-01-01T00:00:00",
-					TimeZone:  "UTC",
-					RRule:     tt.rrule,
-				}
-				err := validate(svc)
-
-				if tt.expectError {
-					testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-						Prop:    "spec.reviewCycle.rrule",
-						Message: tt.expectedMsg,
-					})
-				} else {
-					testutils.AssertNoError(t, svc, err)
-				}
-			})
+	t.Run("valid rrule - weekly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=WEEKLY;INTERVAL=1",
 		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - monthly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - yearly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=YEARLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - single occurrence with any frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=HOURLY;COUNT=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("nil reviewCycle should be valid", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = nil
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
 	})
 }
 

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -100,6 +100,153 @@ func TestValidate_Spec(t *testing.T) {
 	})
 }
 
+func TestValidate_ReviewCycle(t *testing.T) {
+	t.Run("valid reviewCycle", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("invalid startDate - not RFC3339", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop: "spec.reviewCycle.startDate",
+			Code: "invalid_rfc3339",
+		})
+	})
+
+	t.Run("empty startDate", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop: "spec.reviewCycle.startDate",
+			Code: rules.ErrorCodeRequired,
+		})
+	})
+
+	t.Run("invalid rrule - missing FREQ", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop: "spec.reviewCycle.rrule",
+			Code: "transform",
+		})
+	})
+
+	t.Run("empty rrule", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop: "spec.reviewCycle.rrule",
+			Code: rules.ErrorCodeRequired,
+		})
+	})
+
+	t.Run("invalid rrule - hourly frequency not allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=HOURLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop:    "spec.reviewCycle.rrule",
+			Message: "frequency must be daily, weekly, monthly, or yearly",
+		})
+	})
+
+	t.Run("invalid rrule - minutely frequency not allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=MINUTELY;INTERVAL=60",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop:    "spec.reviewCycle.rrule",
+			Message: "frequency must be daily, weekly, monthly, or yearly",
+		})
+	})
+
+	t.Run("valid rrule - daily frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=DAILY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - weekly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=WEEKLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - monthly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - yearly frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=YEARLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("valid rrule - single occurrence with any frequency allowed", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartDate: "2023-01-01T00:00:00Z",
+			RRule:     "FREQ=HOURLY;COUNT=1",
+		}
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+
+	t.Run("nil reviewCycle should be valid", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = nil
+		err := validate(svc)
+		testutils.AssertNoError(t, svc, err)
+	})
+}
+
 func validService() Service {
 	return New(
 		Metadata{

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -228,8 +228,143 @@ func TestValidate_ReviewCycle(t *testing.T) {
 				expectError: false,
 			},
 			{
-				name:        "single occurrence with any frequency allowed",
+				name:        "single occurrence with any frequency not allowed",
 				rrule:       "FREQ=HOURLY;COUNT=1",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "single occurrence with daily frequency not allowed",
+				rrule:       "FREQ=DAILY;COUNT=1",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "multiple limited occurrences not allowed",
+				rrule:       "FREQ=WEEKLY;COUNT=5",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "zero interval not allowed",
+				rrule:       "FREQ=DAILY;INTERVAL=0",
+				expectError: false, // rrule library accepts 0 and converts to 1
+			},
+			{
+				name:        "negative interval not allowed",
+				rrule:       "FREQ=WEEKLY;INTERVAL=-1",
+				expectError: true,
+				expectedMsg: "interval must be greater than 0",
+			},
+			{
+				name:        "secondly frequency not allowed",
+				rrule:       "FREQ=SECONDLY;INTERVAL=1",
+				expectError: true,
+				expectedMsg: "frequency must be DAILY, WEEKLY, MONTHLY, or YEARLY",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				svc := validService()
+				svc.Spec.ReviewCycle = &ReviewCycle{
+					StartTime: "2023-01-01T00:00:00",
+					TimeZone:  "UTC",
+					RRule:     tt.rrule,
+				}
+				err := validate(svc)
+
+				if tt.expectError {
+					testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+						Prop:    "spec.reviewCycle.rrule",
+						Message: tt.expectedMsg,
+					})
+				} else {
+					testutils.AssertNoError(t, svc, err)
+				}
+			})
+		}
+	})
+
+	t.Run("rrule complex validation scenarios", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			rrule       string
+			expectError bool
+			expectedMsg string
+		}{
+			{
+				name:        "daily with complex by-rules allowed",
+				rrule:       "FREQ=DAILY;BYHOUR=9,17;BYMINUTE=0",
+				expectError: false,
+			},
+			{
+				name:        "weekly with multiple weekdays allowed",
+				rrule:       "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=10;BYMINUTE=30",
+				expectError: false,
+			},
+			{
+				name:        "monthly with specific month days allowed",
+				rrule:       "FREQ=MONTHLY;BYMONTHDAY=1,15;BYHOUR=14;BYMINUTE=0",
+				expectError: false,
+			},
+			{
+				name:        "yearly with specific month and day allowed",
+				rrule:       "FREQ=YEARLY;BYMONTH=1,6,12;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0",
+				expectError: false,
+			},
+			{
+				name:        "daily with high interval allowed",
+				rrule:       "FREQ=DAILY;INTERVAL=30",
+				expectError: false,
+			},
+			{
+				name:        "weekly with high interval allowed",
+				rrule:       "FREQ=WEEKLY;INTERVAL=12;BYDAY=MO",
+				expectError: false,
+			},
+			{
+				name:        "monthly with high interval allowed",
+				rrule:       "FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=15",
+				expectError: false,
+			},
+			{
+				name:        "yearly with interval allowed",
+				rrule:       "FREQ=YEARLY;INTERVAL=2;BYMONTH=6;BYMONTHDAY=1",
+				expectError: false,
+			},
+			{
+				name:        "hourly with until date not allowed",
+				rrule:       "FREQ=HOURLY;UNTIL=20251231T235959Z",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "daily with until date not allowed",
+				rrule:       "FREQ=DAILY;UNTIL=20251231T235959Z",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "weekly with until and count not allowed",
+				rrule:       "FREQ=WEEKLY;UNTIL=20251231T235959Z;COUNT=10",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "monthly with count and no until not allowed",
+				rrule:       "FREQ=MONTHLY;COUNT=12;BYMONTHDAY=1",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "complex daily pattern without count allowed",
+				rrule:       "FREQ=DAILY;INTERVAL=2;BYHOUR=9,13,17;BYMINUTE=0,30",
+				expectError: false,
+			},
+			{
+				name:        "complex weekly pattern without count allowed",
+				rrule:       "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9;BYMINUTE=0",
 				expectError: false,
 			},
 		}
@@ -256,11 +391,84 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 	})
 
-	t.Run("nil reviewCycle should be valid", func(t *testing.T) {
-		svc := validService()
-		svc.Spec.ReviewCycle = nil
-		err := validate(svc)
-		testutils.AssertNoError(t, svc, err)
+	t.Run("rrule edge cases and boundary conditions", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			rrule       string
+			expectError bool
+			expectedMsg string
+		}{
+			{
+				name:        "malformed rrule",
+				rrule:       "INVALID_RRULE_FORMAT",
+				expectError: true,
+				expectedMsg: "wrong format",
+			},
+			{
+				name:        "empty frequency value",
+				rrule:       "FREQ=;INTERVAL=1",
+				expectError: true,
+				expectedMsg: "FREQ option has no value",
+			},
+			{
+				name:        "invalid frequency value",
+				rrule:       "FREQ=INVALID;INTERVAL=1",
+				expectError: true,
+				expectedMsg: "undefined frequency: INVALID",
+			},
+			{
+				name:        "count with zero value not allowed",
+				rrule:       "FREQ=DAILY;COUNT=0",
+				expectError: false, // rrule library accepts 0 but our validator should catch positive count
+			},
+			{
+				name:        "count with negative value not allowed",
+				rrule:       "FREQ=WEEKLY;COUNT=-5",
+				expectError: false, // rrule library may handle this differently
+			},
+			{
+				name:        "count with positive value not allowed",
+				rrule:       "FREQ=DAILY;COUNT=10",
+				expectError: true,
+				expectedMsg: "rrule must have continuous occurrences",
+			},
+			{
+				name:        "very high interval allowed",
+				rrule:       "FREQ=YEARLY;INTERVAL=100",
+				expectError: false,
+			},
+			{
+				name:        "daily with valid bysetpos",
+				rrule:       "FREQ=DAILY;BYSETPOS=1;BYHOUR=9;BYMINUTE=0",
+				expectError: false,
+			},
+			{
+				name:        "weekly with valid wkst",
+				rrule:       "FREQ=WEEKLY;WKST=MO;BYDAY=FR",
+				expectError: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				svc := validService()
+				svc.Spec.ReviewCycle = &ReviewCycle{
+					StartTime: "2023-01-01T00:00:00",
+					TimeZone:  "UTC",
+					RRule:     tt.rrule,
+				}
+				err := validate(svc)
+
+				if tt.expectError {
+					testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+						Prop:    "spec.reviewCycle.rrule",
+						Message: tt.expectedMsg,
+					})
+				} else {
+					testutils.AssertNoError(t, svc, err)
+				}
+			})
+		}
 	})
 }
 

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -140,6 +140,26 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		})
 	})
 
+	t.Run("blank chars startTime", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "    ",
+			TimeZone:  "UTC",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec.reviewCycle.startTime",
+				Code: rules.ErrorCodeStringNotEmpty,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.reviewCycle.startTime",
+				Code: "string_date_time",
+			},
+		)
+	})
+
 	t.Run("empty timeZone", func(t *testing.T) {
 		svc := validService()
 		svc.Spec.ReviewCycle = &ReviewCycle{
@@ -152,6 +172,26 @@ func TestValidate_ReviewCycle(t *testing.T) {
 			Prop: "spec.reviewCycle.timeZone",
 			Code: rules.ErrorCodeRequired,
 		})
+	})
+
+	t.Run("blank chars timeZone", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "    ",
+			RRule:     "FREQ=MONTHLY;INTERVAL=1",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec.reviewCycle.timeZone",
+				Code: rules.ErrorCodeStringNotEmpty,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.reviewCycle.timeZone",
+				Code: rules.ErrorCodeStringTimeZone,
+			},
+		)
 	})
 
 	t.Run("invalid timeZone", func(t *testing.T) {
@@ -193,6 +233,21 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
 			Prop: "spec.reviewCycle.rrule",
 			Code: rules.ErrorCodeRequired,
+		})
+	})
+
+	t.Run("blank chars rrule", func(t *testing.T) {
+		svc := validService()
+		svc.Spec.ReviewCycle = &ReviewCycle{
+			StartTime: "2023-01-01T00:00:00",
+			TimeZone:  "UTC",
+			RRule:     "   ",
+		}
+		err := validate(svc)
+		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
+			Prop:    "spec.reviewCycle.rrule",
+			Message: "wrong format",
+			Code:    "transform",
 		})
 	})
 

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -193,7 +193,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 				name:        "missing FREQ",
 				rrule:       "INTERVAL=1",
 				expectError: true,
-				expectedMsg: "missing FREQ in rrule",
+				expectedMsg: "RRULE property FREQ is required",
 			},
 			{
 				name:        "hourly frequency not allowed",


### PR DESCRIPTION
## Motivation

Add `reviewCycle` to Service kind spec.

## Summary

This pull request introduces a new `ReviewCycle` feature for services, enabling the specification and validation of recurring review schedules. The changes span the addition of new fields, validation logic, and comprehensive test cases to ensure correctness.

### New `ReviewCycle` Feature:

* **Definition of `ReviewCycle`:**
  - Added a new `ReviewCycle` struct to define recurring review schedules with fields for `StartTime`, `TimeZone`, and `RRule`. (`manifest/v1alpha/service/service.go`, [manifest/v1alpha/service/service.goR48-R73](diffhunk://#diff-38c42076c670a2a2528ffa147c38baedafa53df7b5e71fc8d218931f7988b483R48-R73))
  - Introduced a corresponding `ReviewCycleStatus` struct to track the dynamic status of review cycles, including `Next` and `Previous` review dates. (`manifest/v1alpha/service/service.go`, [manifest/v1alpha/service/service.goR48-R73](diffhunk://#diff-38c42076c670a2a2528ffa147c38baedafa53df7b5e71fc8d218931f7988b483R48-R73))

* **Integration into Service Specification:**
  - Updated the `Spec` struct to include an optional `ReviewCycle` field. (`manifest/v1alpha/service/service.go`, [manifest/v1alpha/service/service.goR48-R73](diffhunk://#diff-38c42076c670a2a2528ffa147c38baedafa53df7b5e71fc8d218931f7988b483R48-R73))
  - Added example usage of `ReviewCycle` in `example_test.go` to demonstrate its integration into service definitions. (`manifest/v1alpha/service/example_test.go`, [[1]](diffhunk://#diff-43c6db24bc2f728c214dadb88518bec875a8687a1e5423e89d1c985954759c5bR27-R31) [[2]](diffhunk://#diff-43c6db24bc2f728c214dadb88518bec875a8687a1e5423e89d1c985954759c5bR58-R61)

### Validation Enhancements:

* **Validation Rules for `ReviewCycle`:**
  - Implemented validation rules to ensure `StartTime` is a valid RFC3339 datetime, `TimeZone` is a valid IANA time zone, and `RRule` adheres to a minimum frequency of daily. (`manifest/v1alpha/service/validation.go`, [manifest/v1alpha/service/validation.goR19-R62](diffhunk://#diff-67805f9564f05eb17d8489735ce32f944100fc5f7fb8e43c02ed7263261789dfR19-R62))
  - Added a reusable `atLeastDailyFreq` rule to enforce allowed recurrence frequencies. (`manifest/v1alpha/service/validation.go`, [manifest/v1alpha/service/validation.goR19-R62](diffhunk://#diff-67805f9564f05eb17d8489735ce32f944100fc5f7fb8e43c02ed7263261789dfR19-R62))

* **Integration into Service Validation:**
  - Updated the `validator` for the `Service` object to include `ReviewCycle` validation. (`manifest/v1alpha/service/validation.go`, [manifest/v1alpha/service/validation.goR74-R76](diffhunk://#diff-67805f9564f05eb17d8489735ce32f944100fc5f7fb8e43c02ed7263261789dfR74-R76))

### Testing:

* **Unit Tests for Validation:**
  - Added comprehensive test cases for `ReviewCycle` validation, covering valid configurations, invalid `StartTime` formats, empty fields, invalid time zones, and invalid/unsupported `RRule` frequencies. (`manifest/v1alpha/service/validation_test.go`, [manifest/v1alpha/service/validation_test.goR103-R266](diffhunk://#diff-6c1c58938fb1609f9bfabd13a723d078e1f2dc9f5882f9a3257a1cbc4ab0b8e4R103-R266))
  - Verified that a `nil` `ReviewCycle` is valid, ensuring backward compatibility. (`manifest/v1alpha/service/validation_test.go`, [manifest/v1alpha/service/validation_test.goR103-R266](diffhunk://#diff-6c1c58938fb1609f9bfabd13a723d078e1f2dc9f5882f9a3257a1cbc4ab0b8e4R103-R266))


## Release Notes

- Add `reviewCycle` to Service kind spec.

```
apiVersion: n9/v1alpha
kind: Service
metadata:
  name: prometheus
  project: default
spec:
  description: Prometheus
  reviewCycle:
    startTime: "2025-01-01T11:00:00"         // Date with time in RFC3339 format without time zone.
    timeZone: "Europe/Warsaw"                // Name as in IANA Time Zone Database.
    rrule: "FREQ=WEEKLY;BYDAY=MO;INTERVAL=4" // Schedule in RFC5545 format. The minimum frequency is daily.
```
