### PR TITLE
fix: set Splunk Observability agent example to beta channel

### DIFF
--- a/manifest/v1alpha/agent/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/agent/examples/splunk-observability.yaml
@@ -11,7 +11,7 @@ metadata:
     team: sales
 spec:
   description: Example Splunk Observability Agent
-  releaseChannel: stable
+  releaseChannel: beta
   splunkObservability:
     realm: us1
   historicalDataRetrieval:

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -50,6 +50,8 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,
 	v1alpha.Dash0,
+	// Replay only enabled on alpha and beta channels.
+	v1alpha.SplunkObservability,
 }
 
 func (a agentExample) Generate() v1alphaAgent.Agent {


### PR DESCRIPTION
Switches the Splunk Observability agent example from `stable` to `beta` so the historicalDataRetrieval fields it sets are actually accepted by the backend.

| Field | Before | After |
|---|---|---|
| `spec.releaseChannel` | `stable` | `beta` |

## Motivation

Backend enables Splunk Observability replay defaults on alpha and beta channels only. The example combined `releaseChannel: stable` with `historicalDataRetrieval: { 30 Day / 15 Day }`, so e2e suites that derive fixtures from this example saw the HDR fields stripped on round-trip and the agent equality assertion failed.

## Release Notes

Skipped - example fixture only.
