### PR TITLE
feat: add support for SumoLogic single-query good-over-total metrics [PC-17863]

### DIFF
--- a/internal/manifest/v1alpha/slo/slo.go
+++ b/internal/manifest/v1alpha/slo/slo.go
@@ -13,4 +13,5 @@ var BadOverTotalEnabledSources = []v1alpha.DataSourceType{
 var SingleQueryGoodOverTotalEnabledSources = []v1alpha.DataSourceType{
 	v1alpha.Splunk,
 	v1alpha.Honeycomb,
+	v1alpha.SumoLogic,
 }

--- a/manifest/v1alpha/examples/slo.go
+++ b/manifest/v1alpha/examples/slo.go
@@ -93,6 +93,9 @@ var customMetricExamples = map[v1alpha.DataSourceType]map[metricVariant][]metric
 			metricSubVariantSumoLogicMetrics,
 			metricSubVariantSumoLogicLogs,
 		},
+		metricVariantSingleQueryGoodRatio: []metricSubVariant{
+			metricSubVariantSumoLogicLogs,
+		},
 	},
 	v1alpha.Instana: {
 		metricVariantThreshold: []metricSubVariant{

--- a/manifest/v1alpha/examples/slo_variants.go
+++ b/manifest/v1alpha/examples/slo_variants.go
@@ -696,26 +696,26 @@ func (s sloExample) generateMetricVariant(slo v1alphaSLO.SLO) v1alphaSLO.SLO {
 		switch s.MetricVariant + s.MetricSubVariant {
 		case metricVariantThreshold + metricSubVariantSumoLogicMetrics:
 			return setThresholdMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type:         ptr("metrics"),
+				Type:         ptr(v1alphaSLO.SumoLogicTypeMetric),
 				Rollup:       ptr("Avg"),
 				Quantization: ptr("15s"),
 				Query:        ptr(`metric=CPU_Usage`),
 			}))
 		case metricVariantGoodRatio + metricSubVariantSumoLogicMetrics:
 			return setGoodOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type:         ptr("metrics"),
+				Type:         ptr(v1alphaSLO.SumoLogicTypeMetric),
 				Rollup:       ptr("Avg"),
 				Quantization: ptr("15s"),
 				Query:        ptr(`metric=Mem_Used`),
 			}), newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type:         ptr("metrics"),
+				Type:         ptr(v1alphaSLO.SumoLogicTypeMetric),
 				Rollup:       ptr("Avg"),
 				Quantization: ptr("15s"),
 				Query:        ptr(`metric=Mem_Total`),
 			}))
 		case metricVariantThreshold + metricSubVariantSumoLogicLogs:
 			return setThresholdMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type: ptr("logs"),
+				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
 				Query: ptr(`_sourceCategory=uploads/nginx
 | timeslice 1m as n9_time
 | parse "HTTP/1.1" * * " as (status_code, size, tail)
@@ -725,7 +725,7 @@ func (s sloExample) generateMetricVariant(slo v1alphaSLO.SLO) v1alphaSLO.SLO {
 			}))
 		case metricVariantGoodRatio + metricSubVariantSumoLogicLogs:
 			return setGoodOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type: ptr("logs"),
+				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
 				Query: ptr(`_collector="app-cluster" _source="logs"
 | json "log"
 | timeslice 15s as n9_time
@@ -734,12 +734,24 @@ func (s sloExample) generateMetricVariant(slo v1alphaSLO.SLO) v1alphaSLO.SLO {
 | sum(log_level_not_error) as n9_value by n9_time
 | sort by n9_time asc`),
 			}), newMetricSpec(v1alphaSLO.SumoLogicMetric{
-				Type: ptr("logs"),
+				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
 				Query: ptr(`_collector="app-cluster" _source="logs"
 | json "log"
 | timeslice 15s as n9_time
 | parse "level=* *" as (log_level, tail)
 | count(*) as n9_value by n9_time
+| sort by n9_time asc`),
+			}))
+		case metricVariantSingleQueryGoodRatio + metricSubVariantSumoLogicLogs:
+			return setSingleQueryGoodOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
+				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
+				Query: ptr(`_collector="n9-dev-tooling-cluster" _source="logs"
+| json "log"
+| timeslice 15s as n9_time
+| parse "level=* *" as (log_level, tail)
+| if (log_level = "info", 1, 0) as good
+| 1 as total
+| sum(good) as n9_good, sum(total) as n9_total by n9_time
 | sort by n9_time asc`),
 			}))
 		}

--- a/manifest/v1alpha/slo/examples/sumo-logic.yaml
+++ b/manifest/v1alpha/slo/examples/sumo-logic.yaml
@@ -626,6 +626,302 @@
         - name: slack-notification
           project: default
         alertAfter: 1h
+# Metric type: single query good over total
+# Metric variant: logs
+# Budgeting method: Occurrences
+# Time window type: Calendar
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Sumo Logic SLO
+    indicator:
+      metricSource:
+        name: sumo-logic
+        project: default
+        kind: Agent
+    budgetingMethod: Occurrences
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      countMetrics:
+        incremental: true
+        goodTotal:
+          sumoLogic:
+            type: logs
+            query: |-
+              _collector="n9-dev-tooling-cluster" _source="logs"
+              | json "log"
+              | timeslice 15s as n9_time
+              | parse "level=* *" as (log_level, tail)
+              | if (log_level = "info", 1, 0) as good
+              | 1 as total
+              | sum(good) as n9_good, sum(total) as n9_total by n9_time
+              | sort by n9_time asc
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Month
+      count: 1
+      isRolling: false
+      calendar:
+        startTime: "2022-12-01 00:00:00"
+        timeZone: UTC
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: single query good over total
+# Metric variant: logs
+# Budgeting method: Occurrences
+# Time window type: Rolling
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Sumo Logic SLO
+    indicator:
+      metricSource:
+        name: sumo-logic
+        project: default
+        kind: Agent
+    budgetingMethod: Occurrences
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      countMetrics:
+        incremental: true
+        goodTotal:
+          sumoLogic:
+            type: logs
+            query: |-
+              _collector="n9-dev-tooling-cluster" _source="logs"
+              | json "log"
+              | timeslice 15s as n9_time
+              | parse "level=* *" as (log_level, tail)
+              | if (log_level = "info", 1, 0) as good
+              | 1 as total
+              | sum(good) as n9_good, sum(total) as n9_total by n9_time
+              | sort by n9_time asc
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Hour
+      count: 1
+      isRolling: true
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: single query good over total
+# Metric variant: logs
+# Budgeting method: Timeslices
+# Time window type: Calendar
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Sumo Logic SLO
+    indicator:
+      metricSource:
+        name: sumo-logic
+        project: default
+        kind: Agent
+    budgetingMethod: Timeslices
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      timeSliceTarget: 0.9
+      countMetrics:
+        incremental: true
+        goodTotal:
+          sumoLogic:
+            type: logs
+            query: |-
+              _collector="n9-dev-tooling-cluster" _source="logs"
+              | json "log"
+              | timeslice 15s as n9_time
+              | parse "level=* *" as (log_level, tail)
+              | if (log_level = "info", 1, 0) as good
+              | 1 as total
+              | sum(good) as n9_good, sum(total) as n9_total by n9_time
+              | sort by n9_time asc
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Month
+      count: 1
+      isRolling: false
+      calendar:
+        startTime: "2022-12-01 00:00:00"
+        timeZone: UTC
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: single query good over total
+# Metric variant: logs
+# Budgeting method: Timeslices
+# Time window type: Rolling
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Sumo Logic SLO
+    indicator:
+      metricSource:
+        name: sumo-logic
+        project: default
+        kind: Agent
+    budgetingMethod: Timeslices
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      timeSliceTarget: 0.9
+      countMetrics:
+        incremental: true
+        goodTotal:
+          sumoLogic:
+            type: logs
+            query: |-
+              _collector="n9-dev-tooling-cluster" _source="logs"
+              | json "log"
+              | timeslice 15s as n9_time
+              | parse "level=* *" as (log_level, tail)
+              | if (log_level = "info", 1, 0) as good
+              | 1 as total
+              | sum(good) as n9_good, sum(total) as n9_total by n9_time
+              | sort by n9_time asc
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Hour
+      count: 1
+      isRolling: true
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
 # Metric type: threshold
 # Metric variant: logs
 # Budgeting method: Occurrences

--- a/manifest/v1alpha/slo/metrics_sumo_logic.go
+++ b/manifest/v1alpha/slo/metrics_sumo_logic.go
@@ -114,6 +114,15 @@ var (
 	sumoLogicSingleQueryLogsTypeValidation = getSumoLogicLogsTypeValidation(true)
 )
 
+var sumoLogicSingleQueryMetricsTypeValidation = govy.New[SumoLogicMetric](
+	govy.For(govy.GetSelf[SumoLogicMetric]()).
+		Rules(rules.Forbidden[SumoLogicMetric]()),
+).
+	When(
+		func(m SumoLogicMetric) bool { return m.Type != nil && *m.Type == SumoLogicTypeMetric },
+		govy.WhenDescription("type is '%s'", SumoLogicTypeMetric),
+	)
+
 func getSumoLogicLogsTypeValidation(isSingleQuery bool) govy.Validator[SumoLogicMetric] {
 	var valueRule govy.Rule[string]
 	switch isSingleQuery {

--- a/manifest/v1alpha/slo/metrics_sumo_logic_test.go
+++ b/manifest/v1alpha/slo/metrics_sumo_logic_test.go
@@ -642,3 +642,18 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 		})
 	}
 }
+
+func TestSumoLogic_MetricsType_SingleQuery(t *testing.T) {
+	t.Run("unsupported single query", func(t *testing.T) {
+		slo := validSingleQueryGoodOverTotalCountMetricSLO(v1alpha.SumoLogic)
+		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.SumoLogic.Type = ptr(SumoLogicTypeMetric)
+
+		err := validate(slo)
+		testutils.AssertContainsErrors(t, slo, err, 1,
+			testutils.ExpectedError{
+				Prop: "spec.objectives[0].countMetrics.goodTotal.sumoLogic",
+				Code: rules.ErrorCodeForbidden,
+			},
+		)
+	})
+}

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -152,7 +152,10 @@ var singleQueryMetricSpecValidation = govy.New[MetricSpec](
 		Include(honeycombSingleQueryValidation),
 	govy.ForPointer(func(m MetricSpec) *SumoLogicMetric { return m.SumoLogic }).
 		WithName("sumoLogic").
-		Include(sumoLogicSingleQueryLogsTypeValidation),
+		Include(
+			sumoLogicSingleQueryLogsTypeValidation,
+			sumoLogicSingleQueryMetricsTypeValidation,
+		),
 )
 
 var metricSpecValidation = govy.New[MetricSpec](

--- a/manifest/v1alpha/slo/metrics_validation.go
+++ b/manifest/v1alpha/slo/metrics_validation.go
@@ -150,6 +150,9 @@ var singleQueryMetricSpecValidation = govy.New[MetricSpec](
 	govy.ForPointer(func(m MetricSpec) *HoneycombMetric { return m.Honeycomb }).
 		WithName("honeycomb").
 		Include(honeycombSingleQueryValidation),
+	govy.ForPointer(func(m MetricSpec) *SumoLogicMetric { return m.SumoLogic }).
+		WithName("sumoLogic").
+		Include(sumoLogicSingleQueryLogsTypeValidation),
 )
 
 var metricSpecValidation = govy.New[MetricSpec](

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -186,7 +186,7 @@ func TestValidate_Spec_Attachments(t *testing.T) {
 	t.Run("fails, too many attachments", func(t *testing.T) {
 		slo := validSLO()
 		var attachments []Attachment
-		for i := 0; i < 21; i++ {
+		for range 21 {
 			attachments = append(attachments, Attachment{})
 		}
 		slo.Spec.Attachments = attachments
@@ -2020,6 +2020,16 @@ var validSingleQueryMetricSpecs = map[v1alpha.DataSourceType]MetricSpec{
 	}},
 	v1alpha.Honeycomb: {Honeycomb: &HoneycombMetric{
 		Attribute: "dc.sli.some-service-availability",
+	}},
+	v1alpha.SumoLogic: {SumoLogic: &SumoLogicMetric{
+		Type: ptr(SumoLogicTypeLogs),
+		Query: ptr(`_collector="n9-dev-tooling-cluster" _source="logs"
+		| json "log" 
+		| timeslice 15s as n9_time
+		| parse "level=* *" as (log_level, tail)
+		| if (log_level = "info", 1, 0) as good
+		| 1 as total
+		| sum(good) as n9_good, sum(total) as n9_total by n9_time`),
 	}},
 }
 

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -2024,7 +2024,7 @@ var validSingleQueryMetricSpecs = map[v1alpha.DataSourceType]MetricSpec{
 	v1alpha.SumoLogic: {SumoLogic: &SumoLogicMetric{
 		Type: ptr(SumoLogicTypeLogs),
 		Query: ptr(`_collector="n9-dev-tooling-cluster" _source="logs"
-		| json "log" 
+		| json "log"
 		| timeslice 15s as n9_time
 		| parse "level=* *" as (log_level, tail)
 		| if (log_level = "info", 1, 0) as good


### PR DESCRIPTION
## Motivation

In order to better align good and total values returned from the SumoLogic API and improve rate limiting constraints we're adding single query support.

## Summary

This update introduces support for SumoLogic single-query good-over-total metrics. Changes include:

- Added `SumoLogic` to the list of supported data sources for single-query good-over-total metrics.
- Updated the `generateMetricVariant` function to handle the new metric variant for SumoLogic logs.
- Refactored SumoLogic logs validation logic to support single-query metrics, introducing a new `getSumoLogicLogsTypeValidation` function.
- Enhanced validation rules to ensure proper query structure for single-query metrics, including checks for `n9_good`, `n9_total`, and `timeslice` usage.
- Added comprehensive test cases to validate both valid and invalid scenarios for SumoLogic single-query metrics.
- Updated the `singleQueryMetricSpecValidation` to include SumoLogic-specific validation rules.

These changes ensure robust support for SumoLogic single-query metrics while maintaining strict validation to prevent misconfigurations.

## Testing

Added unit tests and examples, which are automatically tested by end-to-end tests.

## Release Notes

Added single query support for SumoLogic, users can now define `spec.objectives[*].countMetrics.goodTotal.sumoLogic`.
The support for single query metrics is now limited to `logs` type, `metrics` type is not yet supported.
