### PR TITLE
chore: add not_started status to SLO Review

### DIFF
--- a/manifest/v1alpha/slo/slo.go
+++ b/manifest/v1alpha/slo/slo.go
@@ -245,9 +245,9 @@ type ReplayStatus struct {
 }
 
 type ReviewStatus struct {
-	Status         string    `json:"status"`
-	DueDate        time.Time `json:"dueDate"`
-	ReviewedBy     string    `json:"reviewedBy,omitempty,omitzero"`
-	ReviewedAt     time.Time `json:"reviewedAt,omitzero"`
-	AnnotationName string    `json:"annotationName,omitempty,omitzero"`
+	Status         string `json:"status"`
+	DueDate        string `json:"dueDate,omitzero"`
+	ReviewedBy     string `json:"reviewedBy,omitzero"`
+	ReviewedAt     string `json:"reviewedAt,omitzero"`
+	AnnotationName string `json:"annotationName,omitzero"`
 }

--- a/sdk/endpoints/objects/v1/slos/review/review.go
+++ b/sdk/endpoints/objects/v1/slos/review/review.go
@@ -10,7 +10,7 @@ const (
 	StatusReviewed   = "reviewed"
 	StatusSkipped    = "skipped"
 	StatusOverdue    = "overdue"
-	StatusNotStarted = "not_started"
+	StatusNotStarted = "notStarted"
 )
 
 type SubmitReviewPayload struct {

--- a/sdk/endpoints/objects/v1/slos/review/review.go
+++ b/sdk/endpoints/objects/v1/slos/review/review.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	StatusPending  = "pending"
-	StatusReviewed = "reviewed"
-	StatusSkipped  = "skipped"
-	StatusOverdue  = "overdue"
+	StatusPending    = "pending"
+	StatusReviewed   = "reviewed"
+	StatusSkipped    = "skipped"
+	StatusOverdue    = "overdue"
+	StatusNotStarted = "not_started"
 )
 
 type SubmitReviewPayload struct {
@@ -33,6 +34,7 @@ var validator = govy.New(
 			StatusPending,
 			StatusReviewed,
 			StatusOverdue,
+			StatusNotStarted,
 		)),
 	govy.For(func(r SubmitReviewPayload) string { return r.Note }).
 		OmitEmpty().


### PR DESCRIPTION
## Summary

Add `not_started` status to submit Review payload definition. 

