### PR TITLE
feat: PC-19870 allow alpha and beta release channels for Splunk Observability

### DIFF
--- a/manifest/v1alpha/agent/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/agent/examples/splunk-observability.yaml
@@ -11,7 +11,7 @@
       team: sales
   spec:
     description: Example Splunk Observability Agent
-    releaseChannel: stable
+    releaseChannel: beta
     splunkObservability:
       realm: us1
     queryDelay:

--- a/manifest/v1alpha/agent/validation.go
+++ b/manifest/v1alpha/agent/validation.go
@@ -42,8 +42,7 @@ var specValidation = govy.New[Spec](
 		Rules(exactlyOneDataSourceTypeValidationRule).
 		Rules(
 			historicalDataRetrievalValidationRule,
-			queryDelayValidationRule,
-			releaseChannelValidationRule),
+			queryDelayValidationRule),
 	govy.For(func(s Spec) v1alpha.ReleaseChannel { return s.ReleaseChannel }).
 		WithName("releaseChannel").
 		OmitEmpty().
@@ -322,7 +321,6 @@ var (
 const (
 	errCodeExactlyOneDataSourceType  = "exactly_one_data_source_type"
 	errCodeQueryDelayOutOfBounds     = "query_delay_out_of_bounds"
-	errCodeUnsupportedReleaseChannel = "unsupported_release_channel"
 	errCodeHTTPOrHTTPSSchemeRequired = "url_http_or_https_scheme"
 	errCodeHTTPSSchemeRequired       = "https_scheme_required"
 )
@@ -544,17 +542,6 @@ var queryDelayValidationRule = govy.NewRule(func(spec Spec) error {
 	}
 	return nil
 }).WithErrorCode(errCodeQueryDelayOutOfBounds)
-
-var releaseChannelValidationRule = govy.NewRule(func(spec Spec) error {
-	typ, _ := spec.GetType()
-	if typ == v1alpha.SplunkObservability && spec.ReleaseChannel != v1alpha.ReleaseChannelBeta {
-		return govy.NewPropertyError(jsonpath.New().Name("releaseChannel"),
-			spec.ReleaseChannel,
-			errors.New("must be 'beta' for Splunk Observability"),
-		)
-	}
-	return nil
-}).WithErrorCode(errCodeUnsupportedReleaseChannel)
 
 // newURLValidator is a helper construct for Agent which only have a simple 'url' field govy.
 func newURLValidator[S any](getter govy.PropertyGetter[string, S]) govy.Validator[S] {

--- a/manifest/v1alpha/agent/validation.go
+++ b/manifest/v1alpha/agent/validation.go
@@ -42,7 +42,8 @@ var specValidation = govy.New[Spec](
 		Rules(exactlyOneDataSourceTypeValidationRule).
 		Rules(
 			historicalDataRetrievalValidationRule,
-			queryDelayValidationRule),
+			queryDelayValidationRule,
+			releaseChannelValidationRule),
 	govy.For(func(s Spec) v1alpha.ReleaseChannel { return s.ReleaseChannel }).
 		WithName("releaseChannel").
 		OmitEmpty().
@@ -321,6 +322,7 @@ var (
 const (
 	errCodeExactlyOneDataSourceType  = "exactly_one_data_source_type"
 	errCodeQueryDelayOutOfBounds     = "query_delay_out_of_bounds"
+	errCodeUnsupportedReleaseChannel = "unsupported_release_channel"
 	errCodeHTTPOrHTTPSSchemeRequired = "url_http_or_https_scheme"
 	errCodeHTTPSSchemeRequired       = "https_scheme_required"
 )
@@ -542,6 +544,17 @@ var queryDelayValidationRule = govy.NewRule(func(spec Spec) error {
 	}
 	return nil
 }).WithErrorCode(errCodeQueryDelayOutOfBounds)
+
+var releaseChannelValidationRule = govy.NewRule(func(spec Spec) error {
+	typ, _ := spec.GetType()
+	if typ == v1alpha.SplunkObservability && spec.ReleaseChannel != v1alpha.ReleaseChannelBeta {
+		return govy.NewPropertyError(jsonpath.New().Name("releaseChannel"),
+			spec.ReleaseChannel,
+			errors.New("must be 'beta' for Splunk Observability"),
+		)
+	}
+	return nil
+}).WithErrorCode(errCodeUnsupportedReleaseChannel)
 
 // newURLValidator is a helper construct for Agent which only have a simple 'url' field govy.
 func newURLValidator[S any](getter govy.PropertyGetter[string, S]) govy.Validator[S] {

--- a/manifest/v1alpha/agent/validation.go
+++ b/manifest/v1alpha/agent/validation.go
@@ -42,7 +42,8 @@ var specValidation = govy.New[Spec](
 		Rules(exactlyOneDataSourceTypeValidationRule).
 		Rules(
 			historicalDataRetrievalValidationRule,
-			queryDelayValidationRule),
+			queryDelayValidationRule,
+			releaseChannelValidationRule),
 	govy.For(func(s Spec) v1alpha.ReleaseChannel { return s.ReleaseChannel }).
 		WithName("releaseChannel").
 		OmitEmpty().
@@ -321,6 +322,7 @@ var (
 const (
 	errCodeExactlyOneDataSourceType  = "exactly_one_data_source_type"
 	errCodeQueryDelayOutOfBounds     = "query_delay_out_of_bounds"
+	errCodeUnsupportedReleaseChannel = "unsupported_release_channel"
 	errCodeHTTPOrHTTPSSchemeRequired = "url_http_or_https_scheme"
 	errCodeHTTPSSchemeRequired       = "https_scheme_required"
 )
@@ -542,6 +544,19 @@ var queryDelayValidationRule = govy.NewRule(func(spec Spec) error {
 	}
 	return nil
 }).WithErrorCode(errCodeQueryDelayOutOfBounds)
+
+var releaseChannelValidationRule = govy.NewRule(func(spec Spec) error {
+	typ, _ := spec.GetType()
+	if typ == v1alpha.SplunkObservability &&
+		spec.ReleaseChannel != v1alpha.ReleaseChannelBeta &&
+		spec.ReleaseChannel != v1alpha.ReleaseChannelAlpha {
+		return govy.NewPropertyError(jsonpath.New().Name("releaseChannel"),
+			spec.ReleaseChannel,
+			errors.New("must be 'alpha' or 'beta' for Splunk Observability"),
+		)
+	}
+	return nil
+}).WithErrorCode(errCodeUnsupportedReleaseChannel)
 
 // newURLValidator is a helper construct for Agent which only have a simple 'url' field govy.
 func newURLValidator[S any](getter govy.PropertyGetter[string, S]) govy.Validator[S] {

--- a/manifest/v1alpha/agent/validation_test.go
+++ b/manifest/v1alpha/agent/validation_test.go
@@ -638,17 +638,26 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 }
 
 func TestValidateSpec_SplunkObservability(t *testing.T) {
-	t.Run("allows any release channel (agent mode is unrestricted)", func(t *testing.T) {
+	t.Run("passes with alpha or beta release channel", func(t *testing.T) {
 		for _, rc := range []v1alpha.ReleaseChannel{
-			v1alpha.ReleaseChannelStable,
-			v1alpha.ReleaseChannelBeta,
 			v1alpha.ReleaseChannelAlpha,
+			v1alpha.ReleaseChannelBeta,
 		} {
 			agent := validAgent(v1alpha.SplunkObservability)
 			agent.Spec.ReleaseChannel = rc
 			err := validate(agent)
 			testutils.AssertNoError(t, agent, err)
 		}
+	})
+	t.Run("rejects non-alpha/beta release channel", func(t *testing.T) {
+		agent := validAgent(v1alpha.SplunkObservability)
+		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
+		err := validate(agent)
+		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
+			Prop:    "spec.releaseChannel",
+			Code:    errCodeUnsupportedReleaseChannel,
+			Message: "must be 'alpha' or 'beta' for Splunk Observability",
+		})
 	})
 	t.Run("required fields", func(t *testing.T) {
 		agent := validAgent(v1alpha.SplunkObservability)

--- a/manifest/v1alpha/agent/validation_test.go
+++ b/manifest/v1alpha/agent/validation_test.go
@@ -638,11 +638,17 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 }
 
 func TestValidateSpec_SplunkObservability(t *testing.T) {
-	t.Run("passes", func(t *testing.T) {
-		agent := validAgent(v1alpha.SplunkObservability)
-		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
-		err := validate(agent)
-		testutils.AssertNoError(t, agent, err)
+	t.Run("allows any release channel (agent mode is unrestricted)", func(t *testing.T) {
+		for _, rc := range []v1alpha.ReleaseChannel{
+			v1alpha.ReleaseChannelStable,
+			v1alpha.ReleaseChannelBeta,
+			v1alpha.ReleaseChannelAlpha,
+		} {
+			agent := validAgent(v1alpha.SplunkObservability)
+			agent.Spec.ReleaseChannel = rc
+			err := validate(agent)
+			testutils.AssertNoError(t, agent, err)
+		}
 	})
 	t.Run("required fields", func(t *testing.T) {
 		agent := validAgent(v1alpha.SplunkObservability)

--- a/manifest/v1alpha/agent/validation_test.go
+++ b/manifest/v1alpha/agent/validation_test.go
@@ -640,11 +640,13 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 func TestValidateSpec_SplunkObservability(t *testing.T) {
 	t.Run("passes", func(t *testing.T) {
 		agent := validAgent(v1alpha.SplunkObservability)
+		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
 		err := validate(agent)
 		testutils.AssertNoError(t, agent, err)
 	})
 	t.Run("required fields", func(t *testing.T) {
 		agent := validAgent(v1alpha.SplunkObservability)
+		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
 		agent.Spec.SplunkObservability.Realm = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{

--- a/manifest/v1alpha/data_sources.go
+++ b/manifest/v1alpha/data_sources.go
@@ -446,7 +446,6 @@ func DataDogSiteValidationRule() govy.Rule[string] {
 
 func GetReleaseChannelAlphaEnabledDataSources() []DataSourceType {
 	return []DataSourceType{
-		SplunkObservability,
 		Honeycomb,
 	}
 }

--- a/manifest/v1alpha/data_sources.go
+++ b/manifest/v1alpha/data_sources.go
@@ -446,6 +446,7 @@ func DataDogSiteValidationRule() govy.Rule[string] {
 
 func GetReleaseChannelAlphaEnabledDataSources() []DataSourceType {
 	return []DataSourceType{
+		SplunkObservability,
 		Honeycomb,
 	}
 }

--- a/manifest/v1alpha/direct/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/direct/examples/splunk-observability.yaml
@@ -11,7 +11,7 @@ metadata:
     team: sales
 spec:
   description: Example Splunk Observability Direct
-  releaseChannel: alpha
+  releaseChannel: beta
   splunkObservability:
     realm: us1
     accessToken: "[secret]"

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -443,10 +443,10 @@ var releaseChannelValidationRule = govy.NewRule(func(spec Spec) error {
 		)
 	}
 
-	if typ == v1alpha.SplunkObservability && spec.ReleaseChannel != v1alpha.ReleaseChannelAlpha {
+	if typ == v1alpha.SplunkObservability && spec.ReleaseChannel != v1alpha.ReleaseChannelBeta {
 		return govy.NewPropertyError(jsonpath.New().Name("releaseChannel"),
 			spec.ReleaseChannel,
-			errors.New("must be 'alpha' for Splunk Observability"),
+			errors.New("must be 'beta' for Splunk Observability"),
 		)
 	}
 

--- a/manifest/v1alpha/direct/validation.go
+++ b/manifest/v1alpha/direct/validation.go
@@ -443,10 +443,12 @@ var releaseChannelValidationRule = govy.NewRule(func(spec Spec) error {
 		)
 	}
 
-	if typ == v1alpha.SplunkObservability && spec.ReleaseChannel != v1alpha.ReleaseChannelBeta {
+	if typ == v1alpha.SplunkObservability &&
+		spec.ReleaseChannel != v1alpha.ReleaseChannelBeta &&
+		spec.ReleaseChannel != v1alpha.ReleaseChannelAlpha {
 		return govy.NewPropertyError(jsonpath.New().Name("releaseChannel"),
 			spec.ReleaseChannel,
-			errors.New("must be 'beta' for Splunk Observability"),
+			errors.New("must be 'alpha' or 'beta' for Splunk Observability"),
 		)
 	}
 

--- a/manifest/v1alpha/direct/validation_test.go
+++ b/manifest/v1alpha/direct/validation_test.go
@@ -648,13 +648,13 @@ func TestValidateSpec_BigQuery(t *testing.T) {
 func TestValidateSpec_SplunkObservability(t *testing.T) {
 	t.Run("passes", func(t *testing.T) {
 		direct := validDirect(v1alpha.SplunkObservability)
-		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelAlpha
+		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
 		err := validate(direct)
 		testutils.AssertNoError(t, direct, err)
 	})
 	t.Run("required realm", func(t *testing.T) {
 		direct := validDirect(v1alpha.SplunkObservability)
-		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelAlpha
+		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
 		direct.Spec.SplunkObservability.Realm = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{

--- a/manifest/v1alpha/direct/validation_test.go
+++ b/manifest/v1alpha/direct/validation_test.go
@@ -646,11 +646,26 @@ func TestValidateSpec_BigQuery(t *testing.T) {
 }
 
 func TestValidateSpec_SplunkObservability(t *testing.T) {
-	t.Run("passes", func(t *testing.T) {
+	t.Run("passes with alpha or beta release channel", func(t *testing.T) {
+		for _, rc := range []v1alpha.ReleaseChannel{
+			v1alpha.ReleaseChannelAlpha,
+			v1alpha.ReleaseChannelBeta,
+		} {
+			direct := validDirect(v1alpha.SplunkObservability)
+			direct.Spec.ReleaseChannel = rc
+			err := validate(direct)
+			testutils.AssertNoError(t, direct, err)
+		}
+	})
+	t.Run("rejects non-alpha/beta release channel", func(t *testing.T) {
 		direct := validDirect(v1alpha.SplunkObservability)
-		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
+		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
 		err := validate(direct)
-		testutils.AssertNoError(t, direct, err)
+		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
+			Prop:    "spec.releaseChannel",
+			Code:    errCodeUnsupportedReleaseChannel,
+			Message: "must be 'alpha' or 'beta' for Splunk Observability",
+		})
 	})
 	t.Run("required realm", func(t *testing.T) {
 		direct := validDirect(v1alpha.SplunkObservability)

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -59,6 +59,7 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.Elasticsearch,
 	v1alpha.ThousandEyes,
 	// Support for Replay only in beta.
+	v1alpha.SplunkObservability,
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,
 	v1alpha.Dash0,

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -59,7 +59,6 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.Elasticsearch,
 	v1alpha.ThousandEyes,
 	// Support for Replay only in beta.
-	v1alpha.SplunkObservability,
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,
 	v1alpha.Dash0,

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -58,6 +58,8 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	// Support for Replay only in beta.
 	v1alpha.Elasticsearch,
 	v1alpha.ThousandEyes,
+	// Gated to alpha and beta release channels.
+	v1alpha.SplunkObservability,
 	// Support for Replay only in beta.
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,
@@ -99,15 +101,12 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 			Unit:  defaultQueryDelay.Unit,
 		},
 	}
-	agent.Spec.ReleaseChannel = releaseChannelFor(typ, a.replayEnabled)
+	agent.Spec.ReleaseChannel = releaseChannelFor(typ)
 	return agent
 }
 
-func releaseChannelFor(typ v1alpha.DataSourceType, replayEnabled bool) v1alpha.ReleaseChannel {
+func releaseChannelFor(typ v1alpha.DataSourceType) v1alpha.ReleaseChannel {
 	if !slices.Contains(betaChannelAgents, typ) {
-		return v1alpha.ReleaseChannelStable
-	}
-	if typ == v1alpha.SplunkObservability && !replayEnabled {
 		return v1alpha.ReleaseChannelStable
 	}
 	return v1alpha.ReleaseChannelBeta

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -58,8 +58,6 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	// Support for Replay only in beta.
 	v1alpha.Elasticsearch,
 	v1alpha.ThousandEyes,
-	// Gated to alpha and beta release channels.
-	v1alpha.SplunkObservability,
 	// Support for Replay only in beta.
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,

--- a/manifest/v1alpha/examples/direct.go
+++ b/manifest/v1alpha/examples/direct.go
@@ -38,9 +38,7 @@ func Direct() []Example {
 	return examples
 }
 
-var alphaChannelDirects = []v1alpha.DataSourceType{
-	v1alpha.SplunkObservability,
-}
+var alphaChannelDirects = []v1alpha.DataSourceType{}
 
 var betaChannelDirects = []v1alpha.DataSourceType{
 	v1alpha.AzureMonitor,
@@ -50,6 +48,7 @@ var betaChannelDirects = []v1alpha.DataSourceType{
 	v1alpha.AzurePrometheus,
 	v1alpha.ThousandEyes,
 	// Support for Replay only in beta.
+	v1alpha.SplunkObservability,
 	v1alpha.SumoLogic,
 	v1alpha.Dash0,
 }

--- a/manifest/v1alpha/examples/direct.go
+++ b/manifest/v1alpha/examples/direct.go
@@ -38,8 +38,6 @@ func Direct() []Example {
 	return examples
 }
 
-var alphaChannelDirects = []v1alpha.DataSourceType{}
-
 var betaChannelDirects = []v1alpha.DataSourceType{
 	v1alpha.AzureMonitor,
 	v1alpha.Honeycomb,
@@ -87,8 +85,6 @@ func (d directExample) Generate() v1alphaDirect.Direct {
 		},
 	}
 	switch {
-	case slices.Contains(alphaChannelDirects, typ):
-		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelAlpha
 	case slices.Contains(betaChannelDirects, typ):
 		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
 	default:


### PR DESCRIPTION
Allow Splunk Observability data sources on both the `alpha` and `beta` release channels (Direct and Agent), instead of beta only. Splunk Observability stays available on `alpha` while Replay graduates onto `beta`.

## Behavior

| Spec | Before (beta-only) | After |
|---|---|---|
| Splunk Observability Direct | `beta` only | `alpha` or `beta` |
| Splunk Observability in alpha-enabled sources | dropped | kept |
| Splunk Observability Agent | gated to `beta` | `alpha` or `beta` |

## Edge Cases

- The agent gate mirrors the direct gate: `alpha` or `beta` only, `stable` rejected with a clear error. The agent example is generated on `beta`.
- Direct still rejects `stable` for Splunk Observability with a clear error.

