### PR TITLE
[PC-17863] Add SumoLogic Single Query Examples

### DIFF
--- a/manifest/v1alpha/examples/slo_variants.go
+++ b/manifest/v1alpha/examples/slo_variants.go
@@ -232,8 +232,9 @@ const (
 	metricSubVariantPingdomUptime      metricVariant = "uptime"
 	metricSubVariantPingdomTransaction metricVariant = "transaction"
 	// SumoLogic.
-	metricSubVariantSumoLogicMetrics metricVariant = "metrics"
-	metricSubVariantSumoLogicLogs    metricVariant = "logs"
+	metricSubVariantSumoLogicMetrics      metricVariant = "metrics"
+	metricSubVariantSumoLogicLogs         metricVariant = "logs"
+	metricSubVariantSumoLogicLogsAllTotal metricVariant = "logs all total"
 	// Instana.
 	metricSubVariantInstanaInfrastructureQuery      metricVariant = "infrastructure query"
 	metricSubVariantInstanaInfrastructureSnapshotID metricVariant = "infrastructure snapshot id"
@@ -743,6 +744,17 @@ func (s sloExample) generateMetricVariant(slo v1alphaSLO.SLO) v1alphaSLO.SLO {
 | sort by n9_time asc`),
 			}))
 		case metricVariantSingleQueryGoodRatio + metricSubVariantSumoLogicLogs:
+			return setSingleQueryGoodOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
+				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
+				Query: ptr(`_sourcecategory="kubernetes/applications/frontend/cache"
+| parse "cache_status=* response_time=*" as cache_status, response_time
+| timeslice 15s as n9_time
+| if(cache_status="HIT", 1, 0) as good
+| if(cache_status="HIT" OR cache_status="MISS", 1, 0) as total
+| sum(good) as n9_good, sum(total) as n9_total by n9_time
+| sort by n9_time asc`),
+			}))
+		case metricVariantSingleQueryGoodRatio + metricSubVariantSumoLogicLogsAllTotal:
 			return setSingleQueryGoodOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SumoLogicMetric{
 				Type: ptr(v1alphaSLO.SumoLogicTypeLogs),
 				Query: ptr(`_collector="n9-dev-tooling-cluster" _source="logs"

--- a/manifest/v1alpha/slo/examples/sumo-logic.yaml
+++ b/manifest/v1alpha/slo/examples/sumo-logic.yaml
@@ -628,6 +628,79 @@
         alertAfter: 1h
 # Metric type: single query good over total
 # Metric variant: logs
+# Budgeting method: Timeslices
+# Time window type: Rolling
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: frontend-cache-performance-slo
+    displayName: Frontend Cache Performance SLO
+    project: default
+    labels:
+      area:
+      - performance
+      - frontend
+      env:
+      - prod
+      - canary
+      region:
+      - global
+      team:
+      - frontend
+      - product
+    annotations:
+      area: performance
+      env: prod
+      region: global
+      team: frontend
+  spec:
+    description: Monitor frontend cache hit rate using single query SumoLogic logs
+    indicator:
+      metricSource:
+        name: sumo-logic
+        project: default
+        kind: Agent
+    budgetingMethod: Timeslices
+    objectives:
+    - displayName: Cache Hit Rate
+      value: 1.0
+      name: cache-performance
+      target: 0.95
+      timeSliceTarget: 0.9
+      countMetrics:
+        incremental: true
+        goodTotal:
+          sumoLogic:
+            type: logs
+            query: |-
+              _sourcecategory="kubernetes/applications/frontend/cache"
+              | parse "cache_status=* response_time=*" as cache_status, response_time
+              | timeslice 15s as n9_time
+              | if(cache_status="HIT", 1, 0) as good
+              | if(cache_status="HIT" OR cache_status="MISS", 1, 0) as total
+              | sum(good) as n9_good,
+                sum(total) as n9_total
+                by n9_time
+              | sort by n9_time asc
+      primary: true
+    service: frontend-cache
+    timeWindows:
+    - unit: Hour
+      count: 1
+      isRolling: true
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: single query good over total
+# Metric variant: logs
 # Budgeting method: Occurrences
 # Time window type: Calendar
 - apiVersion: n9/v1alpha

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -2021,8 +2021,6 @@ var validSingleQueryMetricSpecs = map[v1alpha.DataSourceType]MetricSpec{
 	v1alpha.Honeycomb: {Honeycomb: &HoneycombMetric{
 		Attribute: "dc.sli.some-service-availability",
 	}},
-	// SumoLogic single query example uses cache monitoring query as the canonical example.
-	// This demonstrates realistic good/total conditions without the "1 as total" pattern.
 	v1alpha.SumoLogic: {SumoLogic: &SumoLogicMetric{
 		Type: ptr(SumoLogicTypeLogs),
 		Query: ptr(`_sourcecategory="kubernetes/applications/frontend/cache"


### PR DESCRIPTION
# Add SumoLogic Single Query Examples

## Release Notes
Added examples for SumoLogic single-query good-over-total metrics SLO configurations.

## Motivation
PR #803 added core support for SumoLogic single-query good-over-total metrics. This PR provides additional examples for single query approach in SumoLogic.
