### PR TITLE
feat: add sloctl config section

### DIFF
--- a/sdk/config.go
+++ b/sdk/config.go
@@ -110,10 +110,24 @@ type Config struct {
 
 // ContextlessConfig stores config not tied to any specific context.
 type ContextlessConfig struct {
-	DefaultContext string `toml:"defaultContext" json:"defaultContext" env:"DEFAULT_CONTEXT"`
-	// Sloctl exclusive.
-	FilesPromptEnabled   *bool `toml:"filesPromptEnabled" json:"filesPromptEnabled" env:"FILES_PROMPT_ENABLED"`
-	FilesPromptThreshold *int  `toml:"filesPromptThreshold" json:"filesPromptThreshold" env:"FILES_PROMPT_THRESHOLD"`
+	DefaultContext string        `toml:"defaultContext" json:"defaultContext" env:"DEFAULT_CONTEXT"`
+	Sloctl         *SloctlConfig `toml:"sloctl,omitempty" json:"sloctl,omitempty"`
+
+	// Deprecated: Use [SloctlConfig.FilesPromptEnabled].
+	FilesPromptEnabled *bool `toml:"filesPromptEnabled,omitempty" json:"-" yaml:"-"`
+	// Deprecated: Use [SloctlConfig.FilesPromptThreshold].
+	FilesPromptThreshold *int `toml:"filesPromptThreshold,omitempty" json:"-" yaml:"-"`
+}
+
+// SloctlConfig stores settings specific to sloctl.
+type SloctlConfig struct {
+	FilesPromptEnabled   *bool `toml:"filesPromptEnabled" json:"filesPromptEnabled,omitempty"`
+	FilesPromptThreshold *int  `toml:"filesPromptThreshold" json:"filesPromptThreshold,omitempty"`
+}
+
+type sloctlEnvConfig struct {
+	FilesPromptEnabled   *bool `env:"FILES_PROMPT_ENABLED"`
+	FilesPromptThreshold *int  `env:"FILES_PROMPT_THRESHOLD"`
 }
 
 // ContextConfig stores context specific config.
@@ -306,20 +320,58 @@ func newConfig(options []ConfigOption) (*Config, error) {
 }
 
 func (c *Config) resolveContextlessConfig() error {
+	c.contextlessConfig.normalizeSloctlConfig()
 	if err := c.processEnvVariables(&c.contextlessConfig, true); err != nil {
 		return err
 	}
+	if c.contextlessConfig.Sloctl == nil {
+		c.contextlessConfig.Sloctl = new(SloctlConfig)
+	}
+	if err := c.processSloctlEnvVariables(); err != nil {
+		return err
+	}
+	c.contextlessConfig.normalizeSloctlConfig()
 	if c.options.context != "" {
 		c.currentContext = c.options.context
 	} else {
 		c.currentContext = c.contextlessConfig.DefaultContext
 	}
-	if c.contextlessConfig.FilesPromptEnabled != nil {
-		c.FilesPromptEnabled = *c.contextlessConfig.FilesPromptEnabled
+	if c.contextlessConfig.Sloctl != nil && c.contextlessConfig.Sloctl.FilesPromptEnabled != nil {
+		c.FilesPromptEnabled = *c.contextlessConfig.Sloctl.FilesPromptEnabled
 	}
-	if c.contextlessConfig.FilesPromptThreshold != nil {
-		c.FilesPromptThreshold = *c.contextlessConfig.FilesPromptThreshold
+	if c.contextlessConfig.Sloctl != nil && c.contextlessConfig.Sloctl.FilesPromptThreshold != nil {
+		c.FilesPromptThreshold = *c.contextlessConfig.Sloctl.FilesPromptThreshold
 	}
+	return nil
+}
+
+func (c *ContextlessConfig) normalizeSloctlConfig() {
+	if c.Sloctl == nil {
+		if c.FilesPromptEnabled == nil && c.FilesPromptThreshold == nil {
+			return
+		}
+		c.Sloctl = new(SloctlConfig)
+	}
+	if c.Sloctl.FilesPromptEnabled == nil {
+		c.Sloctl.FilesPromptEnabled = c.FilesPromptEnabled
+	}
+	if c.Sloctl.FilesPromptThreshold == nil {
+		c.Sloctl.FilesPromptThreshold = c.FilesPromptThreshold
+	}
+	c.FilesPromptEnabled = c.Sloctl.FilesPromptEnabled
+	c.FilesPromptThreshold = c.Sloctl.FilesPromptThreshold
+}
+
+func (c *Config) processSloctlEnvVariables() error {
+	envConfig := sloctlEnvConfig{
+		FilesPromptEnabled:   c.contextlessConfig.Sloctl.FilesPromptEnabled,
+		FilesPromptThreshold: c.contextlessConfig.Sloctl.FilesPromptThreshold,
+	}
+	if err := c.processEnvVariables(&envConfig, true); err != nil {
+		return err
+	}
+	c.contextlessConfig.Sloctl.FilesPromptEnabled = envConfig.FilesPromptEnabled
+	c.contextlessConfig.Sloctl.FilesPromptThreshold = envConfig.FilesPromptThreshold
 	return nil
 }
 

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -324,9 +324,6 @@ func (c *Config) resolveContextlessConfig() error {
 	if err := c.processEnvVariables(&c.contextlessConfig, true); err != nil {
 		return err
 	}
-	if c.contextlessConfig.Sloctl == nil {
-		c.contextlessConfig.Sloctl = new(SloctlConfig)
-	}
 	if err := c.processSloctlEnvVariables(); err != nil {
 		return err
 	}
@@ -336,6 +333,8 @@ func (c *Config) resolveContextlessConfig() error {
 	} else {
 		c.currentContext = c.contextlessConfig.DefaultContext
 	}
+	c.FilesPromptEnabled = defaultFilesPromptEnabled
+	c.FilesPromptThreshold = defaultFilesPromptThreshold
 	if c.contextlessConfig.Sloctl != nil && c.contextlessConfig.Sloctl.FilesPromptEnabled != nil {
 		c.FilesPromptEnabled = *c.contextlessConfig.Sloctl.FilesPromptEnabled
 	}
@@ -363,16 +362,30 @@ func (c *ContextlessConfig) normalizeSloctlConfig() {
 }
 
 func (c *Config) processSloctlEnvVariables() error {
-	envConfig := sloctlEnvConfig{
-		FilesPromptEnabled:   c.contextlessConfig.Sloctl.FilesPromptEnabled,
-		FilesPromptThreshold: c.contextlessConfig.Sloctl.FilesPromptThreshold,
+	envConfig := sloctlEnvConfig{}
+	if c.contextlessConfig.Sloctl != nil {
+		envConfig.FilesPromptEnabled = c.contextlessConfig.Sloctl.FilesPromptEnabled
+		envConfig.FilesPromptThreshold = c.contextlessConfig.Sloctl.FilesPromptThreshold
 	}
-	if err := c.processEnvVariables(&envConfig, true); err != nil {
+	if err := c.processEnvVariablesWithoutDefaults(&envConfig, true); err != nil {
 		return err
+	}
+	if envConfig.FilesPromptEnabled == nil && envConfig.FilesPromptThreshold == nil {
+		return nil
+	}
+	if c.contextlessConfig.Sloctl == nil {
+		c.contextlessConfig.Sloctl = new(SloctlConfig)
 	}
 	c.contextlessConfig.Sloctl.FilesPromptEnabled = envConfig.FilesPromptEnabled
 	c.contextlessConfig.Sloctl.FilesPromptThreshold = envConfig.FilesPromptThreshold
 	return nil
+}
+
+func (c *Config) processEnvVariablesWithoutDefaults(iv any, overwrite bool) error {
+	defaults := c.envConfigDefaults
+	c.envConfigDefaults = nil
+	defer func() { c.envConfigDefaults = defaults }()
+	return c.processEnvVariables(iv, overwrite)
 }
 
 func (c *Config) resolveContextConfig() error {

--- a/sdk/config_file.go
+++ b/sdk/config_file.go
@@ -50,6 +50,7 @@ func (f *FileConfig) Load(path string) error {
 	if _, err := toml.DecodeFile(path, &f); err != nil {
 		return errors.Wrapf(err, "could not decode config file: %s", path)
 	}
+	f.normalizeSloctlConfig()
 	return nil
 }
 
@@ -72,13 +73,21 @@ func (f *FileConfig) writeToTempFile(path string) (tmpFileName string, err error
 		return "", err
 	}
 	defer func() { _ = tmpFile.Close() }()
-	if err = toml.NewEncoder(tmpFile).Encode(f); err != nil {
+	config := f.normalizedForSave()
+	if err = toml.NewEncoder(tmpFile).Encode(config); err != nil {
 		return "", err
 	}
 	if err = tmpFile.Sync(); err != nil {
 		return "", err
 	}
 	return tmpFile.Name(), nil
+}
+
+func (f FileConfig) normalizedForSave() FileConfig {
+	f.normalizeSloctlConfig()
+	f.FilesPromptEnabled = nil
+	f.FilesPromptThreshold = nil
+	return f
 }
 
 func createDefaultConfigFile(path string) error {

--- a/sdk/config_file_test.go
+++ b/sdk/config_file_test.go
@@ -88,6 +88,58 @@ func TestFileConfig_Load(t *testing.T) {
 			filePath: filePath,
 		}, *config)
 	})
+
+	t.Run("load legacy sloctl TOML", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "legacy-sloctl-toml")
+		err := os.WriteFile(filePath, []byte(`
+defaultContext = "default"
+filesPromptEnabled = false
+filesPromptThreshold = 30
+
+[contexts]
+  [contexts.default]
+    clientId = "default-id"
+    clientSecret = "default-secret"
+`), 0o600)
+		require.NoError(t, err)
+
+		config := new(FileConfig)
+		require.NoError(t, config.Load(filePath))
+		assert.Equal(t, &SloctlConfig{
+			FilesPromptEnabled:   ptr(false),
+			FilesPromptThreshold: ptr(30),
+		}, config.Sloctl)
+		assert.Equal(t, ptr(false), config.FilesPromptEnabled)
+		assert.Equal(t, ptr(30), config.FilesPromptThreshold)
+	})
+
+	t.Run("new sloctl TOML takes precedence over legacy TOML", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "mixed-sloctl-toml")
+		err := os.WriteFile(filePath, []byte(`
+defaultContext = "default"
+filesPromptEnabled = true
+filesPromptThreshold = 10
+
+[sloctl]
+  filesPromptEnabled = false
+  filesPromptThreshold = 30
+
+[contexts]
+  [contexts.default]
+    clientId = "default-id"
+    clientSecret = "default-secret"
+`), 0o600)
+		require.NoError(t, err)
+
+		config := new(FileConfig)
+		require.NoError(t, config.Load(filePath))
+		assert.Equal(t, &SloctlConfig{
+			FilesPromptEnabled:   ptr(false),
+			FilesPromptThreshold: ptr(30),
+		}, config.Sloctl)
+		assert.Equal(t, ptr(false), config.FilesPromptEnabled)
+		assert.Equal(t, ptr(30), config.FilesPromptThreshold)
+	})
 }
 
 func TestFileConfig_Save(t *testing.T) {
@@ -120,6 +172,10 @@ func TestFileConfig_Save(t *testing.T) {
 		config := &FileConfig{
 			ContextlessConfig: ContextlessConfig{
 				DefaultContext: "my-context",
+				Sloctl: &SloctlConfig{
+					FilesPromptEnabled:   ptr(false),
+					FilesPromptThreshold: ptr(30),
+				},
 			},
 			Contexts: map[string]ContextConfig{
 				"my-context": {
@@ -141,19 +197,56 @@ func TestFileConfig_Save(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, filePath)
 
-		var savedConfig FileConfig
-		_, err = toml.DecodeFile(filePath, &savedConfig)
+		savedConfig := new(FileConfig)
+		err = savedConfig.Load(filePath)
 		require.NoError(t, err)
-		assert.EqualExportedValues(t, *config, savedConfig)
+		config.normalizeSloctlConfig()
+		assert.EqualExportedValues(t, *config, *savedConfig)
+	})
+
+	t.Run("save migrates legacy sloctl config", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "legacy-sloctl-config-file")
+		config := &FileConfig{
+			ContextlessConfig: ContextlessConfig{
+				DefaultContext:       "my-context",
+				FilesPromptEnabled:   ptr(false),
+				FilesPromptThreshold: ptr(30),
+			},
+			Contexts: map[string]ContextConfig{
+				"my-context": {
+					ClientID:     "client-id",
+					ClientSecret: "client-secret",
+				},
+			},
+			filePath: filePath,
+		}
+
+		err := config.Save(filePath)
+		require.NoError(t, err)
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "[sloctl]")
+		assert.NotContains(t, string(data), "\nfilesPromptEnabled = false")
+		assert.NotContains(t, string(data), "\nfilesPromptThreshold = 30")
+
+		savedConfig := new(FileConfig)
+		err = savedConfig.Load(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, &SloctlConfig{
+			FilesPromptEnabled:   ptr(false),
+			FilesPromptThreshold: ptr(30),
+		}, savedConfig.Sloctl)
 	})
 }
 
 func TestFileConfig_Encoding(t *testing.T) {
 	testConfig := FileConfig{
 		ContextlessConfig: ContextlessConfig{
-			DefaultContext:       "production",
-			FilesPromptEnabled:   ptr(true),
-			FilesPromptThreshold: ptr(25),
+			DefaultContext: "production",
+			Sloctl: &SloctlConfig{
+				FilesPromptEnabled:   ptr(true),
+				FilesPromptThreshold: ptr(25),
+			},
 		},
 		Contexts: map[string]ContextConfig{
 			"production": {

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -233,6 +233,7 @@ func TestReadConfig_Defaults(t *testing.T) {
 		currentContext:       defaultContext,
 		options:              optionsConfig{NoConfigFile: ptr(true)},
 	}, conf)
+	assert.Nil(t, conf.contextlessConfig.Sloctl)
 }
 
 func TestReadConfig_EnvVariablesMinimal(t *testing.T) {
@@ -403,6 +404,21 @@ func TestSaveAccessToken(t *testing.T) {
 		assert.Equal(t, "new", newConf.AccessToken)
 		oldConf.AccessToken = "new"
 		assertConfigsAreEqual(t, oldConf, newConf)
+	})
+
+	t.Run("does not persist default sloctl config", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "sloctl-defaults.toml")
+		copyEmbeddedFile(t, "minimal_config.toml", filePath)
+
+		config, err := ReadConfig(ConfigOptionFilePath(filePath))
+		require.NoError(t, err)
+		require.NoError(t, config.saveAccessToken("new"))
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "[sloctl]")
+		assert.NotContains(t, string(data), "filesPromptEnabled")
+		assert.NotContains(t, string(data), "filesPromptThreshold")
 	})
 }
 

--- a/sdk/test_data/config/full_config.toml
+++ b/sdk/test_data/config/full_config.toml
@@ -1,6 +1,8 @@
 defaultContext = "non-default"
-filesPromptThreshold = 30
-filesPromptEnabled = false
+
+[sloctl]
+  filesPromptThreshold = 30
+  filesPromptEnabled = false
 
 [Contexts]
   [Contexts.default]

--- a/sdk/test_data/config/full_config_env_override.toml
+++ b/sdk/test_data/config/full_config_env_override.toml
@@ -1,6 +1,8 @@
 defaultContext = "default"
-filesPromptThreshold = 30
-filesPromptEnabled = false
+
+[sloctl]
+  filesPromptThreshold = 30
+  filesPromptEnabled = false
 
 [Contexts]
   [Contexts.default]

--- a/sdk/test_data/config_file/encoded_config.json
+++ b/sdk/test_data/config_file/encoded_config.json
@@ -1,7 +1,9 @@
 {
   "defaultContext": "production",
-  "filesPromptEnabled": true,
-  "filesPromptThreshold": 25,
+  "sloctl": {
+    "filesPromptEnabled": true,
+    "filesPromptThreshold": 25
+  },
   "contexts": {
     "production": {
       "clientId": "prod-client-id",

--- a/sdk/test_data/config_file/encoded_config.toml
+++ b/sdk/test_data/config_file/encoded_config.toml
@@ -1,6 +1,8 @@
 defaultContext = "production"
-filesPromptEnabled = true
-filesPromptThreshold = 25
+
+[sloctl]
+  filesPromptEnabled = true
+  filesPromptThreshold = 25
 
 [contexts]
   [contexts.production]

--- a/sdk/test_data/config_file/encoded_config.yaml
+++ b/sdk/test_data/config_file/encoded_config.yaml
@@ -1,7 +1,8 @@
 contextlessconfig:
   defaultContext: production
-  filesPromptEnabled: true
-  filesPromptThreshold: 25
+  sloctl:
+    filesPromptEnabled: true
+    filesPromptThreshold: 25
 contexts:
   production:
     clientId: prod-client-id


### PR DESCRIPTION
## Motivation

The sloctl-specific file prompt settings are currently stored at the root of the SDK config file. This PR moves them under a dedicated `sloctl` section while preserving compatibility with existing root-level TOML configs.
This improves readability and allows us to add new sloctl configurations more easily.

## Summary

- Add `SloctlConfig` and make it the canonical serialized location for file prompt settings.
- Keep legacy root-level TOML fields readable, with `[sloctl]` values taking precedence when both are present.
- Normalize legacy values on load and emit only the new nested shape on save, including updated TOML/JSON/YAML fixtures.
