### PR TITLE
feat: add BurnAnomaly annotation category

### DIFF
--- a/manifest/v1alpha/annotation/category.go
+++ b/manifest/v1alpha/annotation/category.go
@@ -15,6 +15,7 @@ NoDataAnomaly
 IncrementalMismatchAnomaly
 NoBurnAnomaly
 ConstantBurnAnomaly
+BurnAnomaly
 )*/
 type Category string
 
@@ -26,6 +27,7 @@ var systemCategories = []Category{
 	CategoryIncrementalMismatchAnomaly,
 	CategoryNoBurnAnomaly,
 	CategoryConstantBurnAnomaly,
+	CategoryBurnAnomaly,
 }
 
 var userCategories = []Category{

--- a/manifest/v1alpha/annotation/category_enum.go
+++ b/manifest/v1alpha/annotation/category_enum.go
@@ -21,6 +21,7 @@ const (
 	CategoryIncrementalMismatchAnomaly Category = "IncrementalMismatchAnomaly"
 	CategoryNoBurnAnomaly              Category = "NoBurnAnomaly"
 	CategoryConstantBurnAnomaly        Category = "ConstantBurnAnomaly"
+	CategoryBurnAnomaly                Category = "BurnAnomaly"
 )
 
 var ErrInvalidCategory = errors.New("not a valid Category")
@@ -37,6 +38,7 @@ func CategoryValues() []Category {
 		CategoryIncrementalMismatchAnomaly,
 		CategoryNoBurnAnomaly,
 		CategoryConstantBurnAnomaly,
+		CategoryBurnAnomaly,
 	}
 }
 
@@ -62,6 +64,7 @@ var _CategoryValue = map[string]Category{
 	"IncrementalMismatchAnomaly": CategoryIncrementalMismatchAnomaly,
 	"NoBurnAnomaly":              CategoryNoBurnAnomaly,
 	"ConstantBurnAnomaly":        CategoryConstantBurnAnomaly,
+	"BurnAnomaly":                CategoryBurnAnomaly,
 }
 
 // ParseCategory attempts to convert a string to a Category.

--- a/manifest/v1alpha/annotation/category_test.go
+++ b/manifest/v1alpha/annotation/category_test.go
@@ -1,0 +1,17 @@
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCategory_BurnAnomaly(t *testing.T) {
+	category, err := ParseCategory("BurnAnomaly")
+	require.NoError(t, err)
+	assert.Equal(t, CategoryBurnAnomaly, category)
+	assert.True(t, CategoryBurnAnomaly.IsValid())
+	assert.Contains(t, GetSystemCategories(), CategoryBurnAnomaly)
+	assert.NotContains(t, GetUserCategories(), CategoryBurnAnomaly)
+}


### PR DESCRIPTION
## Release Notes

Add SDK manifest support for the `BurnAnomaly` system annotation category.

## Motivation

The platform is adding a Burn anomaly detector whose annotations use the `BurnAnomaly` category. The Go manifest API needs to recognize that category during API and manifest conversion while keeping it reserved for system-created annotations.

## Summary

- Add `BurnAnomaly` to the annotation category enum source and generated enum output.
- Include `CategoryBurnAnomaly` in system annotation categories.
- Keep `CategoryBurnAnomaly` out of user-created annotation categories.
- Add focused tests for parsing, validity, and system/user category membership.

## Testing

`GOCACHE=/tmp/go-build go generate ./manifest/v1alpha/annotation`

`GOCACHE=/tmp/go-build go test ./manifest/v1alpha/annotation -run 'Test(Category_BurnAnomaly|Spec_Category)' -count=1`

`GOCACHE=/tmp/go-build go test ./manifest/v1alpha/annotation -count=1`

`git diff --check`
