### PR TITLE
chore: drop redundant Splunk Observability replay comment

### DIFF
--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -50,7 +50,6 @@ var betaChannelAgents = []v1alpha.DataSourceType{
 	v1alpha.SumoLogic,
 	v1alpha.Atlas,
 	v1alpha.Dash0,
-	// Replay only enabled on alpha and beta channels.
 	v1alpha.SplunkObservability,
 }
 


### PR DESCRIPTION
Follow-up to #926, which moved the Splunk Observability example onto the beta channel. The inline `// Replay only enabled on alpha and beta channels.` comment is redundant now that the entry sits inside `betaChannelAgents`, so this drops it.