### PR TITLE
feat: Add predefined Nobl9 platform instances

### DIFF
--- a/sdk/config.go
+++ b/sdk/config.go
@@ -108,24 +108,24 @@ type Config struct {
 
 // ContextlessConfig stores config not tied to any specific context.
 type ContextlessConfig struct {
-	DefaultContext string `toml:"defaultContext" env:"DEFAULT_CONTEXT"`
+	DefaultContext string `toml:"defaultContext" json:"defaultContext" env:"DEFAULT_CONTEXT"`
 	// Sloctl exclusive.
-	FilesPromptEnabled   *bool `toml:"filesPromptEnabled" env:"FILES_PROMPT_ENABLED"`
-	FilesPromptThreshold *int  `toml:"filesPromptThreshold" env:"FILES_PROMPT_THRESHOLD"`
+	FilesPromptEnabled   *bool `toml:"filesPromptEnabled" json:"filesPromptEnabled" env:"FILES_PROMPT_ENABLED"`
+	FilesPromptThreshold *int  `toml:"filesPromptThreshold" json:"filesPromptThreshold" env:"FILES_PROMPT_THRESHOLD"`
 }
 
 // ContextConfig stores context specific config.
 type ContextConfig struct {
-	ClientID       string         `toml:"clientId" env:"CLIENT_ID"`
-	ClientSecret   string         `toml:"clientSecret" env:"CLIENT_SECRET"`
-	AccessToken    string         `toml:"accessToken,omitempty" env:"ACCESS_TOKEN"`
-	Project        string         `toml:"project,omitempty" env:"PROJECT"`
-	URL            string         `toml:"url,omitempty" env:"URL"`
-	OktaOrgURL     string         `toml:"oktaOrgURL,omitempty" env:"OKTA_ORG_URL"`
-	OktaAuthServer string         `toml:"oktaAuthServer,omitempty" env:"OKTA_AUTH_SERVER"`
-	DisableOkta    *bool          `toml:"disableOkta,omitempty" env:"DISABLE_OKTA"`
-	Organization   string         `toml:"organization,omitempty" env:"ORGANIZATION"`
-	Timeout        *time.Duration `toml:"timeout,omitempty" env:"TIMEOUT"`
+	ClientID       string         `toml:"clientId" json:"clientId" env:"CLIENT_ID"`
+	ClientSecret   string         `toml:"clientSecret" json:"clientSecret" env:"CLIENT_SECRET"`
+	AccessToken    string         `toml:"accessToken,omitempty" json:"accessToken,omitempty" env:"ACCESS_TOKEN"`
+	Project        string         `toml:"project,omitempty" json:"project,omitempty" env:"PROJECT"`
+	URL            string         `toml:"url,omitempty" json:"url,omitempty" env:"URL"`
+	OktaOrgURL     string         `toml:"oktaOrgURL,omitempty" json:"oktaOrgUrl,omitempty" env:"OKTA_ORG_URL"`
+	OktaAuthServer string         `toml:"oktaAuthServer,omitempty" json:"oktaAuthServer,omitempty" env:"OKTA_AUTH_SERVER"`
+	DisableOkta    *bool          `toml:"disableOkta,omitempty" json:"disableOkta,omitempty" env:"DISABLE_OKTA"`
+	Organization   string         `toml:"organization,omitempty" json:"organization,omitempty" env:"ORGANIZATION"`
+	Timeout        *time.Duration `toml:"timeout,omitempty" json:"timeout,omitempty" env:"TIMEOUT"`
 }
 
 // ConfigOption conveys extra configuration details for [ReadConfig] function.

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -29,6 +29,11 @@ const (
 	defaultFilesPromptThreshold = 23
 )
 
+var (
+	defaultOktaOrgURL     = platformInstanceAuthConfigs[PlatformInstanceDefault].URL
+	defaultOktaAuthServer = platformInstanceAuthConfigs[PlatformInstanceDefault].AuthServer
+)
+
 // GetDefaultConfigPath returns the default path to Nobl9 configuration file (config.toml).
 func GetDefaultConfigPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -282,6 +287,8 @@ func newConfig(options []ConfigOption) (*Config, error) {
 			"NO_CONFIG_FILE":         strconv.FormatBool(defaultNoConfigFile),
 			"DEFAULT_CONTEXT":        defaultContext,
 			"PROJECT":                DefaultProject,
+			"OKTA_ORG_URL":           defaultOktaOrgURL.String(),
+			"OKTA_AUTH_SERVER":       defaultOktaAuthServer,
 			"DISABLE_OKTA":           strconv.FormatBool(defaultDisableOkta),
 			"ORGANIZATION":           defaultOrganization,
 			"TIMEOUT":                defaultTimeout.String(),
@@ -349,15 +356,14 @@ func (c *Config) resolveContextConfig() error {
 	c.Timeout = *c.contextConfig.Timeout
 	c.DisableOkta = *c.contextConfig.DisableOkta
 	c.Organization = c.contextConfig.Organization
-	if c.options.platformInstance == "" {
-		c.options.platformInstance = PlatformInstanceDefault
+	if c.options.platformInstance != "" {
+		authConfig, err := GetPlatformInstanceAuthConfig(c.options.platformInstance)
+		if err != nil {
+			return err
+		}
+		c.OktaOrgURL = authConfig.URL
+		c.OktaAuthServer = authConfig.AuthServer
 	}
-	authConfig, err := GetPlatformInstanceAuthConfig(c.options.platformInstance)
-	if err != nil {
-		return err
-	}
-	c.OktaOrgURL = authConfig.URL
-	c.OktaAuthServer = authConfig.AuthServer
 	return nil
 }
 

--- a/sdk/config_file.go
+++ b/sdk/config_file.go
@@ -11,9 +11,23 @@ import (
 // FileConfig contains fully parsed config file.
 type FileConfig struct {
 	ContextlessConfig `toml:",inline"`
-	Contexts          map[string]ContextConfig `toml:"contexts"`
+	Contexts          map[string]ContextConfig `toml:"contexts" json:"contexts"`
 
 	filePath string
+}
+
+// GetCurrentContextConfig retrieves the [ContextConfig] for the current default context.
+func (f *FileConfig) GetCurrentContextConfig() (ContextConfig, error) {
+	return f.GetContextConfig(f.DefaultContext)
+}
+
+// GetContextConfig retrieves the [ContextConfig] associated with the provided context name.
+func (f *FileConfig) GetContextConfig(contextName string) (ContextConfig, error) {
+	config, ok := f.Contexts[contextName]
+	if !ok {
+		return config, errors.Errorf("no config defined for %q context", contextName)
+	}
+	return config, nil
 }
 
 // GetPath retrieves the file path [FileConfig] was loaded from.

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -172,6 +172,52 @@ func TestReadConfig_ConfigOption(t *testing.T) {
 	}, conf)
 }
 
+func TestConfigOptionPlatformInstance(t *testing.T) {
+	t.Run("default instance", func(t *testing.T) {
+		conf, err := ReadConfig(
+			ConfigOptionWithCredentials("clientId", "clientSecret"),
+			ConfigOptionPlatformInstance(PlatformInstanceDefault),
+			ConfigOptionNoConfigFile())
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://accounts.nobl9.com", conf.OktaOrgURL.String())
+		assert.Equal(t, "auseg9kiegWKEtJZC416", conf.OktaAuthServer)
+	})
+
+	t.Run("US1 instance", func(t *testing.T) {
+		conf, err := ReadConfig(
+			ConfigOptionWithCredentials("clientId", "clientSecret"),
+			ConfigOptionPlatformInstance(PlatformInstanceUS1),
+			ConfigOptionNoConfigFile())
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://accounts-us1.nobl9.com", conf.OktaOrgURL.String())
+		assert.Equal(t, "ausaew9480S3Sn89f5d7", conf.OktaAuthServer)
+	})
+
+	t.Run("custom instance", func(t *testing.T) {
+		conf, err := ReadConfig(
+			ConfigOptionWithCredentials("clientId", "clientSecret"),
+			ConfigOptionPlatformInstance(PlatformInstanceCustom),
+			ConfigOptionNoConfigFile())
+		require.NoError(t, err)
+
+		// Custom instance should use the default values or empty values
+		assert.Nil(t, conf.OktaOrgURL)
+		assert.Empty(t, conf.OktaAuthServer)
+	})
+
+	t.Run("invalid instance", func(t *testing.T) {
+		invalidInstance := PlatformInstance("invalid.instance.com")
+		_, err := ReadConfig(
+			ConfigOptionWithCredentials("clientId", "clientSecret"),
+			ConfigOptionPlatformInstance(invalidInstance),
+			ConfigOptionNoConfigFile())
+		require.Error(t, err)
+		assert.EqualError(t, err, `"invalid.instance.com" platform instance is not supported`)
+	})
+}
+
 func TestReadConfig_Defaults(t *testing.T) {
 	conf, err := ReadConfig(
 		ConfigOptionWithCredentials("clientId", "clientSecret"),

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -22,11 +22,6 @@ var configTestData embed.FS
 
 const configTestDataPath = "test_data/config"
 
-var (
-	defaultOktaOrgURL     = platformInstanceAuthConfigs[PlatformInstanceDefault].URL
-	defaultOktaAuthServer = platformInstanceAuthConfigs[PlatformInstanceDefault].AuthServer
-)
-
 func TestReadConfig_FromMinimalConfigFile(t *testing.T) {
 	tempDir := setupConfigTestData(t)
 	expected := &Config{

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -22,14 +22,19 @@ var configTestData embed.FS
 
 const configTestDataPath = "test_data/config"
 
+var (
+	defaultOktaOrgURL     = platformInstanceAuthConfigs[PlatformInstanceDefault].URL
+	defaultOktaAuthServer = platformInstanceAuthConfigs[PlatformInstanceDefault].AuthServer
+)
+
 func TestReadConfig_FromMinimalConfigFile(t *testing.T) {
 	tempDir := setupConfigTestData(t)
 	expected := &Config{
 		ClientID:             "someId",
 		ClientSecret:         "someSecret",
 		Project:              DefaultProject,
-		OktaOrgURL:           &defaultOktaOrgURL,
-		OktaAuthServer:       defaultOktaAuthServerID,
+		OktaOrgURL:           defaultOktaOrgURL,
+		OktaAuthServer:       defaultOktaAuthServer,
 		Timeout:              defaultTimeout,
 		FilesPromptEnabled:   defaultFilesPromptEnabled,
 		FilesPromptThreshold: defaultFilesPromptThreshold,
@@ -92,8 +97,8 @@ func TestReadConfig_CreateConfigFileIfNotPresent(t *testing.T) {
 		ClientID:             "clientId",
 		ClientSecret:         "clientSecret",
 		Project:              DefaultProject,
-		OktaOrgURL:           &defaultOktaOrgURL,
-		OktaAuthServer:       defaultOktaAuthServerID,
+		OktaOrgURL:           defaultOktaOrgURL,
+		OktaAuthServer:       defaultOktaAuthServer,
 		Timeout:              10 * time.Second,
 		FilesPromptEnabled:   defaultFilesPromptEnabled,
 		FilesPromptThreshold: defaultFilesPromptThreshold,
@@ -162,8 +167,8 @@ func TestReadConfig_ConfigOption(t *testing.T) {
 		ClientID:             "clientId",
 		ClientSecret:         "clientSecret",
 		Project:              DefaultProject,
-		OktaOrgURL:           &defaultOktaOrgURL,
-		OktaAuthServer:       defaultOktaAuthServerID,
+		OktaOrgURL:           defaultOktaOrgURL,
+		OktaAuthServer:       defaultOktaAuthServer,
 		Timeout:              10 * time.Minute,
 		FilesPromptEnabled:   defaultFilesPromptEnabled,
 		FilesPromptThreshold: defaultFilesPromptThreshold,
@@ -182,8 +187,8 @@ func TestReadConfig_Defaults(t *testing.T) {
 		ClientID:             "clientId",
 		ClientSecret:         "clientSecret",
 		Project:              DefaultProject,
-		OktaOrgURL:           &defaultOktaOrgURL,
-		OktaAuthServer:       defaultOktaAuthServerID,
+		OktaOrgURL:           defaultOktaOrgURL,
+		OktaAuthServer:       defaultOktaAuthServer,
 		Timeout:              defaultTimeout,
 		FilesPromptEnabled:   defaultFilesPromptEnabled,
 		FilesPromptThreshold: defaultFilesPromptThreshold,
@@ -212,8 +217,8 @@ func TestReadConfig_EnvVariablesMinimal(t *testing.T) {
 		ClientID:             "clientId",
 		ClientSecret:         "clientSecret",
 		Project:              DefaultProject,
-		OktaOrgURL:           &defaultOktaOrgURL,
-		OktaAuthServer:       defaultOktaAuthServerID,
+		OktaOrgURL:           defaultOktaOrgURL,
+		OktaAuthServer:       defaultOktaAuthServer,
 		Timeout:              defaultTimeout,
 		FilesPromptEnabled:   defaultFilesPromptEnabled,
 		FilesPromptThreshold: defaultFilesPromptThreshold,

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -56,7 +56,7 @@ func httpCheckRetry(ctx context.Context, resp *http.Response, err error) (bool, 
 
 func httpShouldRetryPolicy(resp *http.Response, retryErr error) (shouldRetry bool) {
 	if retryErr != nil {
-		if v, isUrlError := retryErr.(*url.Error); isUrlError {
+		if v, isURLError := retryErr.(*url.Error); isURLError {
 			// Don't retry if the error was due to too many redirects.
 			if redirectsErrorRe.MatchString(v.Error()) {
 				return false
@@ -94,4 +94,4 @@ type httpNoopLogger struct{}
 // Printf is empty, because we only want to fulfill [retryablehttp.Logger] interface.
 // [retryablehttp.Client.Logger] makes extensive use of the logger yielding way too much info.
 // We silence the logger and print the info where needed.
-func (l httpNoopLogger) Printf(string, ...interface{}) {}
+func (l httpNoopLogger) Printf(string, ...any) {}

--- a/sdk/instances.go
+++ b/sdk/instances.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"maps"
 	"net/url"
+
+	"github.com/pkg/errors"
 )
 
 // PlatformInstanceAuthConfig is the auth server configuration used to retrieve Nobl9 access token.
@@ -35,6 +37,16 @@ var platformInstanceAuthConfigs = map[PlatformInstance]PlatformInstanceAuthConfi
 // GetPlatformInstanceAuthConfigs returns a mapping of platform instance hosts to their auth configs.
 func GetPlatformInstanceAuthConfigs() map[PlatformInstance]PlatformInstanceAuthConfig {
 	return maps.Clone(platformInstanceAuthConfigs)
+}
+
+// GetPlatformInstanceAuthConfig returns a [PlatformInstanceAuthConfig] for provided platform instance.
+// If the instance name is not valid, it returns an error.
+func GetPlatformInstanceAuthConfig(instance PlatformInstance) (*PlatformInstanceAuthConfig, error) {
+	conf, ok := platformInstanceAuthConfigs[instance]
+	if !ok {
+		return nil, errors.Errorf("%q platform instance is not supported", instance)
+	}
+	return &conf, nil
 }
 
 // GetPlatformInstances returns a list of all available Nobl9 platform instances.

--- a/sdk/instances.go
+++ b/sdk/instances.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-// PlatformInstanceAuthConfig is
+// PlatformInstanceAuthConfig is the auth server configuration used to retrieve Nobl9 access token.
 type PlatformInstanceAuthConfig struct {
 	URL        *url.URL
 	AuthServer string
@@ -32,10 +32,12 @@ var platformInstanceAuthConfigs = map[PlatformInstance]PlatformInstanceAuthConfi
 	PlatformInstanceCustom: {},
 }
 
+// GetPlatformInstanceAuthConfigs returns a mapping of platform instance hosts to their auth configs.
 func GetPlatformInstanceAuthConfigs() map[PlatformInstance]PlatformInstanceAuthConfig {
 	return maps.Clone(platformInstanceAuthConfigs)
 }
 
+// GetPlatformInstances returns a list of all available Nobl9 platform instances.
 func GetPlatformInstances() []PlatformInstance {
 	return []PlatformInstance{
 		PlatformInstanceDefault,

--- a/sdk/instances.go
+++ b/sdk/instances.go
@@ -1,0 +1,45 @@
+package sdk
+
+import (
+	"maps"
+	"net/url"
+)
+
+// PlatformInstanceAuthConfig is
+type PlatformInstanceAuthConfig struct {
+	URL        *url.URL
+	AuthServer string
+}
+
+// PlatformInstance is the Nobl9 platform instance host which the [Client] will communicate with.
+type PlatformInstance string
+
+const (
+	PlatformInstanceDefault PlatformInstance = "app.nobl9.com"
+	PlatformInstanceUS1     PlatformInstance = "us1.nobl9.com"
+	PlatformInstanceCustom  PlatformInstance = "custom"
+)
+
+var platformInstanceAuthConfigs = map[PlatformInstance]PlatformInstanceAuthConfig{
+	PlatformInstanceDefault: {
+		URL:        &url.URL{Scheme: "https", Host: "accounts.nobl9.com"},
+		AuthServer: "auseg9kiegWKEtJZC416",
+	},
+	PlatformInstanceUS1: {
+		URL:        &url.URL{Scheme: "https", Host: "accounts-us1.nobl9.com"},
+		AuthServer: "ausaew9480S3Sn89f5d7",
+	},
+	PlatformInstanceCustom: {},
+}
+
+func GetPlatformInstanceAuthConfigs() map[PlatformInstance]PlatformInstanceAuthConfig {
+	return maps.Clone(platformInstanceAuthConfigs)
+}
+
+func GetPlatformInstances() []PlatformInstance {
+	return []PlatformInstance{
+		PlatformInstanceDefault,
+		PlatformInstanceUS1,
+		PlatformInstanceCustom,
+	}
+}

--- a/sdk/instances_test.go
+++ b/sdk/instances_test.go
@@ -1,0 +1,75 @@
+package sdk
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlatformInstanceAuthConfig(t *testing.T) {
+	t.Run("valid default instance", func(t *testing.T) {
+		config, err := GetPlatformInstanceAuthConfig(PlatformInstanceDefault)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		expectedURL := &url.URL{Scheme: "https", Host: "accounts.nobl9.com"}
+		assert.Equal(t, expectedURL, config.URL)
+		assert.Equal(t, "auseg9kiegWKEtJZC416", config.AuthServer)
+	})
+
+	t.Run("valid US1 instance", func(t *testing.T) {
+		config, err := GetPlatformInstanceAuthConfig(PlatformInstanceUS1)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		expectedURL := &url.URL{Scheme: "https", Host: "accounts-us1.nobl9.com"}
+		assert.Equal(t, expectedURL, config.URL)
+		assert.Equal(t, "ausaew9480S3Sn89f5d7", config.AuthServer)
+	})
+
+	t.Run("valid custom instance", func(t *testing.T) {
+		config, err := GetPlatformInstanceAuthConfig(PlatformInstanceCustom)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		assert.Nil(t, config.URL)
+		assert.Empty(t, config.AuthServer)
+	})
+
+	t.Run("invalid instance", func(t *testing.T) {
+		invalidInstance := PlatformInstance("invalid.instance.com")
+		config, err := GetPlatformInstanceAuthConfig(invalidInstance)
+
+		require.Error(t, err)
+		assert.Nil(t, config)
+		assert.Contains(t, err.Error(), "platform instance is not supported")
+		assert.Contains(t, err.Error(), "invalid.instance.com")
+	})
+
+	t.Run("empty instance", func(t *testing.T) {
+		config, err := GetPlatformInstanceAuthConfig("")
+
+		require.Error(t, err)
+		assert.Nil(t, config)
+		assert.Contains(t, err.Error(), "platform instance is not supported")
+	})
+}
+
+func TestGetPlatformInstanceAuthConfig_ReturnsPointer(t *testing.T) {
+	config1, err1 := GetPlatformInstanceAuthConfig(PlatformInstanceDefault)
+	config2, err2 := GetPlatformInstanceAuthConfig(PlatformInstanceDefault)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	// Ensure we get different pointer instances (not the same reference)
+	assert.NotSame(t, config1, config2)
+
+	// But the values should be equal
+	assert.Equal(t, config1, config2)
+}

--- a/sdk/jwt_test.go
+++ b/sdk/jwt_test.go
@@ -15,10 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testIssuer      = "https://accounts.nobl9.com/oauth2/ausdh151kj9OOWv5x191"
-	testJWKFetchURL = "https://accounts.nobl9.com/abc"
-)
+const testIssuer = "https://accounts.nobl9.com/oauth2/ausdh151kj9OOWv5x191"
 
 func TestJWTParser_Parse(t *testing.T) {
 	t.Run("return error if either token or clientID are empty", func(t *testing.T) {

--- a/sdk/test_data/config_file/encoded_config.json
+++ b/sdk/test_data/config_file/encoded_config.json
@@ -1,0 +1,26 @@
+{
+  "defaultContext": "production",
+  "filesPromptEnabled": true,
+  "filesPromptThreshold": 25,
+  "contexts": {
+    "production": {
+      "clientId": "prod-client-id",
+      "clientSecret": "prod-client-secret",
+      "accessToken": "prod-access-token",
+      "project": "prod-project",
+      "url": "https://api.nobl9.com",
+      "oktaOrgUrl": "https://accounts.nobl9.com",
+      "oktaAuthServer": "auseg9kiegWKEtJZC416",
+      "disableOkta": false,
+      "organization": "my-org",
+      "timeout": 30000000000
+    },
+    "staging": {
+      "clientId": "staging-id",
+      "clientSecret": "staging-secret",
+      "project": "staging-project",
+      "disableOkta": true,
+      "timeout": 15000000000
+    }
+  }
+}

--- a/sdk/test_data/config_file/encoded_config.toml
+++ b/sdk/test_data/config_file/encoded_config.toml
@@ -1,0 +1,22 @@
+defaultContext = "production"
+filesPromptEnabled = true
+filesPromptThreshold = 25
+
+[contexts]
+  [contexts.production]
+    clientId = "prod-client-id"
+    clientSecret = "prod-client-secret"
+    accessToken = "prod-access-token"
+    project = "prod-project"
+    url = "https://api.nobl9.com"
+    oktaOrgURL = "https://accounts.nobl9.com"
+    oktaAuthServer = "auseg9kiegWKEtJZC416"
+    disableOkta = false
+    organization = "my-org"
+    timeout = "30s"
+  [contexts.staging]
+    clientId = "staging-id"
+    clientSecret = "staging-secret"
+    project = "staging-project"
+    disableOkta = true
+    timeout = "15s"

--- a/sdk/test_data/config_file/encoded_config.yaml
+++ b/sdk/test_data/config_file/encoded_config.yaml
@@ -1,0 +1,22 @@
+contextlessconfig:
+  defaultContext: production
+  filesPromptEnabled: true
+  filesPromptThreshold: 25
+contexts:
+  production:
+    clientId: prod-client-id
+    clientSecret: prod-client-secret
+    accessToken: prod-access-token
+    project: prod-project
+    url: https://api.nobl9.com
+    oktaOrgUrl: https://accounts.nobl9.com
+    oktaAuthServer: auseg9kiegWKEtJZC416
+    disableOkta: false
+    organization: my-org
+    timeout: 30s
+  staging:
+    clientId: staging-id
+    clientSecret: staging-secret
+    project: staging-project
+    disableOkta: true
+    timeout: 15s


### PR DESCRIPTION
## Motivation

With users on different Nobl9 platform instances it'd be beneficial to have a way of allowing 

## Testing

Added unit tests.