### PR TITLE
feat: PI-775 Add service/integration scope to AlertSilence

### DIFF
--- a/manifest/v1alpha/alertsilence/alert_silence.go
+++ b/manifest/v1alpha/alertsilence/alert_silence.go
@@ -40,9 +40,11 @@ type Metadata struct {
 // Spec represents content of AlertSilence's Spec.
 type Spec struct {
 	Description string            `json:"description"`
-	SLO         string            `json:"slo"`
-	AlertPolicy AlertPolicySource `json:"alertPolicy"`
+	SLO         string            `json:"slo,omitempty"`
+	AlertPolicy AlertPolicySource `json:"alertPolicy,omitempty"`
 	Period      Period            `json:"period"`
+	Service     string            `json:"service,omitempty"`
+	Integration string            `json:"integration,omitempty"`
 }
 
 // AlertPolicySource represents AlertPolicy attached to the SLO.
@@ -51,12 +53,22 @@ type AlertPolicySource struct {
 	Project string `json:"project,omitempty"`
 }
 
+// SilenceScope defines the scope of an AlertSilence.
+type SilenceScope string
+
+const (
+	SilenceScopeSLO         SilenceScope = "slo"
+	SilenceScopeService     SilenceScope = "service"
+	SilenceScopeIntegration SilenceScope = "integration"
+)
+
 // Status represents content of Status optional for AlertSilence object.
 type Status struct {
-	From      string `json:"from"`
-	To        string `json:"to"`
-	CreatedAt string `json:"createdAt"`
-	UpdatedAt string `json:"updatedAt"`
+	From      string       `json:"from"`
+	To        string       `json:"to"`
+	CreatedAt string       `json:"createdAt"`
+	UpdatedAt string       `json:"updatedAt"`
+	Scope     SilenceScope `json:"scope,omitempty"`
 }
 
 // Period represents time range configuration for AlertSilence.

--- a/manifest/v1alpha/alertsilence/validation.go
+++ b/manifest/v1alpha/alertsilence/validation.go
@@ -22,7 +22,12 @@ var validator = govy.New[AlertSilence](
 	govy.For(govy.GetSelf[AlertSilence]()).
 		Cascade(govy.CascadeModeStop).
 		Include(metadataValidation).
-		Rules(alertPolicyProjectConsistencyRule),
+		Include(
+			govy.New[AlertSilence](
+				govy.For(govy.GetSelf[AlertSilence]()).
+					Rules(alertPolicyProjectConsistencyRule),
+			).When(func(s AlertSilence) bool { return isSLOScope(s.Spec) }),
+		),
 	govy.For(func(s AlertSilence) Spec { return s.Spec }).
 		WithName("spec").
 		Include(specValidation),
@@ -33,9 +38,57 @@ var metadataValidation = govy.New[AlertSilence](
 	validationV1Alpha.FieldRuleMetadataProject(func(s AlertSilence) string { return s.Metadata.Project }),
 )
 
+// silenceScopeRule validates that exactly one scope is specified:
+// either {slo + alertPolicy} OR {service} OR {integration}.
+var silenceScopeRule = govy.NewRule(func(s Spec) error {
+	hasSLO := s.SLO != "" || s.AlertPolicy.Name != ""
+	hasService := s.Service != ""
+	hasIntegration := s.Integration != ""
+
+	scopeCount := 0
+	if hasSLO {
+		scopeCount++
+	}
+	if hasService {
+		scopeCount++
+	}
+	if hasIntegration {
+		scopeCount++
+	}
+
+	if scopeCount == 0 {
+		return govy.NewRuleError(
+			"exactly one scope must be specified: {slo, alertPolicy}, {service}, or {integration}",
+			errorCodeInvalidSilenceScope,
+		)
+	}
+	if scopeCount > 1 {
+		return govy.NewRuleError(
+			"only one scope can be specified: {slo, alertPolicy}, {service}, or {integration} are mutually exclusive",
+			errorCodeInvalidSilenceScope,
+		)
+	}
+
+	if hasSLO && (s.SLO == "" || s.AlertPolicy.Name == "") {
+		return govy.NewRuleError(
+			"both 'slo' and 'alertPolicy.name' are required when using SLO-level silence",
+			errorCodeInvalidSilenceScope,
+		)
+	}
+
+	return nil
+}).WithErrorCode(errorCodeInvalidSilenceScope)
+
+func isSLOScope(s Spec) bool {
+	return s.Service == "" && s.Integration == ""
+}
+
 var specValidation = govy.New[Spec](
+	govy.For(govy.GetSelf[Spec]()).
+		Rules(silenceScopeRule),
 	govy.For(func(s Spec) string { return s.SLO }).
 		WithName("slo").
+		When(func(s Spec) bool { return isSLOScope(s) }).
 		Required().
 		Rules(validationV1Alpha.StringName()),
 	govy.For(func(s Spec) string { return s.Description }).
@@ -43,7 +96,16 @@ var specValidation = govy.New[Spec](
 		Rules(validationV1Alpha.StringDescription()),
 	govy.For(func(s Spec) AlertPolicySource { return s.AlertPolicy }).
 		WithName("alertPolicy").
+		When(func(s Spec) bool { return isSLOScope(s) }).
 		Include(alertPolicySourceValidation),
+	govy.For(func(s Spec) string { return s.Service }).
+		WithName("service").
+		OmitEmpty().
+		Rules(validationV1Alpha.StringName()),
+	govy.For(func(s Spec) string { return s.Integration }).
+		WithName("integration").
+		OmitEmpty().
+		Rules(validationV1Alpha.StringName()),
 	govy.For(func(s Spec) Period { return s.Period }).
 		WithName("period").
 		Cascade(govy.CascadeModeStop).
@@ -80,6 +142,7 @@ var alertPolicySourceValidation = govy.New[AlertPolicySource](
 const (
 	errorCodeEndTimeNotBeforeOrNotEqualStartTime = "end_time_not_before_or_not_equal_start_time"
 	errorCodeInconsistentProject                 = "alert_policy_project_inconsistent"
+	errorCodeInvalidSilenceScope                 = "invalid_silence_scope"
 )
 
 var endTimeNotBeforeStartTimeRule = govy.NewRule(func(p Period) error {

--- a/manifest/v1alpha/alertsilence/validation_test.go
+++ b/manifest/v1alpha/alertsilence/validation_test.go
@@ -106,10 +106,16 @@ func TestValidate_Spec_Slo(t *testing.T) {
 		alertSilence := validAlertSilence()
 		alertSilence.Spec.SLO = ""
 		err := validate(alertSilence)
-		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: "spec.slo",
-			Code: rules.ErrorCodeRequired,
-		})
+		testutils.AssertContainsErrors(t, alertSilence, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec",
+				Code: errorCodeInvalidSilenceScope,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.slo",
+				Code: rules.ErrorCodeRequired,
+			},
+		)
 	})
 }
 
@@ -156,10 +162,16 @@ func TestValidate_Spec_AlertPolicy(t *testing.T) {
 		alertSilence := validAlertSilence()
 		alertSilence.Spec.AlertPolicy.Name = ""
 		err := validate(alertSilence)
-		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: "spec.alertPolicy.name",
-			Code: rules.ErrorCodeRequired,
-		})
+		testutils.AssertContainsErrors(t, alertSilence, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec",
+				Code: errorCodeInvalidSilenceScope,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.alertPolicy.name",
+				Code: rules.ErrorCodeRequired,
+			},
+		)
 	})
 	t.Run("fails, invalid project", func(t *testing.T) {
 		alertSilence := validAlertSilence()
@@ -281,6 +293,170 @@ func TestValidate_Spec_EndTime(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestValidate_Spec_ServiceScope(t *testing.T) {
+	t.Run("passes, valid service-level silence", func(t *testing.T) {
+		alertSilence := validServiceSilence()
+		err := validate(alertSilence)
+		testutils.AssertNoError(t, alertSilence, err)
+	})
+	t.Run("fails, invalid service name", func(t *testing.T) {
+		alertSilence := validServiceSilence()
+		alertSilence.Spec.Service = "INVALID SERVICE!!"
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
+			Prop: "spec.service",
+			Code: validationV1Alpha.ErrorCodeStringName,
+		})
+	})
+	t.Run("fails, service and slo both set", func(t *testing.T) {
+		alertSilence := validServiceSilence()
+		alertSilence.Spec.SLO = "my-slo"
+		alertSilence.Spec.AlertPolicy = AlertPolicySource{Name: "my-policy"}
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
+			Prop: "spec",
+			Code: errorCodeInvalidSilenceScope,
+		})
+	})
+	t.Run("fails, service and integration both set", func(t *testing.T) {
+		alertSilence := validServiceSilence()
+		alertSilence.Spec.Integration = "my-integration"
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
+			Prop: "spec",
+			Code: errorCodeInvalidSilenceScope,
+		})
+	})
+	t.Run("passes, alertPolicy project consistency not checked for service scope", func(t *testing.T) {
+		alertSilence := validServiceSilence()
+		alertSilence.Metadata.Project = "project-1"
+		err := validate(alertSilence)
+		testutils.AssertNoError(t, alertSilence, err)
+	})
+}
+
+func TestValidate_Spec_IntegrationScope(t *testing.T) {
+	t.Run("passes, valid integration-level silence", func(t *testing.T) {
+		alertSilence := validIntegrationSilence()
+		err := validate(alertSilence)
+		testutils.AssertNoError(t, alertSilence, err)
+	})
+	t.Run("fails, invalid integration name", func(t *testing.T) {
+		alertSilence := validIntegrationSilence()
+		alertSilence.Spec.Integration = "INVALID INTEGRATION!!"
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
+			Prop: "spec.integration",
+			Code: validationV1Alpha.ErrorCodeStringName,
+		})
+	})
+	t.Run("fails, integration and slo both set", func(t *testing.T) {
+		alertSilence := validIntegrationSilence()
+		alertSilence.Spec.SLO = "my-slo"
+		alertSilence.Spec.AlertPolicy = AlertPolicySource{Name: "my-policy"}
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
+			Prop: "spec",
+			Code: errorCodeInvalidSilenceScope,
+		})
+	})
+}
+
+func TestValidate_Spec_NoScope(t *testing.T) {
+	t.Run("fails, no scope specified", func(t *testing.T) {
+		alertSilence := New(
+			Metadata{
+				Name:    "alert-silence",
+				Project: "default",
+			},
+			Spec{
+				Period: Period{
+					StartTime: ptr(time.Date(2023, 5, 1, 17, 10, 5, 0, time.UTC)),
+					Duration:  "10m",
+				},
+			},
+		)
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 3,
+			testutils.ExpectedError{
+				Prop: "spec",
+				Code: errorCodeInvalidSilenceScope,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.slo",
+				Code: rules.ErrorCodeRequired,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.alertPolicy.name",
+				Code: rules.ErrorCodeRequired,
+			},
+		)
+	})
+}
+
+func TestValidate_Spec_SLOScope_RequiresBothFields(t *testing.T) {
+	t.Run("fails, slo set but no alertPolicy", func(t *testing.T) {
+		alertSilence := New(
+			Metadata{
+				Name:    "alert-silence",
+				Project: "default",
+			},
+			Spec{
+				SLO: "my-slo",
+				Period: Period{
+					StartTime: ptr(time.Date(2023, 5, 1, 17, 10, 5, 0, time.UTC)),
+					Duration:  "10m",
+				},
+			},
+		)
+		err := validate(alertSilence)
+		testutils.AssertContainsErrors(t, alertSilence, err, 2,
+			testutils.ExpectedError{
+				Prop: "spec",
+				Code: errorCodeInvalidSilenceScope,
+			},
+			testutils.ExpectedError{
+				Prop: "spec.alertPolicy.name",
+				Code: rules.ErrorCodeRequired,
+			},
+		)
+	})
+}
+
+func validServiceSilence() AlertSilence {
+	return New(
+		Metadata{
+			Name:    "service-silence",
+			Project: "default",
+		},
+		Spec{
+			Description: "Service-level silence",
+			Service:     "my-service",
+			Period: Period{
+				StartTime: ptr(time.Date(2023, 5, 1, 17, 10, 5, 0, time.UTC)),
+				Duration:  "15m",
+			},
+		},
+	)
+}
+
+func validIntegrationSilence() AlertSilence {
+	return New(
+		Metadata{
+			Name:    "integration-silence",
+			Project: "default",
+		},
+		Spec{
+			Description: "Integration-level silence",
+			Integration: "my-integration",
+			Period: Period{
+				StartTime: ptr(time.Date(2023, 5, 1, 17, 10, 5, 0, time.UTC)),
+				Duration:  "15m",
+			},
+		},
+	)
 }
 
 func validAlertSilence() AlertSilence {


### PR DESCRIPTION
## Summary

- Add `Service` and `Integration` fields to `AlertSilence.Spec` (both `omitempty`)
- Make `SLO` and `AlertPolicy` fields `omitempty` (previously required, now conditional)
- Add `SilenceScope` type (`slo`, `service`, `integration`) and `Scope` field to `Status`
- Add mutual exclusivity validation: exactly one of {`slo`+`alertPolicy`}, {`service`}, or {`integration`} must be specified
- Conditional validation: `slo` and `alertPolicy` remain required only when service/integration are empty (backward compatible)
- Validate `service` and `integration` with `StringName()` rules

## Test plan

- [x] Unit tests: 192 new lines in `validation_test.go` covering mutual exclusivity, conditional required fields, and all scope combinations
- [x] Manual: Used with n9 backend on dev-coral — `sloctl apply` with `spec.service` creates service-scoped silence correctly

## Related PRs

- n9 backend: nobl9/n9#20475
- n9 frontend: nobl9/n9#20476