### PR TITLE
feat: PI-1274 Add SendResolution support to TeamsAlertMethod

### DIFF
--- a/manifest/v1alpha/alertmethod/alert_method.go
+++ b/manifest/v1alpha/alertmethod/alert_method.go
@@ -135,7 +135,8 @@ type JiraAlertMethod struct {
 
 // TeamsAlertMethod represents a set of properties required create Microsoft Teams notifications.
 type TeamsAlertMethod struct {
-	URL string `json:"url"`
+	URL            string          `json:"url"`
+	SendResolution *SendResolution `json:"sendResolution,omitempty"`
 }
 
 // EmailAlertMethod represents a set of properties required to send an email.

--- a/manifest/v1alpha/alertmethod/validation.go
+++ b/manifest/v1alpha/alertmethod/validation.go
@@ -270,6 +270,9 @@ var teamsValidation = govy.New[TeamsAlertMethod](
 				return nil
 			}),
 		),
+	govy.ForPointer(func(s TeamsAlertMethod) *SendResolution { return s.SendResolution }).
+		WithName("sendResolution").
+		Include(sendResolutionValidation),
 ).When(
 	func(v TeamsAlertMethod) bool { return !isHiddenValue(v.URL) },
 	govy.WhenDescriptionf("is empty or equal to '%s'", v1alpha.HiddenValue),

--- a/manifest/v1alpha/alertmethod/validation.go
+++ b/manifest/v1alpha/alertmethod/validation.go
@@ -260,6 +260,10 @@ var teamsValidation = govy.New[TeamsAlertMethod](
 	govy.Transform(func(t TeamsAlertMethod) string { return t.URL }, url.Parse).
 		WithName("url").
 		HideValue().
+		When(
+			func(t TeamsAlertMethod) bool { return !isHiddenValue(t.URL) },
+			govy.WhenDescriptionf("is empty or equal to '%s'", v1alpha.HiddenValue),
+		).
 		Cascade(govy.CascadeModeStop).
 		Rules(rules.URL()).
 		Rules(
@@ -273,9 +277,6 @@ var teamsValidation = govy.New[TeamsAlertMethod](
 	govy.ForPointer(func(s TeamsAlertMethod) *SendResolution { return s.SendResolution }).
 		WithName("sendResolution").
 		Include(sendResolutionValidation),
-).When(
-	func(v TeamsAlertMethod) bool { return !isHiddenValue(v.URL) },
-	govy.WhenDescriptionf("is empty or equal to '%s'", v1alpha.HiddenValue),
 )
 
 var emailValidation = govy.New[EmailAlertMethod](


### PR DESCRIPTION
## Summary
- Adds `SendResolution` field to `TeamsAlertMethod` struct, enabling all-clear (resolution) notifications for MS Teams alert methods
- Adds validation for the new field, reusing the existing `sendResolutionValidation` (same pattern as PagerDuty and ServiceNow)

## Context
JIRA: PI-1274

Customers want to receive "alert resolved" notifications via MS Teams when alerts are resolved or canceled. This change adds the manifest-level support so that the `n9` backend can wire `SendResolution` for Teams alert methods.

## Test plan
- [x] Existing validation tests continue to pass
- [x] New field follows the same pattern as PagerDuty/ServiceNow SendResolution
- [ ] Companion PR in n9 repo wires the backend notification logic