### PR TITLE
feat: add project-scoped kind helper

### DIFF
--- a/manifest/kind.go
+++ b/manifest/kind.go
@@ -2,7 +2,10 @@ package manifest
 
 //go:generate ../bin/go-enum --nocase --lower --names --values
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // Kind represents all the [Object] kinds available in the API to perform operations on.
 /*ENUM(
@@ -39,6 +42,15 @@ func (k Kind) Equals(s string) bool {
 // In other words, it informs whether the [Kind] lifecycle is managed by the user.
 func (k Kind) Applicable() bool {
 	return k != KindAlert && k != KindUserGroup
+}
+
+// ProjectScoped returns true if the [Kind] is tied to a specific [KindProject].
+// It is equivalent to a type assertion for [ProjectScopedObject]:
+//
+//	_, ok := object.(ProjectScopedObject)
+//	return ok == object.GetKind().ProjectScoped() // always true
+func (k Kind) ProjectScoped() bool {
+	return slices.Contains(ProjectScopedKinds(), k)
 }
 
 // ApplicableKinds returns all the [Kind] instances which can be applied or deleted by the user.

--- a/manifest/kind_test.go
+++ b/manifest/kind_test.go
@@ -1,0 +1,15 @@
+package manifest
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKind_ProjectScoped(t *testing.T) {
+	for _, kind := range KindValues() {
+		isProjectScoped := slices.Contains(ProjectScopedKinds(), kind)
+		assert.Equal(t, kind.ProjectScoped(), isProjectScoped)
+	}
+}

--- a/manifest/v1alpha/generic_object.go
+++ b/manifest/v1alpha/generic_object.go
@@ -17,7 +17,7 @@ const (
 // GenericObject represents a generic map[string]interface{} representation of manifest.Object.
 // It's useful for scenarios where an implementation does not want to be tied to specific
 // v1alpha versions.
-type GenericObject map[string]interface{}
+type GenericObject map[string]any
 
 func (g GenericObject) GetVersion() manifest.Version {
 	name, _ := g[genericFieldVersion].(string)
@@ -32,7 +32,7 @@ func (g GenericObject) GetKind() manifest.Kind {
 }
 
 func (g GenericObject) GetName() string {
-	meta, ok := g[genericFieldMetadata].(map[string]interface{})
+	meta, ok := g[genericFieldMetadata].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -45,7 +45,7 @@ func (g GenericObject) Validate() error {
 }
 
 func (g GenericObject) GetProject() string {
-	meta, ok := g[genericFieldMetadata].(map[string]interface{})
+	meta, ok := g[genericFieldMetadata].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -54,18 +54,16 @@ func (g GenericObject) GetProject() string {
 }
 
 func (g GenericObject) SetProject(project string) manifest.Object {
-	switch g.GetKind() {
-	case 0, manifest.KindProject, manifest.KindRoleBinding, manifest.KindUserGroup:
-		return g
-	default:
-		meta, ok := g[genericFieldMetadata].(map[string]interface{})
-		if !ok {
-			return g
-		}
-		meta[genericFieldProject] = project
-		g[genericFieldMetadata] = meta
+	if !g.GetKind().ProjectScoped() {
 		return g
 	}
+	meta, ok := g[genericFieldMetadata].(map[string]any)
+	if !ok {
+		return g
+	}
+	meta[genericFieldProject] = project
+	g[genericFieldMetadata] = meta
+	return g
 }
 
 func (g GenericObject) GetOrganization() string {

--- a/manifest/v1alpha/generic_object_test.go
+++ b/manifest/v1alpha/generic_object_test.go
@@ -40,7 +40,7 @@ func TestGenericObject_GetKind(t *testing.T) {
 func TestGenericObject_GetName(t *testing.T) {
 	t.Run("returns version", func(t *testing.T) {
 		assert.Equal(t, "default",
-			GenericObject{genericFieldMetadata: map[string]interface{}{genericFieldName: "default"}}.GetName())
+			GenericObject{genericFieldMetadata: map[string]any{genericFieldName: "default"}}.GetName())
 	})
 	t.Run("no metadata, not panics", func(t *testing.T) {
 		assert.NotPanics(t, func() { GenericObject{}.GetName() })
@@ -49,11 +49,11 @@ func TestGenericObject_GetName(t *testing.T) {
 		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: 123}.GetName() })
 	})
 	t.Run("empty, not panics", func(t *testing.T) {
-		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: map[string]interface{}{}}.GetName() })
+		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: map[string]any{}}.GetName() })
 	})
 	t.Run("invalid type, not panics", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			GenericObject{genericFieldMetadata: map[string]interface{}{genericFieldName: 1}}.GetName()
+			GenericObject{genericFieldMetadata: map[string]any{genericFieldName: 1}}.GetName()
 		})
 	})
 }
@@ -61,7 +61,7 @@ func TestGenericObject_GetName(t *testing.T) {
 func TestGenericObject_GetProject(t *testing.T) {
 	t.Run("returns version", func(t *testing.T) {
 		assert.Equal(t, "default",
-			GenericObject{genericFieldMetadata: map[string]interface{}{genericFieldProject: "default"}}.GetProject())
+			GenericObject{genericFieldMetadata: map[string]any{genericFieldProject: "default"}}.GetProject())
 	})
 	t.Run("no metadata, not panics", func(t *testing.T) {
 		assert.NotPanics(t, func() { GenericObject{}.GetProject() })
@@ -70,40 +70,39 @@ func TestGenericObject_GetProject(t *testing.T) {
 		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: 123}.GetProject() })
 	})
 	t.Run("empty, not panics", func(t *testing.T) {
-		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: map[string]interface{}{}}.GetProject() })
+		assert.NotPanics(t, func() { GenericObject{genericFieldMetadata: map[string]any{}}.GetProject() })
 	})
 	t.Run("invalid type, not panics", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			GenericObject{genericFieldMetadata: map[string]interface{}{genericFieldProject: 1}}.GetProject()
+			GenericObject{genericFieldMetadata: map[string]any{genericFieldProject: 1}}.GetProject()
 		})
 	})
 }
 
 func TestGenericObject_SetProject(t *testing.T) {
-	t.Run("sets project", func(t *testing.T) {
-		o := GenericObject{genericFieldMetadata: map[string]interface{}{}}
-		for _, kind := range []manifest.Kind{
-			manifest.KindSLO,
-			manifest.KindProject,
-			manifest.KindService,
-		} {
-			o[genericFieldKind] = kind.String()
-			res := o.SetProject("default").(manifest.ProjectScopedObject)
-			assert.Equal(t, "default", res.GetProject())
+	t.Run("sets project for project scoped kinds", func(t *testing.T) {
+		for _, kind := range manifest.ProjectScopedKinds() {
+			t.Run(kind.String(), func(t *testing.T) {
+				obj := GenericObject{
+					genericFieldKind:     kind.String(),
+					genericFieldMetadata: map[string]any{},
+				}.SetProject("foo")
+				assert.Equal(t, "foo", obj.(GenericObject).GetProject())
+			})
 		}
 	})
-	t.Run("do not set for specific kinds", func(t *testing.T) {
-		o := GenericObject{genericFieldMetadata: map[string]interface{}{}}
-		for _, kind := range []manifest.Kind{
-			0,
-			manifest.KindProject,
-			manifest.KindRoleBinding,
-			manifest.KindUserGroup,
-		} {
-			o[genericFieldKind] = kind.String()
-			res := o.SetProject("default")
-			assert.NotNil(t, res)
-			assert.Nil(t, o[genericFieldMetadata].(map[string]interface{})[genericFieldProject])
+	t.Run("does not set project for organization scoped kinds", func(t *testing.T) {
+		for _, kind := range append([]manifest.Kind{0}, manifest.KindValues()...) {
+			if kind.ProjectScoped() {
+				continue
+			}
+			t.Run(kind.String(), func(t *testing.T) {
+				obj := GenericObject{
+					genericFieldKind:     kind.String(),
+					genericFieldMetadata: map[string]any{},
+				}.SetProject("foo")
+				assert.Empty(t, obj.(GenericObject).GetProject())
+			})
 		}
 	})
 	t.Run("invalid metadata type, not panics", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

We already have generated `ProjectScopedKinds`, but it would be more ergonomic to have a method defined directly on `Kind`.

## Summary

I also fixed invalid logic for `GenericObject` which was not taking into account newer object kinds.

## Release Notes

Added `Kind.ProjectScoped()` which checks whether a kind belongs to a project.
