### PR TITLE
feat: split Splunk Observability agent example into stable + replay subvariant

### DIFF
--- a/manifest/v1alpha/agent/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/agent/examples/splunk-observability.yaml
@@ -1,26 +1,46 @@
-apiVersion: n9/v1alpha
-kind: Agent
-metadata:
-  name: splunk-observability
-  displayName: Splunk Observability Agent
-  project: default
-  annotations:
-    area: latency
-    env: prod
-    region: us
-    team: sales
-spec:
-  description: Example Splunk Observability Agent
-  releaseChannel: beta
-  splunkObservability:
-    realm: us1
-  historicalDataRetrieval:
-    maxDuration:
-      value: 30
-      unit: Day
-    defaultDuration:
-      value: 15
-      unit: Day
-  queryDelay:
-    value: 6
-    unit: Minute
+- apiVersion: n9/v1alpha
+  kind: Agent
+  metadata:
+    name: splunk-observability
+    displayName: Splunk Observability Agent
+    project: default
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability Agent
+    releaseChannel: stable
+    splunkObservability:
+      realm: us1
+    queryDelay:
+      value: 6
+      unit: Minute
+# replay
+- apiVersion: n9/v1alpha
+  kind: Agent
+  metadata:
+    name: splunk-observability
+    displayName: Splunk Observability Agent
+    project: default
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability Agent
+    releaseChannel: beta
+    splunkObservability:
+      realm: us1
+    historicalDataRetrieval:
+      maxDuration:
+        value: 30
+        unit: Day
+      defaultDuration:
+        value: 15
+        unit: Day
+    queryDelay:
+      value: 6
+      unit: Minute

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -25,9 +25,6 @@ func Agent() []Example {
 	examples := make([]Example, 0, len(types)+1)
 	for _, typ := range types {
 		variant := toKebabCase(typ.String())
-		// Splunk Observability only supports replay on the beta channel, so its
-		// canonical example stays on stable without HDR; the replay subvariant
-		// adds beta + HDR alongside.
 		if typ == v1alpha.SplunkObservability {
 			examples = append(examples,
 				newAgentExample(typ, variant, "", false),
@@ -102,12 +99,9 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 			Unit:  defaultQueryDelay.Unit,
 		},
 	}
-	switch {
-	case typ == v1alpha.SplunkObservability && !a.replayEnabled:
-		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
-	case slices.Contains(betaChannelAgents, typ):
+	if slices.Contains(betaChannelAgents, typ) && (typ != v1alpha.SplunkObservability || a.replayEnabled) {
 		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
-	default:
+	} else {
 		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
 	}
 	return agent

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -12,7 +12,8 @@ import (
 
 type agentExample struct {
 	standardExample
-	typ v1alpha.DataSourceType
+	typ           v1alpha.DataSourceType
+	replayEnabled bool
 }
 
 func (a agentExample) GetDataSourceType() v1alpha.DataSourceType {
@@ -21,18 +22,32 @@ func (a agentExample) GetDataSourceType() v1alpha.DataSourceType {
 
 func Agent() []Example {
 	types := v1alpha.DataSourceTypeValues()
-	examples := make([]Example, 0, len(types))
+	examples := make([]Example, 0, len(types)+1)
 	for _, typ := range types {
-		example := agentExample{
-			standardExample: standardExample{
-				Variant: toKebabCase(typ.String()),
-			},
-			typ: typ,
+		variant := toKebabCase(typ.String())
+		// Splunk Observability only supports replay on the beta channel, so its
+		// canonical example stays on stable without HDR; the replay subvariant
+		// adds beta + HDR alongside.
+		if typ == v1alpha.SplunkObservability {
+			examples = append(examples,
+				newAgentExample(typ, variant, "", false),
+				newAgentExample(typ, variant, "replay", true),
+			)
+			continue
 		}
-		example.Object = example.Generate()
-		examples = append(examples, example)
+		examples = append(examples, newAgentExample(typ, variant, "", true))
 	}
 	return examples
+}
+
+func newAgentExample(typ v1alpha.DataSourceType, variant, subVariant string, replayEnabled bool) agentExample {
+	example := agentExample{
+		standardExample: standardExample{Variant: variant, SubVariant: subVariant},
+		typ:             typ,
+		replayEnabled:   replayEnabled,
+	}
+	example.Object = example.Generate()
+	return example
 }
 
 var betaChannelAgents = []v1alpha.DataSourceType{
@@ -68,14 +83,16 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 	)
 	agent = a.generateVariant(agent)
 	typ, _ := agent.Spec.GetType()
-	if maxDuration, err := v1alpha.GetDataRetrievalMaxDuration(manifest.KindAgent, typ); err == nil {
-		defaultDuration := v1alpha.HistoricalRetrievalDuration{
-			Value: ptr(*maxDuration.Value / 2),
-			Unit:  maxDuration.Unit,
-		}
-		agent.Spec.HistoricalDataRetrieval = &v1alpha.HistoricalDataRetrieval{
-			MaxDuration:     maxDuration,
-			DefaultDuration: defaultDuration,
+	if a.replayEnabled {
+		if maxDuration, err := v1alpha.GetDataRetrievalMaxDuration(manifest.KindAgent, typ); err == nil {
+			defaultDuration := v1alpha.HistoricalRetrievalDuration{
+				Value: ptr(*maxDuration.Value / 2),
+				Unit:  maxDuration.Unit,
+			}
+			agent.Spec.HistoricalDataRetrieval = &v1alpha.HistoricalDataRetrieval{
+				MaxDuration:     maxDuration,
+				DefaultDuration: defaultDuration,
+			}
 		}
 	}
 	defaultQueryDelay := v1alpha.GetQueryDelayDefaults()[typ]
@@ -85,9 +102,12 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 			Unit:  defaultQueryDelay.Unit,
 		},
 	}
-	if slices.Contains(betaChannelAgents, typ) {
+	switch {
+	case typ == v1alpha.SplunkObservability && !a.replayEnabled:
+		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
+	case slices.Contains(betaChannelAgents, typ):
 		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
-	} else {
+	default:
 		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
 	}
 	return agent

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -99,12 +99,18 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 			Unit:  defaultQueryDelay.Unit,
 		},
 	}
-	if slices.Contains(betaChannelAgents, typ) && (typ != v1alpha.SplunkObservability || a.replayEnabled) {
-		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelBeta
-	} else {
-		agent.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
-	}
+	agent.Spec.ReleaseChannel = releaseChannelFor(typ, a.replayEnabled)
 	return agent
+}
+
+func releaseChannelFor(typ v1alpha.DataSourceType, replayEnabled bool) v1alpha.ReleaseChannel {
+	if !slices.Contains(betaChannelAgents, typ) {
+		return v1alpha.ReleaseChannelStable
+	}
+	if typ == v1alpha.SplunkObservability && !replayEnabled {
+		return v1alpha.ReleaseChannelStable
+	}
+	return v1alpha.ReleaseChannelBeta
 }
 
 //nolint:gocyclo


### PR DESCRIPTION
Splunk Observability replay requires the beta channel, so the single beta+HDR example shipped before could not stand in for a no-replay configuration. Split into a canonical example on stable without HistoricalDataRetrieval plus a replay subvariant on beta with HDR (SubVariant pattern, same as alert_method.go).

## Release Notes

Splunk Observability Agent example is now shipped as two variants: a canonical stable example without replay, and a replay subvariant on the beta release channel with HistoricalDataRetrieval.

## Related PRs

- nobl9-go #926 "fix: set Splunk Observability agent example to beta channel" (merged 2026-05-21) - flipped the single example to beta, which this PR replaces with two variants