### PR TITLE
feat: [PC-17334] - add review to the SLO kind Status

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -183,6 +183,7 @@ type Status struct {
 	ObjectiveIndicatorValidation []*ObjectiveIndicatorValidationStatus `json:"objectiveIndicatorValidation,omitempty"`
 	// Deprecated: use Status.Replay instead.
 	ReplayStatus *ReplayStatus `json:"timeTravel,omitempty"`
+	ReviewStatus *ReviewStatus `json:"review,omitempty"`
 }
 
 type ObjectiveIndicatorValidationStatus struct {
@@ -241,4 +242,12 @@ type ReplayStatus struct {
 	Unit        string `json:"unit"`
 	Value       int    `json:"value"`
 	StartTime   string `json:"startTime"`
+}
+
+type ReviewStatus struct {
+	Status        string    `json:"status"`
+	ReviewDueDate time.Time `json:"reviewDueDate"`
+	ReviewedBy    *string   `json:"reviewedBy,omitempty"`
+	ReviewedAt    *string   `json:"reviewedAt,omitempty"`
+	AnnotationsID *string   `json:"annotationsID,omitempty"`
 }


### PR DESCRIPTION
## Motivation

We need to present to Users the status of Review

## Summary

Add `ReviewStatus *ReviewStatus` to SLO Status with:
```go
type ReviewStatus struct {
	Status        string    `json:"status"`
	ReviewDueDate time.Time `json:"reviewDueDate"`
	ReviewedBy    *string   `json:"reviewedBy,omitempty"`
	ReviewedAt    *string   `json:"reviewedAt,omitempty"`
	AnnotationsID *string   `json:"annotationsID,omitempty"`
}
```



## Release Notes

Extend SLO status with Review Status
