### PR TITLE
feat: add SlackApp alert method type

### DIFF
--- a/manifest/v1alpha/alert_methods.go
+++ b/manifest/v1alpha/alert_methods.go
@@ -14,5 +14,6 @@ ServiceNow
 Jira
 Teams
 Email
+SlackApp
 )*/
 type AlertMethodType int

--- a/manifest/v1alpha/alert_methods_enum.go
+++ b/manifest/v1alpha/alert_methods_enum.go
@@ -31,11 +31,13 @@ const (
 	AlertMethodTypeTeams
 	// AlertMethodTypeEmail is a AlertMethodType of type Email.
 	AlertMethodTypeEmail
+	// AlertMethodTypeSlackApp is a AlertMethodType of type SlackApp.
+	AlertMethodTypeSlackApp
 )
 
 var ErrInvalidAlertMethodType = errors.New("not a valid AlertMethodType")
 
-const _AlertMethodTypeName = "WebhookPagerDutySlackDiscordOpsgenieServiceNowJiraTeamsEmail"
+const _AlertMethodTypeName = "WebhookPagerDutySlackDiscordOpsgenieServiceNowJiraTeamsEmailSlackApp"
 
 // AlertMethodTypeValues returns a list of the values for AlertMethodType
 func AlertMethodTypeValues() []AlertMethodType {
@@ -49,6 +51,7 @@ func AlertMethodTypeValues() []AlertMethodType {
 		AlertMethodTypeJira,
 		AlertMethodTypeTeams,
 		AlertMethodTypeEmail,
+		AlertMethodTypeSlackApp,
 	}
 }
 
@@ -62,6 +65,7 @@ var _AlertMethodTypeMap = map[AlertMethodType]string{
 	AlertMethodTypeJira:       _AlertMethodTypeName[46:50],
 	AlertMethodTypeTeams:      _AlertMethodTypeName[50:55],
 	AlertMethodTypeEmail:      _AlertMethodTypeName[55:60],
+	AlertMethodTypeSlackApp:   _AlertMethodTypeName[60:68],
 }
 
 // String implements the Stringer interface.
@@ -89,6 +93,7 @@ var _AlertMethodTypeValue = map[string]AlertMethodType{
 	_AlertMethodTypeName[46:50]: AlertMethodTypeJira,
 	_AlertMethodTypeName[50:55]: AlertMethodTypeTeams,
 	_AlertMethodTypeName[55:60]: AlertMethodTypeEmail,
+	_AlertMethodTypeName[60:68]: AlertMethodTypeSlackApp,
 }
 
 // ParseAlertMethodType attempts to convert a string to a AlertMethodType.

--- a/manifest/v1alpha/alertmethod/alert_method.go
+++ b/manifest/v1alpha/alertmethod/alert_method.go
@@ -51,6 +51,7 @@ type Spec struct {
 	Jira        *JiraAlertMethod       `json:"jira,omitempty"`
 	Teams       *TeamsAlertMethod      `json:"msteams,omitempty"`
 	Email       *EmailAlertMethod      `json:"email,omitempty"`
+	SlackApp    *SlackAppAlertMethod   `json:"slackApp,omitempty"`
 }
 
 func (s Spec) GetType() (v1alpha.AlertMethodType, error) {
@@ -73,6 +74,8 @@ func (s Spec) GetType() (v1alpha.AlertMethodType, error) {
 		return v1alpha.AlertMethodTypeTeams, nil
 	case s.Email != nil:
 		return v1alpha.AlertMethodTypeEmail, nil
+	case s.SlackApp != nil:
+		return v1alpha.AlertMethodTypeSlackApp, nil
 	}
 	return 0, errors.New("unknown alert method type")
 }
@@ -148,4 +151,12 @@ type EmailAlertMethod struct {
 	Cc              []string `json:"cc,omitempty"`
 	Bcc             []string `json:"bcc,omitempty"`
 	SendAsPlainText *bool    `json:"sendAsPlainText,omitempty"`
+}
+
+// SlackAppAlertMethod represents a set of properties required to send alerts via the Nobl9 Slack App.
+type SlackAppAlertMethod struct {
+	WorkspaceID   string `json:"workspaceId"`
+	ChannelID     string `json:"channelId"`
+	ChannelName   string `json:"channelName,omitempty"`
+	WebhookSecret string `json:"webhookSecret,omitempty"`
 }

--- a/manifest/v1alpha/alertmethod/validation.go
+++ b/manifest/v1alpha/alertmethod/validation.go
@@ -84,6 +84,9 @@ var specValidation = govy.New[Spec](
 			if s.Email != nil {
 				alertMethodCounter++
 			}
+			if s.SlackApp != nil {
+				alertMethodCounter++
+			}
 			if alertMethodCounter != expectedNumberOfAlertMethodTypes {
 				return errors.New("exactly one alert method configuration is required")
 			}
@@ -116,6 +119,9 @@ var specValidation = govy.New[Spec](
 	govy.ForPointer(func(s Spec) *EmailAlertMethod { return s.Email }).
 		WithName("email").
 		Include(emailValidation),
+	govy.ForPointer(func(s Spec) *SlackAppAlertMethod { return s.SlackApp }).
+		WithName("slackApp").
+		Include(slackAppValidation),
 )
 
 var webhookValidation = govy.New[WebhookAlertMethod](
@@ -302,6 +308,17 @@ var emailValidation = govy.New[EmailAlertMethod](
 	govy.For(func(s EmailAlertMethod) []string { return s.Bcc }).
 		WithName("bcc").
 		Rules(rules.SliceMaxLength[[]string](maxEmailRecipients)),
+)
+
+var slackAppValidation = govy.New[SlackAppAlertMethod](
+	govy.For(func(s SlackAppAlertMethod) string { return s.WorkspaceID }).
+		WithName("workspaceId").
+		Required().
+		Rules(rules.StringNotEmpty()),
+	govy.For(func(s SlackAppAlertMethod) string { return s.ChannelID }).
+		WithName("channelId").
+		Required().
+		Rules(rules.StringNotEmpty()),
 )
 
 func optionalUrlWithPrefixValidation(prefixes ...string) govy.Validator[string] {

--- a/manifest/v1alpha/examples/alert_method.go
+++ b/manifest/v1alpha/examples/alert_method.go
@@ -24,6 +24,7 @@ const (
 var standardAlertMethods = []v1alpha.AlertMethodType{
 	v1alpha.AlertMethodTypePagerDuty,
 	v1alpha.AlertMethodTypeSlack,
+	v1alpha.AlertMethodTypeSlackApp,
 	v1alpha.AlertMethodTypeDiscord,
 	v1alpha.AlertMethodTypeServiceNow,
 	v1alpha.AlertMethodTypeJira,
@@ -151,6 +152,13 @@ func (a alertMethodExample) generateVariant(am v1alphaAlertMethod.AlertMethod) v
 	case v1alpha.AlertMethodTypeSlack:
 		am.Spec.Slack = &v1alphaAlertMethod.SlackAlertMethod{
 			URL: "https://hooks.slack.com/services/321/123/secret",
+		}
+	case v1alpha.AlertMethodTypeSlackApp:
+		am.Spec.SlackApp = &v1alphaAlertMethod.SlackAppAlertMethod{
+			WorkspaceID:   "T0123456789",
+			ChannelID:     "C0123456789",
+			ChannelName:   "alerts",
+			WebhookSecret: "very-secret",
 		}
 	case v1alpha.AlertMethodTypeTeams:
 		am.Spec.Teams = &v1alphaAlertMethod.TeamsAlertMethod{

--- a/tests/v1alpha_alertmethod_test.go
+++ b/tests/v1alpha_alertmethod_test.go
@@ -117,6 +117,8 @@ func assertV1alphaAlertMethodsAreEqual(t *testing.T, expected, actual v1alphaAle
 		expected.Spec.ServiceNow.Password = "[hidden]"
 	case v1alpha.AlertMethodTypeSlack:
 		expected.Spec.Slack.URL = "[hidden]"
+	case v1alpha.AlertMethodTypeSlackApp:
+		expected.Spec.SlackApp.WebhookSecret = "[hidden]"
 	case v1alpha.AlertMethodTypeTeams:
 		expected.Spec.Teams.URL = "[hidden]"
 	case v1alpha.AlertMethodTypeEmail:


### PR DESCRIPTION
## Summary

Adds the `SlackAppAlertMethod` type for the new Nobl9 Slack App integration.

- New `SlackAppAlertMethod` struct (`workspaceId`, `channelId`) on `alertmethod.Spec`.
- New `AlertMethodTypeSlackApp` enum value with name/string mappings.
- Validation rules requiring both `workspaceId` and `channelId` to be non-empty when the SlackApp method is set.

## Why now

This unblocks the n9 PR chain that delivers Slack App notifications:

- nobl9/n9#20644 — proto + shared model types (depends on this release)
- nobl9/n9#20646 — slackoauth service
- nobl9/n9#20653 — infrastructure / Helm / Kafka topics
- nobl9/n9#20832 — `notificationsslackapp` Kafka consumer

n9's `go.mod` currently pins this branch by pseudo-version. Once this PR merges and a release tag is cut, n9 can bump to the proper tagged version.

## Test plan

- [ ] `make test`
- [ ] `make check`