### PR TITLE
chore: simplify testutils contract for property path

### DIFF
--- a/internal/manifest/v1alphatest/labels_validation.go
+++ b/internal/manifest/v1alphatest/labels_validation.go
@@ -34,7 +34,7 @@ func (tc LabelsTestCase[T]) Test(t *testing.T, object T, validate func(T) *v1alp
 
 func GetLabelsTestCases[T manifest.Object](
 	t *testing.T,
-	propertyPath jsonpath.Path,
+	propertyPath string,
 ) map[string]LabelsTestCase[T] {
 	t.Helper()
 
@@ -73,7 +73,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net": {"same", "same", "same"},
 			},
 			error: testutils.ExpectedError{
-				Prop: propertyPath.Name("net"),
+				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
 				Code: rules.ErrorCodeSliceUnique,
 			},
 		},
@@ -82,7 +82,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net": {"", ""},
 			},
 			error: testutils.ExpectedError{
-				Prop: propertyPath.Name("net"),
+				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
 				Code: rules.ErrorCodeSliceUnique,
 			},
 		},
@@ -97,7 +97,7 @@ func GetLabelsTestCases[T manifest.Object](
 				strings.Repeat("net", 40): {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath.Name(strings.Repeat("net", 40)),
+				Prop:       jsonpath.Parse(propertyPath).Name(strings.Repeat("net", 40)).String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringLength,
 			},
@@ -107,7 +107,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"9net": {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath.Name("9net"),
+				Prop:       jsonpath.Parse(propertyPath).Name("9net").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},
@@ -117,7 +117,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net_": {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath.Name("net_"),
+				Prop:       jsonpath.Parse(propertyPath).Name("net_").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},
@@ -127,7 +127,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"nEt": {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath.Name("nEt"),
+				Prop:       jsonpath.Parse(propertyPath).Name("nEt").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},
@@ -137,7 +137,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net": {strings.Repeat("label-", 40)},
 			},
 			error: testutils.ExpectedError{
-				Prop: propertyPath.Name("net").Index(0),
+				Prop: propertyPath + ".net[0]",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 		},

--- a/internal/manifest/v1alphatest/labels_validation.go
+++ b/internal/manifest/v1alphatest/labels_validation.go
@@ -73,7 +73,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net": {"same", "same", "same"},
 			},
 			error: testutils.ExpectedError{
-				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
+				Prop: propertyPath + ".net",
 				Code: rules.ErrorCodeSliceUnique,
 			},
 		},
@@ -82,7 +82,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net": {"", ""},
 			},
 			error: testutils.ExpectedError{
-				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
+				Prop: propertyPath + ".net",
 				Code: rules.ErrorCodeSliceUnique,
 			},
 		},
@@ -97,7 +97,7 @@ func GetLabelsTestCases[T manifest.Object](
 				strings.Repeat("net", 40): {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       jsonpath.Parse(propertyPath).Name(strings.Repeat("net", 40)).String(),
+				Prop:       propertyPath + "." + strings.Repeat("net", 40),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringLength,
 			},
@@ -117,7 +117,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"net_": {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       jsonpath.Parse(propertyPath).Name("net_").String(),
+				Prop:       propertyPath + ".net_",
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},
@@ -127,7 +127,7 @@ func GetLabelsTestCases[T manifest.Object](
 				"nEt": {},
 			},
 			error: testutils.ExpectedError{
-				Prop:       jsonpath.Parse(propertyPath).Name("nEt").String(),
+				Prop:       propertyPath + ".nEt",
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			},

--- a/internal/manifest/v1alphatest/metadata_annotations_validation.go
+++ b/internal/manifest/v1alphatest/metadata_annotations_validation.go
@@ -105,7 +105,7 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 				"net_": "x",
 			},
 			error: testutils.ExpectedError{
-				Prop:       jsonpath.Parse(propertyPath).Name("net_").String(),
+				Prop:       propertyPath + ".net_",
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringKubernetesQualifiedName,
 			},
@@ -115,7 +115,7 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 				"net": strings.Repeat("l", 1051),
 			},
 			error: testutils.ExpectedError{
-				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
+				Prop: propertyPath + ".net",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 		},

--- a/internal/manifest/v1alphatest/metadata_annotations_validation.go
+++ b/internal/manifest/v1alphatest/metadata_annotations_validation.go
@@ -35,7 +35,7 @@ func (tc MetadataAnnotationsTestCase[T]) Test(t *testing.T, object T, validate f
 
 func GetMetadataAnnotationsTestCases[T manifest.Object](
 	t *testing.T,
-	propertyPath jsonpath.Path,
+	propertyPath string,
 ) map[string]MetadataAnnotationsTestCase[T] {
 	t.Helper()
 
@@ -87,10 +87,9 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 				strings.Repeat("l", validationV1Alpha.NameMaximumLength+1) + "/" + strings.Repeat("l", 64): "x",
 			},
 			error: testutils.ExpectedError{
-				Prop: propertyPath.Name(
-					strings.Repeat("l", validationV1Alpha.NameMaximumLength+1) + "/" +
-						strings.Repeat("l", 64),
-				),
+				Prop: jsonpath.Parse(propertyPath).
+					Name(strings.Repeat("l", validationV1Alpha.NameMaximumLength+1) + "/" + strings.Repeat("l", 64)).
+					String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringKubernetesQualifiedName,
 			},
@@ -106,7 +105,7 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 				"net_": "x",
 			},
 			error: testutils.ExpectedError{
-				Prop:       propertyPath.Name("net_"),
+				Prop:       jsonpath.Parse(propertyPath).Name("net_").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringKubernetesQualifiedName,
 			},
@@ -116,7 +115,7 @@ func GetMetadataAnnotationsTestCases[T manifest.Object](
 				"net": strings.Repeat("l", 1051),
 			},
 			error: testutils.ExpectedError{
-				Prop: propertyPath.Name("net"),
+				Prop: jsonpath.Parse(propertyPath).Name("net").String(),
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 		},

--- a/internal/testutils/assert.go
+++ b/internal/testutils/assert.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ExpectedError struct {
-	Prop            jsonpath.Path  `json:"property"`
+	Prop            string         `json:"property"`
 	Code            govy.ErrorCode `json:"code,omitempty"`
 	Message         string         `json:"message,omitempty"`
 	ContainsMessage string         `json:"containsMessage,omitempty"`
@@ -70,7 +70,7 @@ func AssertContainsErrors(
 		for _, actual := range objErr.Errors {
 			var propErr *govy.PropertyError
 			require.ErrorAs(t, actual, &propErr)
-			if !propErr.PropertyPath.Equal(expected.Prop) {
+			if propErr.PropertyPath.String() != expected.Prop {
 				continue
 			}
 			if expected.IsKeyError != propErr.IsKeyError {
@@ -110,9 +110,14 @@ func AssertContainsErrors(
 	}
 }
 
-func PrependPropertyPath(errs []ExpectedError, path jsonpath.Path) []ExpectedError {
+func PrependPropertyPath(errs []ExpectedError, path string) []ExpectedError {
+	prefix := jsonpath.Parse(path)
 	for i := range errs {
-		errs[i].Prop = path.Join(errs[i].Prop)
+		if errs[i].Prop == "" {
+			errs[i].Prop = prefix.String()
+			continue
+		}
+		errs[i].Prop = prefix.Join(jsonpath.Parse(errs[i].Prop)).String()
 	}
 	return errs
 }

--- a/manifest/v1alpha/agent/validation_test.go
+++ b/manifest/v1alpha/agent/validation_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -37,11 +35,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, method, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -59,22 +57,22 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, agent, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	for name, test := range v1alphatest.GetMetadataAnnotationsTestCases[Agent](t, jsonpath.Parse("metadata.annotations")) {
+	for name, test := range v1alphatest.GetMetadataAnnotationsTestCases[Agent](t, "metadata.annotations") {
 		t.Run(name, func(t *testing.T) {
 			svc := validAgent(v1alpha.Prometheus)
 			svc.Metadata.Annotations = test.Annotations
@@ -89,7 +87,7 @@ func TestValidate_Spec(t *testing.T) {
 		agent.Spec.Description = strings.Repeat("A", 2000)
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: validationV1Alpha.ErrorCodeStringDescription,
 		})
 	})
@@ -98,7 +96,7 @@ func TestValidate_Spec(t *testing.T) {
 		agent.Spec.Prometheus = nil
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.New().Name("spec"),
+			Prop: "spec",
 			Code: errCodeExactlyOneDataSourceType,
 		})
 	})
@@ -113,7 +111,7 @@ func TestValidate_Spec(t *testing.T) {
 			agent.Spec.Prometheus = validAgentSpec(v1alpha.Prometheus).Prometheus
 			err := validate(agent)
 			testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.New().Name("spec"),
+				Prop: "spec",
 				Code: errCodeExactlyOneDataSourceType,
 			})
 		}
@@ -138,7 +136,7 @@ func TestValidateSpec_ReleaseChannel(t *testing.T) {
 		agent.Spec.ReleaseChannel = -1
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.releaseChannel"),
+			Prop: "spec.releaseChannel",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -151,11 +149,11 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.value"),
+				Prop: "spec.queryDelay.value",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.unit"),
+				Prop: "spec.queryDelay.unit",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -187,7 +185,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 			}}
 			err := validate(agent)
 			testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.unit"),
+				Prop: "spec.queryDelay.unit",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}
@@ -201,7 +199,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 		}}
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.queryDelay"),
+			Prop: "spec.queryDelay",
 			Code: errCodeQueryDelayOutOfBounds,
 		})
 	})
@@ -213,7 +211,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 		}}
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.queryDelay"),
+			Prop: "spec.queryDelay",
 			Code: errCodeQueryDelayOutOfBounds,
 		})
 	})
@@ -228,7 +226,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 				}}
 				err := validate(agent)
 				testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.queryDelay"),
+					Prop: "spec.queryDelay",
 					Code: errCodeQueryDelayOutOfBounds,
 				})
 			})
@@ -258,11 +256,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration"),
+				Prop: "spec.historicalDataRetrieval.maxDuration",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration"),
+				Prop: "spec.historicalDataRetrieval.defaultDuration",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -277,11 +275,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -291,11 +289,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -308,11 +306,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				},
 			},
@@ -325,11 +323,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 3,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeLessThanOrEqualTo,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeLessThanOrEqualTo,
 				},
 			},
@@ -342,11 +340,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 			},
@@ -391,7 +389,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 		}
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.historicalDataRetrieval"),
+			Prop:    "spec.historicalDataRetrieval",
 			Message: "historical data retrieval is not supported for Generic Agent",
 		})
 	})
@@ -410,7 +408,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			}
 			err := validate(agent)
 			testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration"),
+				Prop:    "spec.historicalDataRetrieval.defaultDuration",
 				Message: "must be less than or equal to 'maxDuration' (1 Hour)",
 			})
 		})
@@ -435,7 +433,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 				}
 				objErr := validate(agent)
 				testutils.AssertContainsErrors(t, agent, objErr, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration"),
+					Prop: "spec.historicalDataRetrieval.maxDuration",
 					Message: fmt.Sprintf("must be less than or equal to %d %s",
 						*maxDuration.Value, maxDuration.Unit),
 				})
@@ -466,7 +464,7 @@ func TestValidateSpec_URLOnlyAgents(t *testing.T) {
 				setURLValue(t, &agent.Spec, typ.String(), "")
 				err := validate(agent)
 				testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse(fmt.Sprintf("spec.%s.url", propName)),
+					Prop: fmt.Sprintf("spec.%s.url", propName),
 					Code: rules.ErrorCodeRequired,
 				})
 			})
@@ -475,7 +473,7 @@ func TestValidateSpec_URLOnlyAgents(t *testing.T) {
 				setURLValue(t, &agent.Spec, typ.String(), "invalid")
 				err := validate(agent)
 				testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse(fmt.Sprintf("spec.%s.url", propName)),
+					Prop: fmt.Sprintf("spec.%s.url", propName),
 					Code: rules.ErrorCodeStringURL,
 				})
 			})
@@ -524,7 +522,7 @@ func TestValidateSpec_PrometheusLikeAgents(t *testing.T) {
 				setStepValue(t, &agent.Spec, field, 9)
 				err := validate(agent)
 				testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse(fmt.Sprintf("spec.%s.step", propName)),
+					Prop: fmt.Sprintf("spec.%s.step", propName),
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				})
 			})
@@ -543,7 +541,7 @@ func TestValidateSpec_Datadog(t *testing.T) {
 		agent.Spec.Datadog.Site = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.datadog.site"),
+			Prop: "spec.datadog.site",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -552,7 +550,7 @@ func TestValidateSpec_Datadog(t *testing.T) {
 		agent.Spec.Datadog.Site = "invalid"
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.datadog.site"),
+			Prop: "spec.datadog.site",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -569,7 +567,7 @@ func TestValidateSpec_NewRelic(t *testing.T) {
 		agent.Spec.NewRelic.AccountID = 0
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.newRelic.accountId"),
+			Prop: "spec.newRelic.accountId",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -578,7 +576,7 @@ func TestValidateSpec_NewRelic(t *testing.T) {
 		agent.Spec.NewRelic.AccountID = -1
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.newRelic.accountId"),
+			Prop: "spec.newRelic.accountId",
 			Code: rules.ErrorCodeGreaterThanOrEqualTo,
 		})
 	})
@@ -598,11 +596,11 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.lightstep.organization"),
+				Prop: "spec.lightstep.organization",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.lightstep.project"),
+				Prop: "spec.lightstep.project",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -612,7 +610,7 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 		agent.Spec.Lightstep.URL = "h ttp"
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.lightstep.url"),
+			Prop: "spec.lightstep.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -650,7 +648,7 @@ func TestValidateSpec_SplunkObservability(t *testing.T) {
 		agent.Spec.SplunkObservability.Realm = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.splunkObservability.realm"),
+			Prop: "spec.splunkObservability.realm",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -667,7 +665,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 		agent.Spec.Dynatrace.URL = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.dynatrace.url"),
+			Prop: "spec.dynatrace.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -676,7 +674,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 		agent.Spec.Dynatrace.URL = "h ttp"
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.dynatrace.url"),
+			Prop: "spec.dynatrace.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -726,7 +724,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 				testutils.AssertNoError(t, agent, err)
 			} else {
 				testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.dynatrace.url"),
+					Prop: "spec.dynatrace.url",
 					ContainsMessage: "Dynatrace SaaS URL (live.dynatrace.com)" +
 						" requires https scheme and empty URL path",
 				})
@@ -749,11 +747,11 @@ func TestValidateSpec_AmazonPrometheus(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.amazonPrometheus.url"),
+				Prop: "spec.amazonPrometheus.url",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.amazonPrometheus.region"),
+				Prop: "spec.amazonPrometheus.region",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -765,11 +763,11 @@ func TestValidateSpec_AmazonPrometheus(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.amazonPrometheus.url"),
+				Prop: "spec.amazonPrometheus.url",
 				Code: rules.ErrorCodeStringURL,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.amazonPrometheus.region"),
+				Prop: "spec.amazonPrometheus.region",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 		)
@@ -787,7 +785,7 @@ func TestValidateSpec_AzureMonitor(t *testing.T) {
 		agent.Spec.AzureMonitor.TenantID = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azureMonitor.tenantId"),
+			Prop: "spec.azureMonitor.tenantId",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -796,7 +794,7 @@ func TestValidateSpec_AzureMonitor(t *testing.T) {
 		agent.Spec.AzureMonitor.TenantID = "invalid"
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azureMonitor.tenantId"),
+			Prop: "spec.azureMonitor.tenantId",
 			Code: rules.ErrorCodeStringUUID,
 		})
 	})
@@ -813,7 +811,7 @@ func TestValidateSpec_LogicMonitor(t *testing.T) {
 		agent.Spec.LogicMonitor.Account = ""
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.logicMonitor.account"),
+			Prop: "spec.logicMonitor.account",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -830,7 +828,7 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		agent.Spec.AzurePrometheus.TenantID = "invalid"
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+			Prop: "spec.azurePrometheus.tenantId",
 			Code: rules.ErrorCodeStringUUID,
 		})
 	})
@@ -841,11 +839,11 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.url"),
+				Prop: "spec.azurePrometheus.url",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+				Prop: "spec.azurePrometheus.tenantId",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -857,11 +855,11 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.url"),
+				Prop: "spec.azurePrometheus.url",
 				Code: rules.ErrorCodeStringURL,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+				Prop: "spec.azurePrometheus.tenantId",
 				Code: rules.ErrorCodeStringUUID,
 			},
 		)
@@ -881,7 +879,7 @@ func TestValidateSpec_Coralogix(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.coralogix.domain"),
+				Prop: "spec.coralogix.domain",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -892,7 +890,7 @@ func TestValidateSpec_Coralogix(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.coralogix.domain"),
+				Prop: "spec.coralogix.domain",
 				Code: rules.ErrorCodeStringFQDN,
 			},
 		)
@@ -911,7 +909,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.slicUrl"),
+				Prop: "spec.atlas.slicUrl",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -922,7 +920,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.slicUrl"),
+				Prop: "spec.atlas.slicUrl",
 				Code: rules.ErrorCodeURL,
 			},
 		)
@@ -933,7 +931,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.slicUrl"),
+				Prop: "spec.atlas.slicUrl",
 				Code: errCodeHTTPOrHTTPSSchemeRequired,
 			},
 		)
@@ -944,7 +942,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.slicStep"),
+				Prop: "spec.atlas.slicStep",
 				Code: rules.ErrorCodeGreaterThanOrEqualTo,
 			},
 		)
@@ -955,7 +953,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.dataReplayUrl"),
+				Prop: "spec.atlas.dataReplayUrl",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -966,7 +964,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.dataReplayUrl"),
+				Prop: "spec.atlas.dataReplayUrl",
 				Code: rules.ErrorCodeURL,
 			},
 		)
@@ -977,7 +975,7 @@ func TestValidateSpec_Atlas(t *testing.T) {
 		err := validate(agent)
 		testutils.AssertContainsErrors(t, agent, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.atlas.dataReplayUrl"),
+				Prop: "spec.atlas.dataReplayUrl",
 				Code: errCodeHTTPOrHTTPSSchemeRequired,
 			},
 		)

--- a/manifest/v1alpha/alert/validation_test.go
+++ b/manifest/v1alpha/alert/validation_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -28,11 +26,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, alert, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)

--- a/manifest/v1alpha/alertmethod/validation_discord_test.go
+++ b/manifest/v1alpha/alertmethod/validation_discord_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -46,7 +44,7 @@ func TestValidate_Spec_DiscordAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.discord.url"),
+					Prop: "spec.discord.url",
 					Code: rules.ErrorCodeStringURL,
 				},
 			},
@@ -58,7 +56,7 @@ func TestValidate_Spec_DiscordAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.discord.url"),
+					Prop:    "spec.discord.url",
 					Message: "must not end with /slack or /github",
 				},
 			},
@@ -70,7 +68,7 @@ func TestValidate_Spec_DiscordAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.discord.url"),
+					Prop:    "spec.discord.url",
 					Message: "must not end with /slack or /github",
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_email_test.go
+++ b/manifest/v1alpha/alertmethod/validation_email_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -55,7 +53,7 @@ func TestValidate_Spec_EmailAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.email"),
+					Prop:    "spec.email",
 					Message: "must contain at least one recipient",
 				},
 			},
@@ -65,7 +63,7 @@ func TestValidate_Spec_EmailAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.email.to"),
+					Prop: "spec.email.to",
 					Code: rules.ErrorCodeSliceMaxLength,
 				},
 			},
@@ -77,7 +75,7 @@ func TestValidate_Spec_EmailAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.email.cc"),
+					Prop: "spec.email.cc",
 					Code: rules.ErrorCodeSliceMaxLength,
 				},
 			},
@@ -89,7 +87,7 @@ func TestValidate_Spec_EmailAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.email.bcc"),
+					Prop: "spec.email.bcc",
 					Code: rules.ErrorCodeSliceMaxLength,
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_jira_test.go
+++ b/manifest/v1alpha/alertmethod/validation_jira_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -37,7 +35,7 @@ func TestValidate_Spec_JiraAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.jira.url"),
+					Prop: "spec.jira.url",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -50,7 +48,7 @@ func TestValidate_Spec_JiraAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.jira.url"),
+					Prop: "spec.jira.url",
 					Code: rules.ErrorCodeURL,
 				},
 			},
@@ -64,7 +62,7 @@ func TestValidate_Spec_JiraAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.jira.url"),
+					Prop:    "spec.jira.url",
 					Message: "requires https scheme",
 				},
 			},
@@ -78,7 +76,7 @@ func TestValidate_Spec_JiraAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.jira.username"),
+					Prop: "spec.jira.username",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -91,7 +89,7 @@ func TestValidate_Spec_JiraAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.jira.projectKey"),
+					Prop: "spec.jira.projectKey",
 					Code: rules.ErrorCodeRequired,
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_opsgenie_test.go
+++ b/manifest/v1alpha/alertmethod/validation_opsgenie_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -66,11 +64,11 @@ func TestValidate_Spec_OpsgenieAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.opsgenie.url"),
+					Prop: "spec.opsgenie.url",
 					Code: rules.ErrorCodeStringURL,
 				},
 				{
-					Prop: jsonpath.Parse("spec.opsgenie.url"),
+					Prop: "spec.opsgenie.url",
 					Code: rules.ErrorCodeStringStartsWith,
 				},
 			},
@@ -82,7 +80,7 @@ func TestValidate_Spec_OpsgenieAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.opsgenie.url"),
+					Prop: "spec.opsgenie.url",
 					Code: rules.ErrorCodeStringStartsWith,
 				},
 			},
@@ -94,7 +92,7 @@ func TestValidate_Spec_OpsgenieAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.opsgenie.auth"),
+					Prop:    "spec.opsgenie.auth",
 					Message: "invalid auth format, should start with either GenieKey or Basic",
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_pagerduty_test.go
+++ b/manifest/v1alpha/alertmethod/validation_pagerduty_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -47,7 +45,7 @@ func TestValidate_Spec_PagerDutyAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.pagerduty.integrationKey"),
+					Prop: "spec.pagerduty.integrationKey",
 					Code: rules.ErrorCodeStringMaxLength,
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_servicenow_test.go
+++ b/manifest/v1alpha/alertmethod/validation_servicenow_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -41,7 +39,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow.instanceName"),
+					Prop: "spec.servicenow.instanceName",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -54,7 +52,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},
@@ -66,7 +64,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},
@@ -80,7 +78,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},
@@ -94,7 +92,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},
@@ -109,7 +107,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},
@@ -122,7 +120,7 @@ func TestValidate_Spec_ServiceNowAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.servicenow"),
+					Prop: "spec.servicenow",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_slack_test.go
+++ b/manifest/v1alpha/alertmethod/validation_slack_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -46,11 +44,11 @@ func TestValidate_Spec_SlackAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.slack.url"),
+					Prop: "spec.slack.url",
 					Code: rules.ErrorCodeStringURL,
 				},
 				{
-					Prop: jsonpath.Parse("spec.slack.url"),
+					Prop: "spec.slack.url",
 					Code: rules.ErrorCodeStringStartsWith,
 				},
 			},
@@ -62,7 +60,7 @@ func TestValidate_Spec_SlackAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.slack.url"),
+					Prop: "spec.slack.url",
 					Code: rules.ErrorCodeStringStartsWith,
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_teams_test.go
+++ b/manifest/v1alpha/alertmethod/validation_teams_test.go
@@ -3,8 +3,6 @@ package alertmethod
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -43,7 +41,7 @@ func TestValidate_Spec_TeamsAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.msteams.url"),
+					Prop: "spec.msteams.url",
 					Code: rules.ErrorCodeURL,
 				},
 			},
@@ -55,7 +53,7 @@ func TestValidate_Spec_TeamsAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.msteams.url"),
+					Prop:    "spec.msteams.url",
 					Message: "requires https scheme",
 				},
 			},

--- a/manifest/v1alpha/alertmethod/validation_test.go
+++ b/manifest/v1alpha/alertmethod/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -33,11 +31,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, method, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -55,22 +53,22 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, alertMethod, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: v1alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: v1alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	tests := v1alphatest.GetMetadataAnnotationsTestCases[AlertMethod](t, jsonpath.Parse("metadata.annotations"))
+	tests := v1alphatest.GetMetadataAnnotationsTestCases[AlertMethod](t, "metadata.annotations")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			svc := validAlertMethod()
@@ -86,7 +84,7 @@ func TestValidate_Spec(t *testing.T) {
 		alertMethod.Spec.Description = strings.Repeat("l", 1051)
 		err := validate(alertMethod)
 		testutils.AssertContainsErrors(t, alertMethod, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: rules.ErrorCodeStringLength,
 		})
 	})
@@ -95,7 +93,7 @@ func TestValidate_Spec(t *testing.T) {
 		alertMethod.Spec = Spec{}
 		err := validate(alertMethod)
 		testutils.AssertContainsErrors(t, alertMethod, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("spec"),
+			Prop:    "spec",
 			Message: "exactly one alert method configuration is required",
 		})
 	})
@@ -111,7 +109,7 @@ func TestValidate_Spec(t *testing.T) {
 		}
 		err := validate(alertMethod)
 		testutils.AssertContainsErrors(t, alertMethod, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("spec"),
+			Prop:    "spec",
 			Message: "exactly one alert method configuration is required",
 		})
 	})

--- a/manifest/v1alpha/alertmethod/validation_webhook_test.go
+++ b/manifest/v1alpha/alertmethod/validation_webhook_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -63,7 +61,7 @@ func TestValidate_Spec_WebhookAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.url"),
+					Prop: "spec.webhook.url",
 					Code: rules.ErrorCodeStringURL,
 				},
 			},
@@ -76,7 +74,7 @@ func TestValidate_Spec_WebhookAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.webhook.template"),
+					Prop:    "spec.webhook.template",
 					Message: "contains invalid template field: sloname",
 				},
 			},
@@ -89,7 +87,7 @@ func TestValidate_Spec_WebhookAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.webhook.templateFields"),
+					Prop:    "spec.webhook.templateFields",
 					Message: "contains invalid template field: sloname",
 				},
 			},
@@ -102,7 +100,7 @@ func TestValidate_Spec_WebhookAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.webhook"),
+					Prop:    "spec.webhook",
 					Message: "must not contain both 'template' and 'templateFields'",
 				},
 			},
@@ -116,7 +114,7 @@ func TestValidate_Spec_WebhookAlertMethod(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.webhook"),
+					Prop:    "spec.webhook",
 					Message: "must contain either 'template' or 'templateFields'",
 				},
 			},
@@ -179,7 +177,7 @@ func TestValidate_Spec_WebhookHeaders(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.headers[0].name"),
+					Prop: "spec.webhook.headers[0].name",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -199,7 +197,7 @@ func TestValidate_Spec_WebhookHeaders(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.headers[0].name"),
+					Prop: "spec.webhook.headers[0].name",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				},
 			},
@@ -219,7 +217,7 @@ func TestValidate_Spec_WebhookHeaders(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.headers[0].value"),
+					Prop: "spec.webhook.headers[0].value",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -238,7 +236,7 @@ func TestValidate_Spec_WebhookHeaders(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.headers[0].value"),
+					Prop: "spec.webhook.headers[0].value",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -257,7 +255,7 @@ func TestValidate_Spec_WebhookHeaders(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.webhook.headers"),
+					Prop: "spec.webhook.headers",
 					Code: rules.ErrorCodeSliceMaxLength,
 				},
 			},

--- a/manifest/v1alpha/alertpolicy/validation_test.go
+++ b/manifest/v1alpha/alertpolicy/validation_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -37,11 +35,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, policy, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -58,18 +56,18 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, policy, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Labels(t *testing.T) {
-	for name, test := range v1alphatest.GetLabelsTestCases[AlertPolicy](t, jsonpath.Parse("metadata.labels")) {
+	for name, test := range v1alphatest.GetLabelsTestCases[AlertPolicy](t, "metadata.labels") {
 		t.Run(name, func(t *testing.T) {
 			svc := validAlertPolicy()
 			svc.Metadata.Labels = test.Labels
@@ -79,7 +77,7 @@ func TestValidate_Metadata_Labels(t *testing.T) {
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	tests := v1alphatest.GetMetadataAnnotationsTestCases[AlertPolicy](t, jsonpath.Parse("metadata.annotations"))
+	tests := v1alphatest.GetMetadataAnnotationsTestCases[AlertPolicy](t, "metadata.annotations")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			svc := validAlertPolicy()
@@ -95,7 +93,7 @@ func TestValidate_Metadata_Project(t *testing.T) {
 		alertPolicy.Metadata.Project = ""
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -106,7 +104,7 @@ func TestValidate_Spec_Description(t *testing.T) {
 	alertPolicy.Spec.Description = strings.Repeat("A", 2000)
 	err := validate(alertPolicy)
 	testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.description"),
+		Prop: "spec.description",
 		Code: validationV1Alpha.ErrorCodeStringDescription,
 	})
 }
@@ -125,7 +123,7 @@ func TestValidate_Spec_Severity(t *testing.T) {
 		alertPolicy.Spec.Severity = ""
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.severity"),
+			Prop: "spec.severity",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -134,7 +132,7 @@ func TestValidate_Spec_Severity(t *testing.T) {
 		alertPolicy.Spec.Severity = "Highest"
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.severity"),
+			Prop: "spec.severity",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -172,7 +170,7 @@ func TestValidate_Spec_CoolDownDuration(t *testing.T) {
 				alertPolicy.Spec.CoolDownDuration = value
 				err := validate(alertPolicy)
 				testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-					Prop:    jsonpath.Parse("spec.coolDown"),
+					Prop:    "spec.coolDown",
 					Code:    testCase.expectedCode,
 					Message: testCase.expectedMessage,
 				})
@@ -193,7 +191,7 @@ func TestValidate_Spec_Conditions(t *testing.T) {
 		alertPolicy.Spec.Conditions = make([]AlertCondition, 0)
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.conditions"),
+			Prop: "spec.conditions",
 			Code: rules.ErrorCodeSliceMinLength,
 		})
 	})
@@ -214,7 +212,7 @@ func TestValidate_Spec_Condition(t *testing.T) {
 		alertPolicy.Spec.Conditions[0].LastsForDuration = "10m"
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.conditions[0]"),
+			Prop: "spec.conditions[0]",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -304,7 +302,7 @@ func TestValidate_Spec_Condition_Measurement(t *testing.T) {
 		alertPolicy.Spec.Conditions[0].AlertingWindow = ""
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.conditions[0].measurement"),
+			Prop: "spec.conditions[0].measurement",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -313,7 +311,7 @@ func TestValidate_Spec_Condition_Measurement(t *testing.T) {
 		alertPolicy.Spec.Conditions[0].Measurement = "Unknown"
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 2, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.conditions[0].measurement"),
+			Prop: "spec.conditions[0].measurement",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -323,7 +321,7 @@ func TestValidate_Spec_Condition_Measurement(t *testing.T) {
 		alertPolicy.Spec.Conditions[0].Value = 0.1
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.conditions[0].measurement"),
+			Prop: "spec.conditions[0].measurement",
 			ContainsMessage: fmt.Sprintf(
 				`must be equal to one of '%s' when 'alertingWindow' is defined`,
 				strings.Join(alertingWindowSupportedMeasurements(), ","),
@@ -340,7 +338,7 @@ func TestValidate_Spec_Condition_Measurement(t *testing.T) {
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.conditions[0].measurement"),
+				Prop: "spec.conditions[0].measurement",
 				ContainsMessage: fmt.Sprintf(
 					`must be equal to one of '%s' when 'lastsFor' is defined`,
 					strings.Join(lastsForSupportedMeasurements(), ","),
@@ -348,7 +346,7 @@ func TestValidate_Spec_Condition_Measurement(t *testing.T) {
 				Code: errorCodeMeasurementWithLastsFor,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.conditions[0].measurement"),
+				Prop: "spec.conditions[0].measurement",
 				ContainsMessage: fmt.Sprintf(
 					`alerting window is required for measurement '%s'`,
 					MeasurementBudgetDrop.String(),
@@ -463,7 +461,7 @@ func TestValidate_Spec_Condition_WithLastsFor_Value(t *testing.T) {
 					alertPolicy.Spec.Conditions[0].AlertingWindow = ""
 					err := validate(alertPolicy)
 					testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-						Prop:            jsonpath.Parse("spec.conditions[0].value"),
+						Prop:            "spec.conditions[0].value",
 						ContainsMessage: testCase.expectedMessage,
 						Code:            testCase.expectedCode,
 					})
@@ -577,7 +575,7 @@ func TestValidate_Spec_Condition_WithAlertingWindow_Value(t *testing.T) {
 					alertPolicy.Spec.Conditions[0].AlertingWindow = "10m"
 					err := validate(alertPolicy)
 					testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-						Prop:            jsonpath.Parse("spec.conditions[0].value"),
+						Prop:            "spec.conditions[0].value",
 						ContainsMessage: testCase.expectedMessage,
 						Code:            testCase.expectedCode,
 					})
@@ -629,7 +627,7 @@ func TestValidate_Spec_Condition_AlertingWindow(t *testing.T) {
 				alertPolicy.Spec.Conditions[0].AlertingWindow = value
 				err := validate(alertPolicy)
 				testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.conditions[0].alertingWindow"),
+					Prop: "spec.conditions[0].alertingWindow",
 					Code: testCase.expectedCode,
 				})
 			}
@@ -683,7 +681,7 @@ func TestValidate_Spec_Condition_AlertingWindow(t *testing.T) {
 				alertPolicy.Spec.Conditions[0].AlertingWindow = value
 				err := validate(alertPolicy)
 				testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-					Prop:    jsonpath.Parse("spec.conditions[0].alertingWindow"),
+					Prop:    "spec.conditions[0].alertingWindow",
 					Message: testCase.expectedMessage,
 					Code:    testCase.expectedCode,
 				})
@@ -741,7 +739,7 @@ func TestValidate_Spec_Condition_LastsForDuration(t *testing.T) {
 				alertPolicy.Spec.Conditions[0].LastsForDuration = value
 				err := validate(alertPolicy)
 				testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.conditions[0].lastsFor"),
+					Prop: "spec.conditions[0].lastsFor",
 					Code: testCase.expectedCode,
 				})
 			}
@@ -808,7 +806,7 @@ func TestValidate_Spec_Condition_Operator(t *testing.T) {
 					testutils.AssertNoError(t, alertPolicy, err)
 				} else {
 					testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-						Prop: jsonpath.Parse("spec.conditions[0].op"),
+						Prop: "spec.conditions[0].op",
 						Message: fmt.Sprintf(
 							`measurement '%s' determines operator must be defined with '%s' or left empty`,
 							measurement.String(), expectedOperator,
@@ -843,7 +841,7 @@ func TestValidate_Spec_Condition_Operator(t *testing.T) {
 		alertPolicy.Spec.Conditions[0].Operator = "noop"
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.conditions[0].op"),
+			Prop:    "spec.conditions[0].op",
 			Message: "'noop' is not valid operator",
 		})
 	})
@@ -886,7 +884,7 @@ func TestValidate_Spec_AlertMethodsRefMetadata(t *testing.T) {
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.alertMethods[0].metadata.name"),
+				Prop: "spec.alertMethods[0].metadata.name",
 				Code: validationV1Alpha.ErrorCodeStringName,
 			},
 		)
@@ -904,7 +902,7 @@ func TestValidate_Spec_AlertMethodsRefMetadata(t *testing.T) {
 		err := validate(alertPolicy)
 		testutils.AssertContainsErrors(t, alertPolicy, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.alertMethods[0].metadata.project"),
+				Prop: "spec.alertMethods[0].metadata.project",
 				Code: validationV1Alpha.ErrorCodeStringName,
 			},
 		)

--- a/manifest/v1alpha/alertsilence/validation_test.go
+++ b/manifest/v1alpha/alertsilence/validation_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -35,11 +33,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, silence, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -56,11 +54,11 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, silence, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
@@ -72,7 +70,7 @@ func TestValidate_Metadata_Project(t *testing.T) {
 		alertSilence.Metadata.Project = ""
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -83,7 +81,7 @@ func TestValidate_Spec_Description(t *testing.T) {
 	alertSilence.Spec.Description = strings.Repeat("A", 2000)
 	err := validate(alertSilence)
 	testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.description"),
+		Prop: "spec.description",
 		Code: validationV1Alpha.ErrorCodeStringDescription,
 	})
 }
@@ -100,7 +98,7 @@ func TestValidate_Spec_Slo(t *testing.T) {
 		alertSilence.Spec.SLO = "MY SLO"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.slo"),
+			Prop: "spec.slo",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -109,7 +107,7 @@ func TestValidate_Spec_Slo(t *testing.T) {
 		alertSilence.Spec.SLO = ""
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.slo"),
+			Prop: "spec.slo",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -150,7 +148,7 @@ func TestValidate_Spec_AlertPolicy(t *testing.T) {
 		alertSilence.Spec.AlertPolicy.Name = "not valid NAME !!"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.alertPolicy.name"),
+			Prop: "spec.alertPolicy.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -159,7 +157,7 @@ func TestValidate_Spec_AlertPolicy(t *testing.T) {
 		alertSilence.Spec.AlertPolicy.Name = ""
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.alertPolicy.name"),
+			Prop: "spec.alertPolicy.name",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -168,7 +166,7 @@ func TestValidate_Spec_AlertPolicy(t *testing.T) {
 		alertSilence.Spec.AlertPolicy.Project = "not valid NAME !!"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 2, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.alertPolicy.project"),
+			Prop: "spec.alertPolicy.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -178,7 +176,7 @@ func TestValidate_Spec_AlertPolicy(t *testing.T) {
 		alertSilence.Spec.AlertPolicy.Project = "project-2"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.alertPolicy.project"),
+			Prop: "spec.alertPolicy.project",
 			Code: errorCodeInconsistentProject,
 		})
 	})
@@ -191,7 +189,7 @@ func TestValidate_Spec_Period(t *testing.T) {
 		alertSilence.Spec.Period.Duration = ""
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.period"),
+			Prop: "spec.period",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -203,7 +201,7 @@ func TestValidate_Spec_Period(t *testing.T) {
 		alertSilence.Spec.Period.Duration = "10m"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.period"),
+			Prop: "spec.period",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -233,7 +231,7 @@ func TestValidate_Spec_Period_Duration(t *testing.T) {
 		alertSilence.Spec.Period.Duration = "3 months"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.period.duration"),
+			Prop: "spec.period.duration",
 			Code: govy.ErrorCodeTransform,
 		})
 	})
@@ -244,7 +242,7 @@ func TestValidate_Spec_Period_Duration(t *testing.T) {
 		alertSilence.Spec.Period.Duration = "0s"
 		err := validate(alertSilence)
 		testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.period.duration"),
+			Prop: "spec.period.duration",
 			Code: rules.ErrorCodeGreaterThan,
 		})
 	})
@@ -278,7 +276,7 @@ func TestValidate_Spec_EndTime(t *testing.T) {
 			alertSilence.Spec.Period = testCase
 			err := validate(alertSilence)
 			testutils.AssertContainsErrors(t, alertSilence, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.period"),
+				Prop: "spec.period",
 				Code: errorCodeEndTimeNotBeforeOrNotEqualStartTime,
 			})
 		})

--- a/manifest/v1alpha/annotation/validation_test.go
+++ b/manifest/v1alpha/annotation/validation_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 	"github.com/stretchr/testify/assert"
 
@@ -33,11 +31,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, annotation, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -54,11 +52,11 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, annotation, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: v1alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: v1alpha.ErrorCodeStringName,
 		},
 	)
@@ -85,7 +83,7 @@ func TestValidate_Spec_Description(t *testing.T) {
 		annotation.Spec.Description = strings.Repeat("A", specDescriptionMaxLength+1)
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: rules.ErrorCodeStringLength,
 		})
 	})
@@ -94,7 +92,7 @@ func TestValidate_Spec_Description(t *testing.T) {
 		annotation.Spec.Description = ""
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -112,7 +110,7 @@ func TestValidate_Spec_Slo(t *testing.T) {
 		annotation.Spec.Slo = "MY SLO"
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.slo"),
+			Prop: "spec.slo",
 			Code: v1alpha.ErrorCodeStringName,
 		})
 	})
@@ -121,7 +119,7 @@ func TestValidate_Spec_Slo(t *testing.T) {
 		annotation.Spec.Slo = ""
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.slo"),
+			Prop: "spec.slo",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -139,7 +137,7 @@ func TestValidate_Spec_Objective(t *testing.T) {
 		annotation.Spec.ObjectiveName = "MY OBJECTIVE"
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectiveName"),
+			Prop: "spec.objectiveName",
 			Code: v1alpha.ErrorCodeStringName,
 		})
 	})
@@ -176,7 +174,7 @@ func TestSpec_Time(t *testing.T) {
 		annotation.Spec.EndTime = time.Date(2023, 5, 2, 17, 10, 5, 0, time.UTC)
 		err := validate(annotation)
 		testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.New().Name("spec"),
+			Prop: "spec",
 			Code: errorCodeEndTimeNotBeforeStartTime,
 		})
 	})
@@ -203,7 +201,7 @@ func TestSpec_Category(t *testing.T) {
 			annotation.Spec.Category = category
 			err := validate(annotation)
 			testutils.AssertContainsErrors(t, annotation, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.category"),
+				Prop: "spec.category",
 				Code: rules.ErrorCodeOneOf,
 			})
 		})
@@ -211,7 +209,7 @@ func TestSpec_Category(t *testing.T) {
 }
 
 func TestValidate_Metadata_Labels(t *testing.T) {
-	for name, test := range v1alphatest.GetLabelsTestCases[Annotation](t, jsonpath.Parse("metadata.labels")) {
+	for name, test := range v1alphatest.GetLabelsTestCases[Annotation](t, "metadata.labels") {
 		t.Run(name, func(t *testing.T) {
 			svc := validAnnotation()
 			svc.Metadata.Labels = test.Labels

--- a/manifest/v1alpha/budgetadjustment/validation_test.go
+++ b/manifest/v1alpha/budgetadjustment/validation_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/teambition/rrule-go"
 
@@ -35,11 +33,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, budgetAdjustment, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -56,11 +54,11 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, budgetAdjustment, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 	)
@@ -82,7 +80,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.description"),
+					Prop: "spec.description",
 					Code: validationV1Alpha.ErrorCodeStringDescription,
 				},
 			},
@@ -95,7 +93,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.firstEventStart"),
+					Prop: "spec.firstEventStart",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -108,7 +106,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.duration"),
+					Prop: "spec.duration",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -122,7 +120,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.filters.slos"),
+					Prop:    "spec.filters.slos",
 					Message: "length must be greater than or equal to 1",
 				},
 			},
@@ -141,7 +139,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.duration"),
+					Prop:    "spec.duration",
 					Message: "duration must be at least 1 minute",
 				},
 			},
@@ -173,7 +171,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].name"),
+					Prop: "spec.filters.slos[0].name",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -192,7 +190,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].name"),
+					Prop: "spec.filters.slos[0].name",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -210,7 +208,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].project"),
+					Prop: "spec.filters.slos[0].project",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -229,7 +227,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].project"),
+					Prop: "spec.filters.slos[0].project",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -249,7 +247,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.rrule"),
+					Prop:    "spec.rrule",
 					Message: "wrong format",
 				},
 			},
@@ -269,7 +267,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.rrule"),
+					Prop:    "spec.rrule",
 					Message: "undefined frequency: TEST",
 				},
 			},
@@ -289,7 +287,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.rrule"),
+					Prop:    "spec.rrule",
 					Message: "interval must be at least 60 minutes for minutely frequency",
 				},
 			},
@@ -309,7 +307,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.rrule"),
+					Prop: "spec.rrule",
 					Code: "transform",
 				},
 			},
@@ -344,7 +342,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos"),
+					Prop: "spec.filters.slos",
 					Code: rules.ErrorCodeSliceUnique,
 				},
 			},
@@ -369,7 +367,7 @@ func TestValidate_Spec(t *testing.T) {
 			},
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos"),
+					Prop: "spec.filters.slos",
 					Code: rules.ErrorCodeSliceUnique,
 				},
 			},

--- a/manifest/v1alpha/dataexport/validation_test.go
+++ b/manifest/v1alpha/dataexport/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -32,11 +30,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, dataExport, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -54,15 +52,15 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, dataExport, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
@@ -103,7 +101,7 @@ func TestValidate_Spec_ExportType(t *testing.T) {
 		dataExport.Spec.ExportType = "Azure"
 		err := validate(dataExport)
 		testutils.AssertContainsErrors(t, dataExport, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.exportType"),
+			Prop: "spec.exportType",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -131,11 +129,11 @@ func TestValidate_Spec_Spec_S3(t *testing.T) {
 			err,
 			2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.bucketName"),
+				Prop: "spec.spec.bucketName",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.roleArn"),
+				Prop: "spec.spec.roleArn",
 				Code: rules.ErrorCodeRequired,
 			})
 	})
@@ -153,7 +151,7 @@ func TestValidate_Spec_Spec_S3(t *testing.T) {
 			err,
 			1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.bucketName"),
+				Prop: "spec.spec.bucketName",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			})
 	})
@@ -171,7 +169,7 @@ func TestValidate_Spec_Spec_S3(t *testing.T) {
 			err,
 			1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.roleArn"),
+				Prop: "spec.spec.roleArn",
 				Code: rules.ErrorCodeStringLength,
 			})
 	})
@@ -199,11 +197,11 @@ func TestValidate_Spec_Spec_Snowflake(t *testing.T) {
 			err,
 			2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.bucketName"),
+				Prop: "spec.spec.bucketName",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.roleArn"),
+				Prop: "spec.spec.roleArn",
 				Code: rules.ErrorCodeRequired,
 			})
 	})
@@ -221,7 +219,7 @@ func TestValidate_Spec_Spec_Snowflake(t *testing.T) {
 			err,
 			1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.bucketName"),
+				Prop: "spec.spec.bucketName",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			})
 	})
@@ -239,7 +237,7 @@ func TestValidate_Spec_Spec_Snowflake(t *testing.T) {
 			err,
 			1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.spec.roleArn"),
+				Prop: "spec.spec.roleArn",
 				Code: rules.ErrorCodeStringLength,
 			})
 	})
@@ -269,7 +267,7 @@ func TestValidate_Spec_Spec_GCS(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				},
 			},
@@ -279,7 +277,7 @@ func TestValidate_Spec_Spec_GCS(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				},
 			},
@@ -289,7 +287,7 @@ func TestValidate_Spec_Spec_GCS(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -298,11 +296,11 @@ func TestValidate_Spec_Spec_GCS(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringLength,
 				},
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				},
 			},
@@ -312,11 +310,11 @@ func TestValidate_Spec_Spec_GCS(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringLength,
 				},
 				{
-					Prop: jsonpath.Parse("spec.spec.bucketName"),
+					Prop: "spec.spec.bucketName",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				},
 			},

--- a/manifest/v1alpha/direct/validation_test.go
+++ b/manifest/v1alpha/direct/validation_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -36,11 +34,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, direct, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -58,22 +56,22 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, direct, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	tests := v1alphatest.GetMetadataAnnotationsTestCases[Direct](t, jsonpath.Parse("metadata.annotations"))
+	tests := v1alphatest.GetMetadataAnnotationsTestCases[Direct](t, "metadata.annotations")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			svc := validDirect(v1alpha.Datadog)
@@ -89,7 +87,7 @@ func TestValidateSpec(t *testing.T) {
 		direct.Spec.Description = strings.Repeat("a", 2000)
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: validationV1Alpha.ErrorCodeStringDescription,
 		})
 	})
@@ -98,7 +96,7 @@ func TestValidateSpec(t *testing.T) {
 		direct.Spec.Datadog = nil
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.New().Name("spec"),
+			Prop: "spec",
 			Code: errCodeExactlyOneDataSourceType,
 		})
 	})
@@ -113,7 +111,7 @@ func TestValidateSpec(t *testing.T) {
 			direct.Spec.Datadog = validDirectSpec(v1alpha.Datadog).Datadog
 			err := validate(direct)
 			testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.New().Name("spec"),
+				Prop: "spec",
 				Code: errCodeExactlyOneDataSourceType,
 			})
 		}
@@ -138,7 +136,7 @@ func TestValidateSpec_ReleaseChannel(t *testing.T) {
 		direct.Spec.ReleaseChannel = -1
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.releaseChannel"),
+			Prop: "spec.releaseChannel",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -153,7 +151,7 @@ func TestValidateSpec_ReleaseChannel(t *testing.T) {
 		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelAlpha
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.releaseChannel"),
+			Prop: "spec.releaseChannel",
 			Code: errCodeUnsupportedReleaseChannel,
 		})
 	})
@@ -162,7 +160,7 @@ func TestValidateSpec_ReleaseChannel(t *testing.T) {
 		direct.Spec.ReleaseChannel = v1alpha.ReleaseChannelStable
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.releaseChannel"),
+			Prop: "spec.releaseChannel",
 			Code: errCodeUnsupportedReleaseChannel,
 		})
 	})
@@ -181,11 +179,11 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.value"),
+				Prop: "spec.queryDelay.value",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.unit"),
+				Prop: "spec.queryDelay.unit",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -217,7 +215,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 			}}
 			err := validate(direct)
 			testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.queryDelay.unit"),
+				Prop: "spec.queryDelay.unit",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}
@@ -231,7 +229,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.queryDelay"),
+			Prop: "spec.queryDelay",
 			Code: errCodeQueryDelayOutOfBounds,
 		})
 	})
@@ -244,7 +242,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 		}}
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.queryDelay"),
+			Prop: "spec.queryDelay",
 			Code: errCodeQueryDelayOutOfBounds,
 		})
 	})
@@ -259,7 +257,7 @@ func TestValidateSpec_QueryDelay(t *testing.T) {
 				}}
 				err := validate(direct)
 				testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.queryDelay"),
+					Prop: "spec.queryDelay",
 					Code: errCodeQueryDelayOutOfBounds,
 				})
 			})
@@ -289,11 +287,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration"),
+				Prop: "spec.historicalDataRetrieval.maxDuration",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration"),
+				Prop: "spec.historicalDataRetrieval.defaultDuration",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -308,11 +306,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -322,11 +320,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -339,11 +337,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				},
 			},
@@ -356,11 +354,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 3,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.value"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.value",
 					Code: rules.ErrorCodeLessThanOrEqualTo,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.value"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.value",
 					Code: rules.ErrorCodeLessThanOrEqualTo,
 				},
 			},
@@ -373,11 +371,11 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			ErrorsCount: 2,
 			Errors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.maxDuration.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration.unit"),
+					Prop: "spec.historicalDataRetrieval.defaultDuration.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 			},
@@ -422,7 +420,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 		}
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.historicalDataRetrieval"),
+			Prop:    "spec.historicalDataRetrieval",
 			Message: "historical data retrieval is not supported for Instana Direct",
 		})
 	})
@@ -441,7 +439,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 			}
 			err := validate(direct)
 			testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.historicalDataRetrieval.defaultDuration"),
+				Prop:    "spec.historicalDataRetrieval.defaultDuration",
 				Message: "must be less than or equal to 'maxDuration' (1 Hour)",
 			})
 		})
@@ -466,7 +464,7 @@ func TestValidateSpec_HistoricalDataRetrieval(t *testing.T) {
 				}
 				objErr := validate(direct)
 				testutils.AssertContainsErrors(t, direct, objErr, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.historicalDataRetrieval.maxDuration"),
+					Prop: "spec.historicalDataRetrieval.maxDuration",
 					Message: fmt.Sprintf("must be less than or equal to %d %s",
 						*maxDuration.Value, maxDuration.Unit),
 				})
@@ -503,7 +501,7 @@ func TestValidateSpec_Datadog(t *testing.T) {
 		direct.Spec.Datadog.Site = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.datadog.site"),
+			Prop: "spec.datadog.site",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -512,7 +510,7 @@ func TestValidateSpec_Datadog(t *testing.T) {
 		direct.Spec.Datadog.Site = "invalid"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.datadog.site"),
+			Prop: "spec.datadog.site",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -544,7 +542,7 @@ func TestValidateSpec_NewRelic(t *testing.T) {
 		direct.Spec.NewRelic.AccountID = 0
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.newRelic.accountId"),
+			Prop: "spec.newRelic.accountId",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -553,7 +551,7 @@ func TestValidateSpec_NewRelic(t *testing.T) {
 		direct.Spec.NewRelic.AccountID = -1
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.newRelic.accountId"),
+			Prop: "spec.newRelic.accountId",
 			Code: rules.ErrorCodeGreaterThanOrEqualTo,
 		})
 	})
@@ -562,7 +560,7 @@ func TestValidateSpec_NewRelic(t *testing.T) {
 		direct.Spec.NewRelic.InsightsQueryKey = "123"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.newRelic.insightsQueryKey"),
+			Prop: "spec.newRelic.insightsQueryKey",
 			Code: rules.ErrorCodeStringStartsWith,
 		})
 	})
@@ -582,15 +580,15 @@ func TestValidateSpec_AppDynamics(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.appDynamics.url"),
+				Prop: "spec.appDynamics.url",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.appDynamics.clientName"),
+				Prop: "spec.appDynamics.clientName",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.appDynamics.accountName"),
+				Prop: "spec.appDynamics.accountName",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -600,7 +598,7 @@ func TestValidateSpec_AppDynamics(t *testing.T) {
 		direct.Spec.AppDynamics.URL = "nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.appDynamics.url"),
+			Prop: "spec.appDynamics.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -609,7 +607,7 @@ func TestValidateSpec_AppDynamics(t *testing.T) {
 		direct.Spec.AppDynamics.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.appDynamics.url"),
+			Prop: "spec.appDynamics.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -641,7 +639,7 @@ func TestValidateSpec_BigQuery(t *testing.T) {
 		direct.Spec.BigQuery.ServiceAccountKey = "{["
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.bigQuery.serviceAccountKey"),
+			Prop: "spec.bigQuery.serviceAccountKey",
 			Code: rules.ErrorCodeStringJSON,
 		})
 	})
@@ -660,7 +658,7 @@ func TestValidateSpec_SplunkObservability(t *testing.T) {
 		direct.Spec.SplunkObservability.Realm = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.splunkObservability.realm"),
+			Prop: "spec.splunkObservability.realm",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -677,7 +675,7 @@ func TestValidateSpec_Splunk(t *testing.T) {
 		direct.Spec.Splunk.URL = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.splunk.url"),
+			Prop: "spec.splunk.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -686,7 +684,7 @@ func TestValidateSpec_Splunk(t *testing.T) {
 		direct.Spec.Splunk.URL = "nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.splunk.url"),
+			Prop: "spec.splunk.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -695,7 +693,7 @@ func TestValidateSpec_Splunk(t *testing.T) {
 		direct.Spec.Splunk.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.splunk.url"),
+			Prop: "spec.splunk.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -712,7 +710,7 @@ func TestValidateSpec_Redshift(t *testing.T) {
 		direct.Spec.Redshift.SecretARN = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.redshift.secretARN"),
+			Prop: "spec.redshift.secretARN",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -729,7 +727,7 @@ func TestValidateSpec_SumoLogic(t *testing.T) {
 		direct.Spec.SumoLogic.URL = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.sumoLogic.url"),
+			Prop: "spec.sumoLogic.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -738,7 +736,7 @@ func TestValidateSpec_SumoLogic(t *testing.T) {
 		direct.Spec.SumoLogic.URL = "nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.sumoLogic.url"),
+			Prop: "spec.sumoLogic.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -747,7 +745,7 @@ func TestValidateSpec_SumoLogic(t *testing.T) {
 		direct.Spec.SumoLogic.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.sumoLogic.url"),
+			Prop: "spec.sumoLogic.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -764,7 +762,7 @@ func TestValidateSpec_Instana(t *testing.T) {
 		direct.Spec.Instana.URL = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.instana.url"),
+			Prop: "spec.instana.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -773,7 +771,7 @@ func TestValidateSpec_Instana(t *testing.T) {
 		direct.Spec.Instana.URL = "nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.instana.url"),
+			Prop: "spec.instana.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -782,7 +780,7 @@ func TestValidateSpec_Instana(t *testing.T) {
 		direct.Spec.Instana.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.instana.url"),
+			Prop: "spec.instana.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -799,7 +797,7 @@ func TestValidateSpec_InfluxDB(t *testing.T) {
 		direct.Spec.InfluxDB.URL = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.influxdb.url"),
+			Prop: "spec.influxdb.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -808,7 +806,7 @@ func TestValidateSpec_InfluxDB(t *testing.T) {
 		direct.Spec.InfluxDB.URL = "nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.influxdb.url"),
+			Prop: "spec.influxdb.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -817,7 +815,7 @@ func TestValidateSpec_InfluxDB(t *testing.T) {
 		direct.Spec.InfluxDB.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.influxdb.url"),
+			Prop: "spec.influxdb.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -849,7 +847,7 @@ func TestValidateSpec_GCM(t *testing.T) {
 		direct.Spec.GCM.ServiceAccountKey = "{["
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.gcm.serviceAccountKey"),
+			Prop: "spec.gcm.serviceAccountKey",
 			Code: rules.ErrorCodeStringJSON,
 		})
 	})
@@ -869,11 +867,11 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.lightstep.organization"),
+				Prop: "spec.lightstep.organization",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.lightstep.project"),
+				Prop: "spec.lightstep.project",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -883,7 +881,7 @@ func TestValidateSpec_Lightstep(t *testing.T) {
 		direct.Spec.Lightstep.URL = "h ttp"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.lightstep.url"),
+			Prop: "spec.lightstep.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -921,7 +919,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 		direct.Spec.Dynatrace.URL = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.dynatrace.url"),
+			Prop: "spec.dynatrace.url",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -930,7 +928,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 		direct.Spec.Dynatrace.URL = "h ttp"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.dynatrace.url"),
+			Prop: "spec.dynatrace.url",
 			Code: rules.ErrorCodeURL,
 		})
 	})
@@ -939,7 +937,7 @@ func TestValidateSpec_Dynatrace(t *testing.T) {
 		direct.Spec.Dynatrace.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.dynatrace.url"),
+			Prop: "spec.dynatrace.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})
@@ -956,7 +954,7 @@ func TestValidateSpec_AzureMonitor(t *testing.T) {
 		direct.Spec.AzureMonitor.TenantID = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azureMonitor.tenantId"),
+			Prop: "spec.azureMonitor.tenantId",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -965,7 +963,7 @@ func TestValidateSpec_AzureMonitor(t *testing.T) {
 		direct.Spec.AzureMonitor.TenantID = "invalid"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azureMonitor.tenantId"),
+			Prop: "spec.azureMonitor.tenantId",
 			Code: rules.ErrorCodeStringUUID,
 		})
 	})
@@ -982,7 +980,7 @@ func TestValidateSpec_LogicMonitor(t *testing.T) {
 		direct.Spec.LogicMonitor.Account = ""
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.logicMonitor.account"),
+			Prop: "spec.logicMonitor.account",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -999,7 +997,7 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		direct.Spec.AzurePrometheus.TenantID = "invalid"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+			Prop: "spec.azurePrometheus.tenantId",
 			Code: rules.ErrorCodeStringUUID,
 		})
 	})
@@ -1012,11 +1010,11 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.url"),
+				Prop: "spec.azurePrometheus.url",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+				Prop: "spec.azurePrometheus.tenantId",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -1028,11 +1026,11 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.url"),
+				Prop: "spec.azurePrometheus.url",
 				Code: rules.ErrorCodeURL,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.azurePrometheus.tenantId"),
+				Prop: "spec.azurePrometheus.tenantId",
 				Code: rules.ErrorCodeStringUUID,
 			},
 		)
@@ -1043,7 +1041,7 @@ func TestValidateSpec_AzurePrometheus(t *testing.T) {
 		direct.Spec.AzurePrometheus.URL = "http://nobl9.com"
 		err := validate(direct)
 		testutils.AssertContainsErrors(t, direct, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.azurePrometheus.url"),
+			Prop: "spec.azurePrometheus.url",
 			Code: errorCodeHTTPSSchemeRequired,
 		})
 	})

--- a/manifest/v1alpha/project/validation_test.go
+++ b/manifest/v1alpha/project/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -34,11 +32,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, project, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -55,18 +53,18 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, project, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 	)
 }
 
 func TestValidate_Metadata_Labels(t *testing.T) {
-	for name, test := range v1alphatest.GetLabelsTestCases[Project](t, jsonpath.Parse("metadata.labels")) {
+	for name, test := range v1alphatest.GetLabelsTestCases[Project](t, "metadata.labels") {
 		t.Run(name, func(t *testing.T) {
 			svc := validProject()
 			svc.Metadata.Labels = test.Labels
@@ -76,7 +74,7 @@ func TestValidate_Metadata_Labels(t *testing.T) {
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	tests := v1alphatest.GetMetadataAnnotationsTestCases[Project](t, jsonpath.Parse("metadata.annotations"))
+	tests := v1alphatest.GetMetadataAnnotationsTestCases[Project](t, "metadata.annotations")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			svc := validProject()
@@ -92,7 +90,7 @@ func TestValidate_Spec(t *testing.T) {
 	err := validate(project)
 	testutils.AssertContainsErrors(t, project, err, 1,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: validationV1Alpha.ErrorCodeStringDescription,
 		},
 	)

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/teambition/rrule-go"
 
+	"github.com/nobl9/govy/pkg/jsonpath"
 	"github.com/nobl9/govy/pkg/rules"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -33,11 +32,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, report, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -53,7 +52,7 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, report, err, 1,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
@@ -66,11 +65,11 @@ func TestValidate_Spec(t *testing.T) {
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 2,
 			testutils.ExpectedError{
-				Prop:    jsonpath.New().Name("spec"),
+				Prop:    "spec",
 				Message: "exactly one report type configuration is required",
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.filters"),
+				Prop: "spec.filters",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -110,7 +109,7 @@ func TestValidate_Spec(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 2, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("spec"),
+			Prop:    "spec",
 			Message: "exactly one report type configuration is required",
 		})
 	})
@@ -162,7 +161,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters"),
+					Prop: "spec.filters",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -172,7 +171,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.filters"),
+					Prop:    "spec.filters",
 					Message: "at least one of the following fields is required: projects, services, slos",
 				},
 			},
@@ -186,7 +185,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.projects[0]"),
+					Prop: "spec.filters.projects[0]",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -198,7 +197,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.services[0].name"),
+					Prop: "spec.filters.services[0].name",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -214,7 +213,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.services[0].name"),
+					Prop: "spec.filters.services[0].name",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -231,7 +230,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.services[0].project"),
+					Prop: "spec.filters.services[0].project",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -247,7 +246,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.services[0].project"),
+					Prop: "spec.filters.services[0].project",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -264,7 +263,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].name"),
+					Prop: "spec.filters.slos[0].name",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -280,7 +279,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].name"),
+					Prop: "spec.filters.slos[0].name",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -297,7 +296,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].project"),
+					Prop: "spec.filters.slos[0].project",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -313,7 +312,7 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.filters.slos[0].project"),
+					Prop: "spec.filters.slos[0].project",
 					Code: validationV1Alpha.ErrorCodeStringName,
 				},
 			},
@@ -390,15 +389,15 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 3,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.rolling.unit"),
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.rolling.count"),
+					Prop: "spec.sloHistory.timeFrame.rolling.count",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.rolling"),
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -411,11 +410,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.rolling.count"),
+					Prop: "spec.sloHistory.timeFrame.rolling.count",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.rolling"),
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -432,11 +431,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.rolling.unit"),
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.rolling"),
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -453,11 +452,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.rolling.unit"),
+					Prop: "spec.sloHistory.timeFrame.rolling.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.rolling"),
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -475,7 +474,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.rolling"),
+					Prop:    "spec.sloHistory.timeFrame.rolling",
 					Message: validUnitAndCountRollingPairs,
 				},
 			},
@@ -493,7 +492,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.timeZone"),
+					Prop: "spec.sloHistory.timeFrame.timeZone",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -510,7 +509,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.timeZone"),
+					Prop:    "spec.sloHistory.timeFrame.timeZone",
 					Message: "not a valid time zone: unknown time zone x",
 				},
 			},
@@ -528,7 +527,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.calendar"),
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validCalendarPairs,
 				},
 			},
@@ -541,7 +540,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.calendar"),
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validCalendarPairs,
 				},
 			},
@@ -558,11 +557,11 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.sloHistory.timeFrame.calendar.unit"),
+					Prop: "spec.sloHistory.timeFrame.calendar.unit",
 					Code: rules.ErrorCodeOneOf,
 				},
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.calendar"),
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validUnitAndCountCalendarPairs,
 				},
 			},
@@ -580,7 +579,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.calendar"),
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: validUnitAndCountCalendarPairs,
 				},
 			},
@@ -598,7 +597,7 @@ func TestValidate_Spec_SLOHistory_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.sloHistory.timeFrame.calendar"),
+					Prop:    "spec.sloHistory.timeFrame.calendar",
 					Message: "dates must be in the past",
 				},
 			},
@@ -651,7 +650,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails with empty rowGroupBy value": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.rowGroupBy"),
+				Prop: "spec.systemHealthReview.rowGroupBy",
 				Code: rules.ErrorCodeRequired,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -662,7 +661,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails with empty thresholds": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.thresholds"),
+				Prop: "spec.systemHealthReview.thresholds",
 				Code: rules.ErrorCodeRequired,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -673,7 +672,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails with invalid thresholds": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.thresholds.greenGt"),
+				Prop: "spec.systemHealthReview.thresholds.greenGt",
 				Code: rules.ErrorCodeLessThan,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -687,7 +686,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails when red is greater than green": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:    jsonpath.Parse("spec.systemHealthReview.thresholds.redLte"),
+				Prop:    "spec.systemHealthReview.thresholds.redLte",
 				Message: "must be less than or equal to 'greenGt' (0.1)",
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -701,7 +700,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails when rowGroupBy is 'project'": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeForbidden,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -713,7 +712,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails when rowGroupBy is 'service'": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeForbidden,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -725,7 +724,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails with too long tableHeader": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.tableHeader"),
+				Prop: "spec.systemHealthReview.tableHeader",
 				Code: rules.ErrorCodeStringMaxLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -736,7 +735,7 @@ func TestValidate_Spec_SystemHealthReview(t *testing.T) {
 		"fails with invalid timeZone": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:    jsonpath.Parse("spec.systemHealthReview.timeFrame.timeZone"),
+				Prop:    "spec.systemHealthReview.timeFrame.timeZone",
 				Message: "not a valid time zone: unknown time zone x",
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -767,7 +766,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with empty columns": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.columns"),
+				Prop: "spec.systemHealthReview.columns",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -778,7 +777,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with too many columns": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.columns"),
+				Prop: "spec.systemHealthReview.columns",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -794,7 +793,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with empty labels": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.columns[0].labels"),
+				Prop: "spec.systemHealthReview.columns[0].labels",
 				Code: rules.ErrorCodeMapMinLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -805,7 +804,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with invalid label key": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:       jsonpath.Parse("spec.systemHealthReview.columns[0].labels.k ey"),
+				Prop:       jsonpath.Parse("spec.systemHealthReview.columns[0].labels").Name("k ey").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			}},
@@ -817,7 +816,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with empty displayName": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.columns[0].displayName"),
+				Prop: "spec.systemHealthReview.columns[0].displayName",
 				Code: rules.ErrorCodeRequired,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -828,7 +827,7 @@ func TestValidate_Spec_SystemHealthReview_Columns(t *testing.T) {
 		"fails with too long displayName": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.columns[0].displayName"),
+				Prop: "spec.systemHealthReview.columns[0].displayName",
 				Code: rules.ErrorCodeStringMaxLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -869,7 +868,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with nil labelRows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -880,7 +879,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with empty labelRows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -891,7 +890,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with too many labelRows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -907,7 +906,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with empty labels": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels"),
+				Prop: "spec.systemHealthReview.labelRows[0].labels",
 				Code: rules.ErrorCodeMapLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -918,7 +917,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with too many labels": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels"),
+				Prop: "spec.systemHealthReview.labelRows[0].labels",
 				Code: rules.ErrorCodeMapLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -929,7 +928,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with invalid label key": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:       jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels.k ey"),
+				Prop:       jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels").Name("k ey").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			}},
@@ -941,7 +940,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with label values": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:    jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels.key1"),
+				Prop:    "spec.systemHealthReview.labelRows[0].labels.key1",
 				Message: "label values must be empty",
 				Code:    rules.ErrorCodeSliceMaxLength,
 			}},
@@ -953,7 +952,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByLabel(t *testing.T) {
 		"fails with displayName": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].displayName"),
+				Prop: "spec.systemHealthReview.labelRows[0].displayName",
 				Code: rules.ErrorCodeForbidden,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1015,7 +1014,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with too many rows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1034,7 +1033,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with nil labelRows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1045,7 +1044,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with empty labelRows": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows"),
+				Prop: "spec.systemHealthReview.labelRows",
 				Code: rules.ErrorCodeSliceLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1056,7 +1055,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with empty labels": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels"),
+				Prop: "spec.systemHealthReview.labelRows[0].labels",
 				Code: rules.ErrorCodeMapMinLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1067,7 +1066,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with invalid label key": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop:       jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels.k ey"),
+				Prop:       jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels").Name("k ey").String(),
 				IsKeyError: true,
 				Code:       rules.ErrorCodeStringMatchRegexp,
 			}},
@@ -1079,7 +1078,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with empty label values": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels.key1"),
+				Prop: "spec.systemHealthReview.labelRows[0].labels.key1",
 				Code: rules.ErrorCodeSliceMinLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1090,7 +1089,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with nil label values": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].labels.key1"),
+				Prop: "spec.systemHealthReview.labelRows[0].labels.key1",
 				Code: rules.ErrorCodeSliceMinLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1101,7 +1100,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with empty displayName": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].displayName"),
+				Prop: "spec.systemHealthReview.labelRows[0].displayName",
 				Code: rules.ErrorCodeRequired,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1112,7 +1111,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 		"fails with too long displayName": {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.Parse("spec.systemHealthReview.labelRows[0].displayName"),
+				Prop: "spec.systemHealthReview.labelRows[0].displayName",
 				Code: rules.ErrorCodeStringMaxLength,
 			}},
 			ConfigFunc: func(conf SystemHealthReviewConfig) SystemHealthReviewConfig {
@@ -1145,7 +1144,7 @@ func TestValidate_Spec_SystemHealthReview_RowGroupByCustom(t *testing.T) {
 				testutils.AssertNoError(t, report, err)
 			default:
 				testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.systemHealthReview.hideUngrouped"),
+					Prop: "spec.systemHealthReview.hideUngrouped",
 					Code: rules.ErrorCodeForbidden,
 				})
 			}
@@ -1163,7 +1162,7 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame"),
+					Prop: "spec.systemHealthReview.timeFrame",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -1182,7 +1181,7 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -1205,7 +1204,7 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.dateTime"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot.dateTime",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -1230,11 +1229,11 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.rrule"),
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.rrule",
 					Message: "wrong format",
 				},
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.dateTime"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot.dateTime",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -1260,11 +1259,11 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.rrule"),
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.rrule",
 					Message: "undefined frequency: TEST",
 				},
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.dateTime"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot.dateTime",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -1290,7 +1289,7 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.rrule"),
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.rrule",
 					Message: "rrule must have at least daily frequency",
 				},
 			},
@@ -1317,11 +1316,11 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 2,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.rrule"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot.rrule",
 					Code: rules.ErrorCodeForbidden,
 				},
 				{
-					Prop: jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.dateTime"),
+					Prop: "spec.systemHealthReview.timeFrame.snapshot.dateTime",
 					Code: rules.ErrorCodeForbidden,
 				},
 			},
@@ -1348,7 +1347,7 @@ func TestValidate_Spec_SystemHealthReview_TimeFrame(t *testing.T) {
 			ExpectedErrorsCount: 1,
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop:    jsonpath.Parse("spec.systemHealthReview.timeFrame.snapshot.dateTime"),
+					Prop:    "spec.systemHealthReview.timeFrame.snapshot.dateTime",
 					Message: "dateTime must be in the past",
 				},
 			},
@@ -1504,7 +1503,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec"),
+			Prop:    "spec",
 			Message: "spec.filters and spec.reliabilityRollup.customHierarchy are mutually exclusive",
 		})
 	})
@@ -1514,7 +1513,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		report.Spec.Filters = nil
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec"),
+			Prop:    "spec",
 			Message: "spec.filters or spec.reliabilityRollup.customHierarchy is required",
 		})
 	})
@@ -1524,7 +1523,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		report.Spec.ReliabilityRollup.TimeFrame = ReliabilityRollupTimeFrame{}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reliabilityRollup.timeFrame"),
+			Prop: "spec.reliabilityRollup.timeFrame",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -1536,7 +1535,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reliabilityRollup.timeFrame"),
+			Prop: "spec.reliabilityRollup.timeFrame",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -1546,7 +1545,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		report.Spec.ReliabilityRollup.TimeFrame.TimeZone = "x"
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.reliabilityRollup.timeFrame.timeZone"),
+			Prop:    "spec.reliabilityRollup.timeFrame.timeZone",
 			Message: "not a valid time zone: unknown time zone x",
 		})
 	})
@@ -1572,7 +1571,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].displayName"),
+			Prop: "spec.reliabilityRollup.customHierarchy[0].displayName",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -1589,11 +1588,11 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].slos[0].project"),
+				Prop: "spec.reliabilityRollup.customHierarchy[0].slos[0].project",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].slos[0].name"),
+				Prop: "spec.reliabilityRollup.customHierarchy[0].slos[0].name",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -1613,11 +1612,11 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].slos[0].project"),
+				Prop: "spec.reliabilityRollup.customHierarchy[0].slos[0].project",
 				Code: validationV1Alpha.ErrorCodeStringName,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].slos[0].name"),
+				Prop: "spec.reliabilityRollup.customHierarchy[0].slos[0].name",
 				Code: validationV1Alpha.ErrorCodeStringName,
 			},
 		)
@@ -1640,7 +1639,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].slos[0].displayName"),
+			Prop: "spec.reliabilityRollup.customHierarchy[0].slos[0].displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		})
 	})
@@ -1656,7 +1655,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reliabilityRollup.customHierarchy[0].displayName"),
+			Prop: "spec.reliabilityRollup.customHierarchy[0].displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		})
 	})
@@ -1712,7 +1711,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.reliabilityRollup.customHierarchy"),
+			Prop:            "spec.reliabilityRollup.customHierarchy",
 			ContainsMessage: "exceeds maximum allowed",
 		})
 	})
@@ -1725,7 +1724,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.reliabilityRollup.customHierarchy"),
+			Prop:            "spec.reliabilityRollup.customHierarchy",
 			ContainsMessage: "exceeds maximum allowed",
 		})
 	})
@@ -1741,7 +1740,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.reliabilityRollup.customHierarchy"),
+			Prop:            "spec.reliabilityRollup.customHierarchy",
 			ContainsMessage: "exceeds maximum allowed",
 		})
 	})
@@ -1769,7 +1768,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		report.Spec.ReliabilityRollup.CustomHierarchy = []HierarchyFolder{}
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec"),
+			Prop:    "spec",
 			Message: "spec.filters or spec.reliabilityRollup.customHierarchy is required",
 		})
 	})
@@ -1788,7 +1787,7 @@ func TestValidate_Spec_ReliabilityRollup(t *testing.T) {
 		report.Spec.Filters = nil
 		err := validate(report)
 		testutils.AssertContainsErrors(t, report, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.filters"),
+			Prop: "spec.filters",
 			Code: rules.ErrorCodeRequired,
 		})
 	})

--- a/manifest/v1alpha/rolebinding/validation_test.go
+++ b/manifest/v1alpha/rolebinding/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -32,11 +30,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, rb, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -60,7 +58,7 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, rb, err, 1,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
@@ -73,7 +71,7 @@ func TestSpec(t *testing.T) {
 		err := validate(rb)
 		testutils.AssertContainsErrors(t, rb, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.roleRef"),
+				Prop: "spec.roleRef",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -84,7 +82,7 @@ func TestSpec(t *testing.T) {
 		err := validate(rb)
 		testutils.AssertContainsErrors(t, rb, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.projectRef"),
+				Prop: "spec.projectRef",
 				Code: validationV1Alpha.ErrorCodeStringName,
 			},
 		)
@@ -124,7 +122,7 @@ func TestSpec(t *testing.T) {
 				rb := New(Metadata{Name: "my-name"}, spec)
 				err := validate(rb)
 				testutils.AssertContainsErrors(t, rb, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.New().Name("spec"),
+					Prop: "spec",
 					Code: rules.ErrorCodeMutuallyExclusive,
 				})
 			})

--- a/manifest/v1alpha/service/validation_test.go
+++ b/manifest/v1alpha/service/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -34,11 +32,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, svc, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -56,22 +54,22 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, svc, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Labels(t *testing.T) {
-	for name, test := range v1alphatest.GetLabelsTestCases[Service](t, jsonpath.Parse("metadata.labels")) {
+	for name, test := range v1alphatest.GetLabelsTestCases[Service](t, "metadata.labels") {
 		t.Run(name, func(t *testing.T) {
 			svc := validService()
 			svc.Metadata.Labels = test.Labels
@@ -81,7 +79,7 @@ func TestValidate_Metadata_Labels(t *testing.T) {
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	tests := v1alphatest.GetMetadataAnnotationsTestCases[Service](t, jsonpath.Parse("metadata.annotations"))
+	tests := v1alphatest.GetMetadataAnnotationsTestCases[Service](t, "metadata.annotations")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			svc := validService()
@@ -97,7 +95,7 @@ func TestValidate_Spec(t *testing.T) {
 		svc.Spec.Description = strings.Repeat("A", 2000)
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.description"),
+			Prop: "spec.description",
 			Code: validationV1Alpha.ErrorCodeStringDescription,
 		})
 	})
@@ -118,7 +116,7 @@ func TestValidate_Spec_ResponsibleUsers(t *testing.T) {
 			expectedErrorCount: 1,
 			expectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.Parse("spec.responsibleUsers[1].id"),
+					Prop: "spec.responsibleUsers[1].id",
 					Code: rules.ErrorCodeStringNotEmpty,
 				},
 			},
@@ -176,7 +174,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.startTime"),
+			Prop: "spec.reviewCycle.startTime",
 			Code: "string_date_time",
 		})
 	})
@@ -190,7 +188,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.startTime"),
+			Prop: "spec.reviewCycle.startTime",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -205,11 +203,11 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reviewCycle.startTime"),
+				Prop: "spec.reviewCycle.startTime",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reviewCycle.startTime"),
+				Prop: "spec.reviewCycle.startTime",
 				Code: "string_date_time",
 			},
 		)
@@ -224,7 +222,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.timeZone"),
+			Prop: "spec.reviewCycle.timeZone",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -239,11 +237,11 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reviewCycle.timeZone"),
+				Prop: "spec.reviewCycle.timeZone",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.reviewCycle.timeZone"),
+				Prop: "spec.reviewCycle.timeZone",
 				Code: rules.ErrorCodeStringTimeZone,
 			},
 		)
@@ -258,7 +256,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.timeZone"),
+			Prop: "spec.reviewCycle.timeZone",
 			Code: "string_time_zone",
 		})
 	})
@@ -272,7 +270,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.rrule"),
+			Prop: "spec.reviewCycle.rrule",
 			Code: "transform",
 		})
 	})
@@ -286,7 +284,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.reviewCycle.rrule"),
+			Prop: "spec.reviewCycle.rrule",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -300,7 +298,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.reviewCycle.rrule"),
+			Prop:    "spec.reviewCycle.rrule",
 			Message: "wrong format",
 			Code:    "transform",
 		})
@@ -315,7 +313,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.reviewCycle.rrule"),
+			Prop:    "spec.reviewCycle.rrule",
 			Message: "rrule frequency must be at least DAILY",
 		})
 	})
@@ -329,7 +327,7 @@ func TestValidate_ReviewCycle(t *testing.T) {
 		}
 		err := validate(svc)
 		testutils.AssertContainsErrors(t, svc, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.reviewCycle.rrule"),
+			Prop:    "spec.reviewCycle.rrule",
 			Message: "rrule frequency must be at least DAILY",
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_amazon_prometheus_test.go
+++ b/manifest/v1alpha/slo/metrics_amazon_prometheus_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestAmazonPrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AmazonPrometheus.PromQL = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.amazonPrometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.amazonPrometheus.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestAmazonPrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AmazonPrometheus.PromQL = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.amazonPrometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.amazonPrometheus.promql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_app_dynamics_test.go
+++ b/manifest/v1alpha/slo/metrics_app_dynamics_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -21,7 +19,7 @@ func TestValidate_AppDynamics_ObjectiveLevel(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.AppDynamics.ApplicationName = ptr("different")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeNotEqualTo,
 		})
 	})
@@ -33,7 +31,7 @@ func TestValidate_AppDynamics_ObjectiveLevel(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.BadMetric.AppDynamics.ApplicationName = ptr("different")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeNotEqualTo,
 		})
 	})
@@ -63,11 +61,11 @@ func TestValidate_AppDynamics_Invalid(t *testing.T) {
 			Spec: &AppDynamicsMetric{},
 			ExpectedErrors: []testutils.ExpectedError{
 				{
-					Prop: jsonpath.New().Name("applicationName"),
+					Prop: "applicationName",
 					Code: rules.ErrorCodeRequired,
 				},
 				{
-					Prop: jsonpath.New().Name("metricPath"),
+					Prop: "metricPath",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -78,7 +76,7 @@ func TestValidate_AppDynamics_Invalid(t *testing.T) {
 				MetricPath:      ptr("path"),
 			},
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.New().Name("applicationName"),
+				Prop: "applicationName",
 				Code: rules.ErrorCodeStringNotEmpty,
 			}},
 		},
@@ -88,7 +86,7 @@ func TestValidate_AppDynamics_Invalid(t *testing.T) {
 				MetricPath:      ptr("App | This* | Latency"),
 			},
 			ExpectedErrors: []testutils.ExpectedError{{
-				Prop: jsonpath.New().Name("metricPath"),
+				Prop: "metricPath",
 				Code: errCodeAppDynamicsWildcardNotSupported,
 			}},
 		},
@@ -100,7 +98,7 @@ func TestValidate_AppDynamics_Invalid(t *testing.T) {
 
 			raw := make([]testutils.ExpectedError, len(test.ExpectedErrors))
 			copy(raw, test.ExpectedErrors)
-			raw = testutils.PrependPropertyPath(raw, jsonpath.Parse("spec.objectives[0].rawMetric.query.appDynamics"))
+			raw = testutils.PrependPropertyPath(raw, "spec.objectives[0].rawMetric.query.appDynamics")
 			testutils.AssertContainsErrors(t, slo, err, len(test.ExpectedErrors), raw...)
 		})
 		t.Run("countMetric "+name, func(t *testing.T) {
@@ -113,8 +111,8 @@ func TestValidate_AppDynamics_Invalid(t *testing.T) {
 			copy(total, test.ExpectedErrors)
 			good := make([]testutils.ExpectedError, len(test.ExpectedErrors))
 			copy(good, test.ExpectedErrors)
-			total = testutils.PrependPropertyPath(total, jsonpath.Parse("spec.objectives[0].countMetrics.total.appDynamics"))
-			good = testutils.PrependPropertyPath(good, jsonpath.Parse("spec.objectives[0].countMetrics.good.appDynamics"))
+			total = testutils.PrependPropertyPath(total, "spec.objectives[0].countMetrics.total.appDynamics")
+			good = testutils.PrependPropertyPath(good, "spec.objectives[0].countMetrics.good.appDynamics")
 			testutils.AssertContainsErrors(t, slo, err, len(test.ExpectedErrors)*2, append(total, good...)...) //nolint: makezero
 		})
 	}

--- a/manifest/v1alpha/slo/metrics_atlas_test.go
+++ b/manifest/v1alpha/slo/metrics_atlas_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.PromQL = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.atlas.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.DataReplay = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas.dataReplay"),
+			Prop: "spec.objectives[0].rawMetric.query.atlas.dataReplay",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -40,7 +38,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.DataReplay.Parameters = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas.dataReplay.parameters"),
+			Prop: "spec.objectives[0].rawMetric.query.atlas.dataReplay.parameters",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -49,7 +47,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.DataReplay.Parameters = map[string]string{}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas.dataReplay.parameters"),
+			Prop: "spec.objectives[0].rawMetric.query.atlas.dataReplay.parameters",
 			Code: rules.ErrorCodeMapMinLength,
 		})
 	})
@@ -58,7 +56,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.DataReplay.GoodSeriesLabel = "good"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas"),
+			Prop:    "spec.objectives[0].rawMetric.query.atlas",
 			Message: "goodSeriesLabel and totalSeriesLabel are forbidden for raw metrics",
 		})
 	})
@@ -67,7 +65,7 @@ func TestAtlas_rawMetric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Atlas.DataReplay.TotalSeriesLabel = "total"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.atlas"),
+			Prop:    "spec.objectives[0].rawMetric.query.atlas",
 			Message: "goodSeriesLabel and totalSeriesLabel are forbidden for raw metrics",
 		})
 	})
@@ -84,7 +82,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.PromQL = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.promql"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -93,7 +91,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.DataReplay = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -102,7 +100,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.DataReplay.GoodSeriesLabel = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.goodSeriesLabel"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.goodSeriesLabel",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -111,7 +109,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.DataReplay.TotalSeriesLabel = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.totalSeriesLabel"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.totalSeriesLabel",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -120,7 +118,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.DataReplay.Parameters = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.parameters"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.parameters",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -129,7 +127,7 @@ func TestAtlas_singleQueryGoodOverTotal(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Atlas.DataReplay.Parameters = map[string]string{}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.parameters"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.atlas.dataReplay.parameters",
 			Code: rules.ErrorCodeMapMinLength,
 		})
 	})
@@ -139,7 +137,7 @@ func TestAtlas_countMetrics_forbidden(t *testing.T) {
 	slo := validCountMetricSLO(v1alpha.Atlas)
 	err := validate(slo)
 	testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+		Prop: "spec.objectives[0].countMetrics",
 		Code: rules.ErrorCodeForbidden,
 	})
 }

--- a/manifest/v1alpha/slo/metrics_azure_monitor_test.go
+++ b/manifest/v1alpha/slo/metrics_azure_monitor_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -32,7 +30,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.metricNamespace' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -40,7 +38,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.metricNamespace' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -61,7 +59,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.resourceId' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -69,7 +67,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.resourceId' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -80,7 +78,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.AzureMonitor = getValidAzureMetric(AzureMonitorDataTypeLogs)
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.dataType' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -88,7 +86,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.dataType' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -103,7 +101,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 			SubscriptionID = "11111111-1111-1111-1111-111111111111"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.subscriptionId' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -111,7 +109,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.subscriptionId' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -126,7 +124,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 			ResourceGroup = "rg-2"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.resourceGroup' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -134,7 +132,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.resourceGroup' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -149,7 +147,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 			WorkspaceID = "11111111-1111-1111-1111-111111111111"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.workspaceId' must be the same for both 'good' and 'total' metrics",
 		})
 		// Bad.
@@ -157,7 +155,7 @@ func TestAzureMonitor_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = nil
 		err = validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "'azureMonitor.workspace.workspaceId' must be the same for both 'bad' and 'total' metrics",
 		})
 	})
@@ -172,7 +170,7 @@ func TestAzureMonitor_DataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dataType"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dataType",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -190,7 +188,7 @@ func TestAzureMonitor_DataType(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AzureMonitor.DataType = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dataType"),
+			Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dataType",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -207,11 +205,11 @@ func TestAzureMonitor_LogsDataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -224,7 +222,7 @@ func TestAzureMonitor_LogsDataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			},
 		)
@@ -237,7 +235,7 @@ func TestAzureMonitor_LogsDataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			},
 		)
@@ -256,15 +254,15 @@ func TestAzureMonitor_MetricDataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.resourceId"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.resourceId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.metricName"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.metricName",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.aggregation"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.aggregation",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -281,11 +279,11 @@ func TestAzureMonitor_MetricDataType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.kqlQuery",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)
@@ -303,7 +301,7 @@ func TestAzureMonitor_MetricDataType(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AzureMonitor.Aggregation = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.aggregation"),
+			Prop: "spec.objectives[0].rawMetric.query.azureMonitor.aggregation",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -321,15 +319,15 @@ func TestAzureMonitorLogAnalyticsWorkspace(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.subscriptionId"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.subscriptionId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.resourceGroup"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.resourceGroup",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.workspaceId"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.workspaceId",
 				Code: rules.ErrorCodeRequired,
 			})
 	})
@@ -349,23 +347,23 @@ func TestAzureMonitorLogAnalyticsWorkspace(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 5,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.resourceId"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.resourceId",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.metricName"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.metricName",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.metricNamespace"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.metricNamespace",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.aggregation"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.aggregation",
 				Code: rules.ErrorCodeForbidden,
 			})
 	})
@@ -376,7 +374,7 @@ func TestAzureMonitorLogAnalyticsWorkspace(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.subscriptionId"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.subscriptionId",
 				Code: rules.ErrorCodeStringUUID,
 			})
 	})
@@ -425,7 +423,7 @@ func TestAzureMonitorLogAnalyticsWorkspace(t *testing.T) {
 				} else {
 					testutils.AssertContainsErrors(t, slo, err, 1,
 						testutils.ExpectedError{
-							Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.resourceGroup"),
+							Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.resourceGroup",
 							Code: rules.ErrorCodeStringMatchRegexp,
 						})
 				}
@@ -480,7 +478,7 @@ func TestAzureMonitorLogAnalyticsWorkspace(t *testing.T) {
 				} else {
 					testutils.AssertContainsErrors(t, slo, err, 1,
 						testutils.ExpectedError{
-							Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.workspace.workspaceId"),
+							Prop: "spec.objectives[0].rawMetric.query.azureMonitor.workspace.workspaceId",
 							Code: rules.ErrorCodeStringUUID,
 						})
 				}
@@ -525,35 +523,35 @@ func TestAzureMonitorDimension(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 9,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[0].name"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[0].name",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[0].value"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[0].value",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[1].name"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[1].name",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[1].value"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[1].value",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[2].name"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[2].name",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[2].value"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[2].value",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[3].name"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[3].name",
 				Code: rules.ErrorCodeStringASCII,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions[3].value"),
+				Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions[3].value",
 				Code: rules.ErrorCodeStringASCII,
 			},
 		)
@@ -572,7 +570,7 @@ func TestAzureMonitorDimension(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.dimensions"),
+			Prop: "spec.objectives[0].rawMetric.query.azureMonitor.dimensions",
 			Code: rules.ErrorCodeSliceUnique,
 		})
 	})
@@ -634,7 +632,7 @@ func TestAzureMonitor_ResourceID(t *testing.T) {
 				testutils.AssertNoError(t, slo, err)
 			} else {
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azureMonitor.resourceId"),
+					Prop: "spec.objectives[0].rawMetric.query.azureMonitor.resourceId",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				})
 			}

--- a/manifest/v1alpha/slo/metrics_azure_prometheus_test.go
+++ b/manifest/v1alpha/slo/metrics_azure_prometheus_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestAzurePrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AzurePrometheus = &AzurePrometheusMetric{}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azurePrometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.azurePrometheus.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestAzurePrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.AzurePrometheus.PromQL = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.azurePrometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.azurePrometheus.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_bigquery_test.go
+++ b/manifest/v1alpha/slo/metrics_bigquery_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -23,7 +21,7 @@ func TestBigQuery_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.BigQuery.ProjectID = "2"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -33,7 +31,7 @@ func TestBigQuery_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.BigQuery.Location = "2"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -46,15 +44,15 @@ func TestBigQuery(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.bigQuery.projectId"),
+				Prop: "spec.objectives[0].rawMetric.query.bigQuery.projectId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.bigQuery.location"),
+				Prop: "spec.objectives[0].rawMetric.query.bigQuery.location",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.bigQuery.query"),
+				Prop: "spec.objectives[0].rawMetric.query.bigQuery.query",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -82,7 +80,7 @@ WHERE http_code = 200 AND created = DATETIME(@n9date_from)`,
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.BigQuery.Query = query
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.bigQuery.query"),
+				Prop:            "spec.objectives[0].rawMetric.query.bigQuery.query",
 				ContainsMessage: expectedDetails,
 			})
 		}

--- a/manifest/v1alpha/slo/metrics_cloudwatch_test.go
+++ b/manifest/v1alpha/slo/metrics_cloudwatch_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/govy/pkg/govy"
@@ -56,7 +54,7 @@ func TestCloudWatch(t *testing.T) {
 				slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch = metric
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch"),
+					Prop: "spec.objectives[0].rawMetric.query.cloudWatch",
 					Code: rules.ErrorCodeOneOf,
 				})
 			})
@@ -67,7 +65,7 @@ func TestCloudWatch(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch.Region = ptr("invalid")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.region"),
+			Prop: "spec.objectives[0].rawMetric.query.cloudWatch.region",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -104,19 +102,19 @@ func TestCloudWatchStandard(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 4,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.metricName"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.metricName",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.namespace"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.namespace",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.stat"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.stat",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.accountId"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.accountId",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 		)
@@ -133,19 +131,19 @@ func TestCloudWatchStandard(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 4,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.namespace"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.namespace",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.metricName"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.metricName",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.stat"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.stat",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.accountId"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.accountId",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			},
 		)
@@ -176,7 +174,7 @@ func TestCloudWatchStandard(t *testing.T) {
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch.AccountID = ptr(accountID)
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.accountId"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.accountId",
 				Code: rules.ErrorCodeStringMatchRegexp,
 			})
 		}
@@ -290,7 +288,7 @@ func TestCloudWatchJSON(t *testing.T) {
 			}
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:            jsonpath.Parse(test.Prop),
+				Prop:            test.Prop,
 				Code:            test.Code,
 				Message:         test.Message,
 				ContainsMessage: test.ContainsMessage,
@@ -317,7 +315,7 @@ func TestCloudWatchSQL(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.sql"),
+			Prop: "spec.objectives[0].rawMetric.query.cloudWatch.sql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -351,7 +349,7 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.CloudWatch.Dimensions = dims
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions"),
+			Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions",
 			Code: rules.ErrorCodeSliceMaxLength,
 		})
 	})
@@ -363,11 +361,11 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -391,27 +389,27 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 6,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].name",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[0].value",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].name"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].name",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].value"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[1].value",
 				Code: rules.ErrorCodeStringMaxLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].name"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].name",
 				Code: rules.ErrorCodeStringASCII,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].value"),
+				Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions[2].value",
 				Code: rules.ErrorCodeStringASCII,
 			},
 		)
@@ -430,7 +428,7 @@ func TestCloudWatch_Dimensions(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.cloudWatch.dimensions"),
+			Prop: "spec.objectives[0].rawMetric.query.cloudWatch.dimensions",
 			Code: rules.ErrorCodeSliceUnique,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_coralogix_test.go
+++ b/manifest/v1alpha/slo/metrics_coralogix_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestCoralogix(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Coralogix.PromQL = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.coralogix.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.coralogix.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestCoralogix(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Coralogix.PromQL = "  "
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.coralogix.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.coralogix.promql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_datadog_test.go
+++ b/manifest/v1alpha/slo/metrics_datadog_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestDatadog(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Datadog.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.datadog.query"),
+			Prop: "spec.objectives[0].rawMetric.query.datadog.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestDatadog(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Datadog.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.datadog.query"),
+			Prop: "spec.objectives[0].rawMetric.query.datadog.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_dynatrace_test.go
+++ b/manifest/v1alpha/slo/metrics_dynatrace_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestDynatrace(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Dynatrace.MetricSelector = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.dynatrace.metricSelector"),
+			Prop: "spec.objectives[0].rawMetric.query.dynatrace.metricSelector",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestDynatrace(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Dynatrace.MetricSelector = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.dynatrace.metricSelector"),
+			Prop: "spec.objectives[0].rawMetric.query.dynatrace.metricSelector",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_elasticsearch_test.go
+++ b/manifest/v1alpha/slo/metrics_elasticsearch_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -26,11 +24,11 @@ func TestElasticsearch(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.elasticsearch.index"),
+				Prop: "spec.objectives[0].rawMetric.query.elasticsearch.index",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.elasticsearch.query"),
+				Prop: "spec.objectives[0].rawMetric.query.elasticsearch.query",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -44,11 +42,11 @@ func TestElasticsearch(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.elasticsearch.index"),
+				Prop: "spec.objectives[0].rawMetric.query.elasticsearch.index",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.elasticsearch.query"),
+				Prop: "spec.objectives[0].rawMetric.query.elasticsearch.query",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 		)
@@ -70,7 +68,7 @@ func TestElasticsearch(t *testing.T) {
 			}
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.elasticsearch.query"),
+				Prop: "spec.objectives[0].rawMetric.query.elasticsearch.query",
 				Code: rules.ErrorCodeStringContains,
 			})
 		}

--- a/manifest/v1alpha/slo/metrics_gcm_test.go
+++ b/manifest/v1alpha/slo/metrics_gcm_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -27,7 +25,7 @@ func TestGCM(t *testing.T) {
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1,
 					testutils.ExpectedError{
-						Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.gcm.projectId"),
+						Prop: "spec.objectives[0].rawMetric.query.gcm.projectId",
 						Code: rules.ErrorCodeRequired,
 					},
 				)
@@ -40,7 +38,7 @@ func TestGCM(t *testing.T) {
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1,
 					testutils.ExpectedError{
-						Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.gcm"),
+						Prop: "spec.objectives[0].rawMetric.query.gcm",
 						Code: rules.ErrorCodeOneOf,
 					},
 				)
@@ -56,7 +54,7 @@ func TestGCM(t *testing.T) {
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1,
 				testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.gcm"),
+					Prop: "spec.objectives[0].rawMetric.query.gcm",
 					Code: rules.ErrorCodeOneOf,
 				},
 			)
@@ -90,7 +88,7 @@ func TestGCM(t *testing.T) {
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1,
 				testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+					Prop: "spec.objectives[0].countMetrics",
 					Code: rules.ErrorCodeNotEqualTo,
 				},
 			)
@@ -104,7 +102,7 @@ func TestGCM(t *testing.T) {
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1,
 				testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+					Prop: "spec.objectives[0].countMetrics",
 					Code: rules.ErrorCodeNotEqualTo,
 				},
 			)

--- a/manifest/v1alpha/slo/metrics_generic_test.go
+++ b/manifest/v1alpha/slo/metrics_generic_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestGeneric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Generic.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.generic.query"),
+			Prop: "spec.objectives[0].rawMetric.query.generic.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestGeneric(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Generic.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.generic.query"),
+			Prop: "spec.objectives[0].rawMetric.query.generic.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_grafana_loki_test.go
+++ b/manifest/v1alpha/slo/metrics_grafana_loki_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestGrafanaLoki(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.GrafanaLoki.Logql = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.grafanaLoki.logql"),
+			Prop: "spec.objectives[0].rawMetric.query.grafanaLoki.logql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestGrafanaLoki(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.GrafanaLoki.Logql = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.grafanaLoki.logql"),
+			Prop: "spec.objectives[0].rawMetric.query.grafanaLoki.logql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_graphite_test.go
+++ b/manifest/v1alpha/slo/metrics_graphite_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestGraphite(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Graphite.MetricPath = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.graphite.metricPath"),
+			Prop: "spec.objectives[0].rawMetric.query.graphite.metricPath",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestGraphite(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Graphite.MetricPath = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.graphite.metricPath"),
+			Prop: "spec.objectives[0].rawMetric.query.graphite.metricPath",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -45,7 +43,7 @@ func TestGraphite(t *testing.T) {
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.Graphite.MetricPath = ptr(path)
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.graphite.metricPath"),
+				Prop:            "spec.objectives[0].rawMetric.query.graphite.metricPath",
 				ContainsMessage: containsMessage,
 			})
 		}

--- a/manifest/v1alpha/slo/metrics_honeycomb_test.go
+++ b/manifest/v1alpha/slo/metrics_honeycomb_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -31,7 +29,7 @@ func TestHoneycomb_singleQuery(t *testing.T) {
 				ErrorsCount: 1,
 				Errors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.honeycomb.attribute"),
+						Prop: "spec.objectives[0].countMetrics.goodTotal.honeycomb.attribute",
 						Code: rules.ErrorCodeStringNotEmpty,
 					},
 				},
@@ -43,7 +41,7 @@ func TestHoneycomb_singleQuery(t *testing.T) {
 				ErrorsCount: 1,
 				Errors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.honeycomb.attribute"),
+						Prop: "spec.objectives[0].countMetrics.goodTotal.honeycomb.attribute",
 						Code: rules.ErrorCodeStringMaxLength,
 					},
 				},
@@ -61,7 +59,7 @@ func TestHoneycomb_rawMetrics_forbidden(t *testing.T) {
 	slo := validRawMetricSLO(v1alpha.Honeycomb)
 	err := validate(slo)
 	testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.honeycomb"),
+		Prop: "spec.objectives[0].rawMetric.query.honeycomb",
 		Code: rules.ErrorCodeForbidden,
 	})
 }
@@ -70,7 +68,7 @@ func TestHoneycomb_countMetrics_forbidden(t *testing.T) {
 	slo := validCountMetricSLO(v1alpha.Honeycomb)
 	err := validate(slo)
 	testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+		Prop: "spec.objectives[0].countMetrics",
 		Code: rules.ErrorCodeForbidden,
 	})
 }

--- a/manifest/v1alpha/slo/metrics_influxdb_test.go
+++ b/manifest/v1alpha/slo/metrics_influxdb_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestInfluxDB(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.InfluxDB.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.influxdb.query"),
+			Prop: "spec.objectives[0].rawMetric.query.influxdb.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestInfluxDB(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.InfluxDB.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.influxdb.query"),
+			Prop: "spec.objectives[0].rawMetric.query.influxdb.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -102,7 +100,7 @@ func TestInfluxDB_Query(t *testing.T) {
 				testutils.AssertNoError(t, slo, err)
 			} else {
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.influxdb.query"),
+					Prop: "spec.objectives[0].rawMetric.query.influxdb.query",
 					Code: rules.ErrorCodeStringMatchRegexp,
 				})
 			}

--- a/manifest/v1alpha/slo/metrics_instana_test.go
+++ b/manifest/v1alpha/slo/metrics_instana_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -45,7 +43,7 @@ func TestInstana_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.Instana = validInstanaInfrastructureMetric()
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -56,27 +54,27 @@ func TestInstana_CountMetrics(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 6,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.instana.application"),
+				Prop: "spec.objectives[0].countMetrics.total.instana.application",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.instana.metricType"),
+				Prop: "spec.objectives[0].countMetrics.total.instana.metricType",
 				Code: rules.ErrorCodeEqualTo,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.instana.infrastructure"),
+				Prop: "spec.objectives[0].countMetrics.total.instana.infrastructure",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.instana.application"),
+				Prop: "spec.objectives[0].countMetrics.good.instana.application",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.instana.metricType"),
+				Prop: "spec.objectives[0].countMetrics.good.instana.metricType",
 				Code: rules.ErrorCodeEqualTo,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.instana.infrastructure"),
+				Prop: "spec.objectives[0].countMetrics.good.instana.infrastructure",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -88,11 +86,11 @@ func TestInstana_CountMetrics(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.instana.metricType"),
+				Prop: "spec.objectives[0].countMetrics.good.instana.metricType",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.instana.metricType"),
+				Prop: "spec.objectives[0].countMetrics.good.instana.metricType",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -112,7 +110,7 @@ func TestInstana_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Infrastructure = &InstanaInfrastructureMetricType{}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.instana"),
+			Prop:    "spec.objectives[0].rawMetric.query.instana",
 			Message: "cannot use both 'instana.application' and 'instana.infrastructure'",
 		})
 	})
@@ -123,7 +121,7 @@ func TestInstana_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Infrastructure = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.instana"),
+			Prop:    "spec.objectives[0].rawMetric.query.instana",
 			Message: "when 'metricType' is 'application', 'instana.application' is required",
 		})
 	})
@@ -134,7 +132,7 @@ func TestInstana_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Infrastructure = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.instana"),
+			Prop:    "spec.objectives[0].rawMetric.query.instana",
 			Message: "when 'metricType' is 'infrastructure', 'instana.infrastructure' is required",
 		})
 	})
@@ -143,7 +141,7 @@ func TestInstana_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.MetricType = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.metricType"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.metricType",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -152,7 +150,7 @@ func TestInstana_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.MetricType = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.metricType"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.metricType",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -168,15 +166,15 @@ func TestInstana_Infrastructure(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.infrastructure.metricRetrievalMethod"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.infrastructure.metricRetrievalMethod",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.infrastructure.metricId"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.infrastructure.metricId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.infrastructure.pluginId"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.infrastructure.pluginId",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -186,7 +184,7 @@ func TestInstana_Infrastructure(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Infrastructure.MetricRetrievalMethod = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.infrastructure.metricRetrievalMethod"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.infrastructure.metricRetrievalMethod",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -229,7 +227,7 @@ func TestInstana_Infrastructure(t *testing.T) {
 				slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Infrastructure.SnapshotID = test.SnapshotID
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.infrastructure"),
+					Prop:    "spec.objectives[0].rawMetric.query.instana.infrastructure",
 					Message: test.ErrorMessage,
 				})
 			})
@@ -248,19 +246,19 @@ func TestInstana_Application(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 4,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.metricId"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.metricId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.aggregation"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.aggregation",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.groupBy"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.groupBy",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.apiQuery"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.apiQuery",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -286,7 +284,7 @@ func TestInstana_Application(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Application.MetricID = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.metricId"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.application.metricId",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -296,7 +294,7 @@ func TestInstana_Application(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Application.APIQuery = "{]}"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.apiQuery"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.application.apiQuery",
 			Code: rules.ErrorCodeStringJSON,
 		})
 	})
@@ -309,11 +307,11 @@ func TestInstana_Application(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.groupBy.tag"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.groupBy.tag",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.groupBy.tagEntity"),
+				Prop: "spec.objectives[0].rawMetric.query.instana.application.groupBy.tagEntity",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -337,7 +335,7 @@ func TestInstana_Application(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Application.GroupBy.TagEntity = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application.groupBy.tagEntity"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.application.groupBy.tagEntity",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -387,7 +385,7 @@ func TestInstana_Application(t *testing.T) {
 				testutils.AssertNoError(t, slo, err)
 			} else {
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application"),
+					Prop: "spec.objectives[0].rawMetric.query.instana.application",
 					Code: rules.ErrorCodeEqualTo,
 				})
 			}
@@ -410,7 +408,7 @@ func TestInstana_Application(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Instana.Application.Aggregation = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.instana.application"),
+			Prop: "spec.objectives[0].rawMetric.query.instana.application",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_lightstep_test.go
+++ b/manifest/v1alpha/slo/metrics_lightstep_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -25,7 +23,7 @@ func TestLightstep_CountMetricLevel(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -34,7 +32,7 @@ func TestLightstep_CountMetricLevel(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.Incremental = ptr(true)
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.incremental"),
+			Prop: "spec.objectives[0].countMetrics.incremental",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -77,7 +75,7 @@ func TestLightstep_RawMetricLevel(t *testing.T) {
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.Lightstep = metric
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.typeOfData"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.typeOfData",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}
@@ -121,7 +119,7 @@ func TestLightstep_TotalMetricLevel(t *testing.T) {
 			slo.Spec.Objectives[0].CountMetrics.TotalMetric.Lightstep = metric
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.lightstep.typeOfData"),
+				Prop: "spec.objectives[0].countMetrics.total.lightstep.typeOfData",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}
@@ -165,7 +163,7 @@ func TestLightstep_GoodMetricLevel(t *testing.T) {
 			slo.Spec.Objectives[0].CountMetrics.GoodMetric.Lightstep = metric
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.lightstep.typeOfData"),
+				Prop: "spec.objectives[0].countMetrics.good.lightstep.typeOfData",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}
@@ -221,23 +219,23 @@ func TestLightstepLatencyTypeOfData(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 5,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.percentile"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.percentile",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.uql"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.uql",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[1].rawMetric.query.lightstep.streamId"),
+				Prop: "spec.objectives[1].rawMetric.query.lightstep.streamId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[1].rawMetric.query.lightstep.percentile"),
+				Prop: "spec.objectives[1].rawMetric.query.lightstep.percentile",
 				Code: rules.ErrorCodeGreaterThan,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[2].rawMetric.query.lightstep.percentile"),
+				Prop: "spec.objectives[2].rawMetric.query.lightstep.percentile",
 				Code: rules.ErrorCodeLessThanOrEqualTo,
 			},
 		)
@@ -265,15 +263,15 @@ func TestLightstepErrorRateTypeOfData(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.percentile"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.percentile",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.uql"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.uql",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.streamId"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.streamId",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -304,15 +302,15 @@ spans count | rate | group_by [], sum
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.uql"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.uql",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.percentile"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.percentile",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.streamId"),
+				Prop: "spec.objectives[0].rawMetric.query.lightstep.streamId",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)
@@ -334,7 +332,7 @@ spans_sample count | delta | filter service == android | group_by [], sum) | joi
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1,
 					testutils.ExpectedError{
-						Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.lightstep.uql"),
+						Prop: "spec.objectives[0].rawMetric.query.lightstep.uql",
 						Code: rules.ErrorCodeStringDenyRegexp,
 					},
 				)
@@ -374,27 +372,27 @@ func TestLightstepGoodTotalTypeOfData(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 6,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.lightstep.percentile"),
+				Prop: "spec.objectives[0].countMetrics.total.lightstep.percentile",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.lightstep.uql"),
+				Prop: "spec.objectives[0].countMetrics.total.lightstep.uql",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.lightstep.streamId"),
+				Prop: "spec.objectives[0].countMetrics.total.lightstep.streamId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.lightstep.percentile"),
+				Prop: "spec.objectives[0].countMetrics.good.lightstep.percentile",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.lightstep.uql"),
+				Prop: "spec.objectives[0].countMetrics.good.lightstep.uql",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.lightstep.streamId"),
+				Prop: "spec.objectives[0].countMetrics.good.lightstep.streamId",
 				Code: rules.ErrorCodeRequired,
 			},
 		)

--- a/manifest/v1alpha/slo/metrics_logic_monitor_test.go
+++ b/manifest/v1alpha/slo/metrics_logic_monitor_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -23,11 +21,11 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.queryType"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.queryType",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.line"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.line",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -41,12 +39,12 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.queryType"),
+				Prop:    "spec.objectives[0].rawMetric.query.logicMonitor.queryType",
 				Code:    rules.ErrorCodeOneOf,
 				Message: "must be one of: device_metrics, website_metrics",
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.line"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.line",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -61,15 +59,15 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.line"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.line",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.graphId"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.graphId",
 				Code: rules.ErrorCodeGreaterThan,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.deviceDataSourceInstanceId"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.deviceDataSourceInstanceId",
 				Code: rules.ErrorCodeGreaterThan,
 			},
 		)
@@ -82,19 +80,19 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 4,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.line"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.line",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.websiteId"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.websiteId",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.checkpointId"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.checkpointId",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor.graphName"),
+				Prop: "spec.objectives[0].rawMetric.query.logicMonitor.graphName",
 				Code: rules.ErrorCodeStringNotEmpty,
 			},
 		)
@@ -113,7 +111,7 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor"),
+				Prop:    "spec.objectives[0].rawMetric.query.logicMonitor",
 				Message: "deviceDataSourceInstanceId and graphId must be empty for website_metrics",
 			},
 		)
@@ -132,7 +130,7 @@ func TestLogicMonitor(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.logicMonitor"),
+				Prop:    "spec.objectives[0].rawMetric.query.logicMonitor",
 				Message: "graphName, checkpointId and websiteId must be empty for device_metrics",
 			},
 		)

--- a/manifest/v1alpha/slo/metrics_newrelic_test.go
+++ b/manifest/v1alpha/slo/metrics_newrelic_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestNewRelic(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.NewRelic.NRQL = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.newRelic.nrql"),
+			Prop: "spec.objectives[0].rawMetric.query.newRelic.nrql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestNewRelic(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.NewRelic.NRQL = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.newRelic.nrql"),
+			Prop: "spec.objectives[0].rawMetric.query.newRelic.nrql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -96,7 +94,7 @@ uNtIL LIMIT MAX TIMESERIES`,
 				testutils.AssertNoError(t, slo, err)
 			} else {
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.newRelic.nrql"),
+					Prop: "spec.objectives[0].rawMetric.query.newRelic.nrql",
 					Code: rules.ErrorCodeStringDenyRegexp,
 				})
 			}

--- a/manifest/v1alpha/slo/metrics_opentsdb_test.go
+++ b/manifest/v1alpha/slo/metrics_opentsdb_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestOpenTSDB(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.OpenTSDB.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.opentsdb.query"),
+			Prop: "spec.objectives[0].rawMetric.query.opentsdb.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestOpenTSDB(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.OpenTSDB.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.opentsdb.query"),
+			Prop: "spec.objectives[0].rawMetric.query.opentsdb.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_pingdom_test.go
+++ b/manifest/v1alpha/slo/metrics_pingdom_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -25,7 +23,7 @@ func TestPingdom_CountMetricsLevel(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -43,7 +41,7 @@ func TestPingdom_CountMetricsLevel(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -56,11 +54,11 @@ func TestPingdom_CountMetricsLevel(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.pingdom.status"),
+				Prop: "spec.objectives[0].countMetrics.total.pingdom.status",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.pingdom.status"),
+				Prop: "spec.objectives[0].countMetrics.good.pingdom.status",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -79,7 +77,7 @@ func TestPingdom_RawMetricLevel(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.Status = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.checkType"),
+			Prop: "spec.objectives[0].rawMetric.query.pingdom.checkType",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -98,7 +96,7 @@ func TestPingdom(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.CheckType = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.checkType"),
+			Prop: "spec.objectives[0].rawMetric.query.pingdom.checkType",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -107,7 +105,7 @@ func TestPingdom(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.CheckID = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.checkId"),
+			Prop: "spec.objectives[0].rawMetric.query.pingdom.checkId",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -116,7 +114,7 @@ func TestPingdom(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.CheckID = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.checkId"),
+			Prop: "spec.objectives[0].rawMetric.query.pingdom.checkId",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -125,7 +123,7 @@ func TestPingdom(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.CheckID = ptr("a12393")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.checkId"),
+			Prop: "spec.objectives[0].rawMetric.query.pingdom.checkId",
 			Code: rules.ErrorCodeStringMatchRegexp,
 		})
 	})
@@ -140,7 +138,7 @@ func TestPingdom_CheckTypeTransaction(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.Pingdom.Status = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.pingdom.status"),
+			Prop: "spec.objectives[0].countMetrics.total.pingdom.status",
 			Code: rules.ErrorCodeForbidden,
 		})
 	})
@@ -175,7 +173,7 @@ func TestPingdom_CheckTypeUptime(t *testing.T) {
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.Pingdom.Status = ptr(status)
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.pingdom.status"),
+				Prop: "spec.objectives[0].rawMetric.query.pingdom.status",
 				Code: rules.ErrorCodeOneOf,
 			})
 		}

--- a/manifest/v1alpha/slo/metrics_prometheus_test.go
+++ b/manifest/v1alpha/slo/metrics_prometheus_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestPrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Prometheus.PromQL = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.prometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.prometheus.promql",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestPrometheus(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Prometheus.PromQL = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.prometheus.promql"),
+			Prop: "spec.objectives[0].rawMetric.query.prometheus.promql",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_redshift_test.go
+++ b/manifest/v1alpha/slo/metrics_redshift_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -24,7 +22,7 @@ func TestRedshift_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.Redshift.Region = ptr("region-2")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -34,7 +32,7 @@ func TestRedshift_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.Redshift.ClusterID = ptr("2")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -44,7 +42,7 @@ func TestRedshift_CountMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric.Redshift.DatabaseName = ptr("prod-db")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -57,19 +55,19 @@ func TestRedshift(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 4,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.region"),
+				Prop: "spec.objectives[0].rawMetric.query.redshift.region",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.clusterId"),
+				Prop: "spec.objectives[0].rawMetric.query.redshift.clusterId",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.databaseName"),
+				Prop: "spec.objectives[0].rawMetric.query.redshift.databaseName",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.query"),
+				Prop: "spec.objectives[0].rawMetric.query.redshift.query",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -79,7 +77,7 @@ func TestRedshift(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Redshift.Region = ptr(strings.Repeat("a", 256))
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.region"),
+			Prop: "spec.objectives[0].rawMetric.query.redshift.region",
 			Code: rules.ErrorCodeStringMaxLength,
 		})
 	})
@@ -95,7 +93,7 @@ func TestRedshift(t *testing.T) {
 			slo.Spec.Objectives[0].RawMetric.MetricQuery.Redshift.Query = ptr(query)
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.redshift.query"),
+				Prop:            "spec.objectives[0].rawMetric.query.redshift.query",
 				ContainsMessage: expectedDetails,
 			})
 		}

--- a/manifest/v1alpha/slo/metrics_splunk_observability_test.go
+++ b/manifest/v1alpha/slo/metrics_splunk_observability_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,7 +20,7 @@ func TestSplunkObservability(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SplunkObservability.Program = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.splunkObservability.program"),
+			Prop: "spec.objectives[0].rawMetric.query.splunkObservability.program",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -31,7 +29,7 @@ func TestSplunkObservability(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SplunkObservability.Program = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.splunkObservability.program"),
+			Prop: "spec.objectives[0].rawMetric.query.splunkObservability.program",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})

--- a/manifest/v1alpha/slo/metrics_splunk_test.go
+++ b/manifest/v1alpha/slo/metrics_splunk_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/govy"
 	"github.com/nobl9/govy/pkg/rules"
 
@@ -23,7 +21,7 @@ func TestSplunk(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Splunk.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.splunk.query"),
+			Prop: "spec.objectives[0].rawMetric.query.splunk.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -32,7 +30,7 @@ func TestSplunk(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Splunk.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.splunk.query"),
+			Prop: "spec.objectives[0].rawMetric.query.splunk.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -74,7 +72,7 @@ fields n9time n9value`,
 				slo.Spec.Objectives[0].RawMetric.MetricQuery.Splunk.Query = ptr(test.Query)
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.splunk.query"),
+					Prop: "spec.objectives[0].rawMetric.query.splunk.query",
 					Code: test.ExpectedCode,
 				})
 			})
@@ -93,7 +91,7 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Splunk.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.splunk.query"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.splunk.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -102,7 +100,7 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Splunk.Query = ptr("")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.splunk.query"),
+			Prop: "spec.objectives[0].countMetrics.goodTotal.splunk.query",
 			Code: rules.ErrorCodeStringNotEmpty,
 		})
 	})
@@ -111,7 +109,7 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.TotalMetric = validMetricSpec(v1alpha.Splunk)
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -120,7 +118,7 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics.GoodMetric = validMetricSpec(v1alpha.Splunk)
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -175,7 +173,7 @@ func TestSplunk_CountMetrics_SingleQuery(t *testing.T) {
 				slo.Spec.Objectives[0].CountMetrics.GoodTotalMetric.Splunk.Query = ptr(test.Query)
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.splunk.query"),
+					Prop: "spec.objectives[0].countMetrics.goodTotal.splunk.query",
 					Code: test.ExpectedCode,
 				})
 			})

--- a/manifest/v1alpha/slo/metrics_sumo_logic_test.go
+++ b/manifest/v1alpha/slo/metrics_sumo_logic_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -28,7 +26,7 @@ func TestSumoLogic_CountMetricsLevel(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -58,7 +56,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -70,7 +68,7 @@ func TestSumoLogic(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Type = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.type"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic.type",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -79,7 +77,7 @@ func TestSumoLogic(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Type = ptr("invalid")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.type"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic.type",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -88,7 +86,7 @@ func TestSumoLogic(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Query = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic"),
+			Prop:    "spec.objectives[0].rawMetric.query.sumoLogic",
 			Code:    rules.ErrorCodeRequired,
 			Message: "one of 'query' or 'queries' is required",
 		})
@@ -103,11 +101,11 @@ func TestSumoLogic_MetricType(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.quantization"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.quantization",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.rollup"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.rollup",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -117,7 +115,7 @@ func TestSumoLogic_MetricType(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Quantization = ptr("invalid")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.quantization"),
+			Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.quantization",
 			Message: `error parsing quantization string to duration - time: invalid duration "invalid"`,
 		})
 	})
@@ -126,7 +124,7 @@ func TestSumoLogic_MetricType(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Quantization = ptr("14s")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.quantization"),
+			Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.quantization",
 			Message: "minimum quantization value is [15s], got: [14s]",
 		})
 	})
@@ -143,7 +141,7 @@ func TestSumoLogic_MetricType(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.SumoLogic.Rollup = ptr("invalid")
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.rollup"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic.rollup",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})
@@ -168,11 +166,11 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.quantization"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.quantization",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.rollup"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.rollup",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)
@@ -190,7 +188,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "query must contain a 'timeslice' operator",
 			},
 		},
@@ -205,7 +203,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "exactly one 'timeslice' usage is required in the query",
 			},
 		},
@@ -219,7 +217,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "timeslice value must be 15, 30, or 60 seconds, got: [015s]",
 			},
 		},
@@ -233,7 +231,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "timeslice interval must be in a NumberUnit form - for example '30s'",
 			},
 		},
@@ -247,7 +245,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "timeslice interval must be in a NumberUnit form - for example '30s'",
 			},
 		},
@@ -261,7 +259,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: "timeslice value must be 15, 30, or 60 seconds, got: [15000ms]",
 			},
 		},
@@ -275,7 +273,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: `error parsing timeslice duration: time: unknown unit "x" in duration "20x"`,
 			},
 		},
@@ -289,7 +287,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:    "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Message: `timeslice value must be 15, 30, or 60 seconds, got: [14s]`,
 			},
 		},
@@ -303,7 +301,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) by n9_time
   | sort by n9_time asc`,
 			Error: testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				ContainsMessage: "n9_value is required",
 			},
 		},
@@ -317,7 +315,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | sum(log_level_not_error) as n9_value by time
   | sort by time asc`,
 			Error: testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				ContainsMessage: "timeslice operator requires an n9_time alias",
 			},
 		},
@@ -330,7 +328,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
   | if (log_level matches "error" ,0,1) as log_level_not_error
   | sum(log_level_not_error) as n9_value`,
 			Error: testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				ContainsMessage: "aggregation function is required",
 			},
 		},
@@ -403,11 +401,11 @@ func TestSumoLogic_LogsType_SingleQuery(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.quantization"),
+				Prop: "spec.objectives[0].countMetrics.goodTotal.sumoLogic.quantization",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.rollup"),
+				Prop: "spec.objectives[0].countMetrics.goodTotal.sumoLogic.rollup",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)
@@ -425,7 +423,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "query must contain a 'timeslice' operator",
 			},
 		},
@@ -440,7 +438,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "exactly one 'timeslice' usage is required in the query",
 			},
 		},
@@ -454,7 +452,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "timeslice value must be 15, 30, or 60 seconds, got: [015s]",
 			},
 		},
@@ -468,7 +466,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "timeslice interval must be in a NumberUnit form - for example '30s'",
 			},
 		},
@@ -482,7 +480,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "timeslice interval must be in a NumberUnit form - for example '30s'",
 			},
 		},
@@ -496,7 +494,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: "timeslice value must be 15, 30, or 60 seconds, got: [15000ms]",
 			},
 		},
@@ -510,7 +508,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: `error parsing timeslice duration: time: unknown unit "x" in duration "20x"`,
 			},
 		},
@@ -524,7 +522,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Message: `timeslice value must be 15, 30, or 60 seconds, got: [14s]`,
 			},
 		},
@@ -538,7 +536,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_bad, sum(total) as n9_total by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Code:    rules.ErrorCodeStringContains,
 				Message: "string must contain the following substrings: 'n9_good', 'n9_total'",
 			},
@@ -553,7 +551,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_all by n9_time`,
 			Error: testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:    "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				Code:    rules.ErrorCodeStringContains,
 				Message: "string must contain the following substrings: 'n9_good', 'n9_total'",
 			},
@@ -568,7 +566,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total by time`,
 			Error: testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:            "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				ContainsMessage: "timeslice operator requires an n9_time alias",
 			},
 		},
@@ -582,7 +580,7 @@ _collector="n9-dev-tooling-cluster" _source="logs"
 	| 1 as total
 	| sum(good) as n9_good, sum(total) as n9_total`,
 			Error: testutils.ExpectedError{
-				Prop:            jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic.query"),
+				Prop:            "spec.objectives[0].countMetrics.goodTotal.sumoLogic.query",
 				ContainsMessage: "aggregation function is required",
 			},
 		},
@@ -688,7 +686,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic",
 			Code: rules.ErrorCodeMutuallyExclusive,
 		})
 	})
@@ -710,7 +708,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic.queries",
 		})
 	})
 	t.Run("duplicate row IDs", func(t *testing.T) {
@@ -726,7 +724,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries"),
+			Prop: "spec.objectives[0].rawMetric.query.sumoLogic.queries",
 		})
 	})
 	t.Run("valid non-sequential row IDs", func(t *testing.T) {
@@ -755,7 +753,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries[0]"),
+			Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.queries[0]",
 			ContainsMessage: "'rowId' must be a single uppercase letter A-F",
 		})
 	})
@@ -771,7 +769,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries[0]"),
+			Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.queries[0]",
 			ContainsMessage: "'rowId' must be a single uppercase letter A-F",
 		})
 	})
@@ -787,7 +785,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries[0]"),
+			Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.queries[0]",
 			ContainsMessage: "'rowId' must be a single uppercase letter A-F",
 		})
 	})
@@ -803,7 +801,7 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:            jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries[0]"),
+			Prop:            "spec.objectives[0].rawMetric.query.sumoLogic.queries[0]",
 			ContainsMessage: "'query' must not be empty",
 		})
 	})
@@ -818,11 +816,11 @@ func TestSumoLogic_MultiQuery(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.queries"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.queries",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.sumoLogic.query"),
+				Prop: "spec.objectives[0].rawMetric.query.sumoLogic.query",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -917,7 +915,7 @@ func TestSumoLogic_MultiQuery_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop: "spec.objectives[0].countMetrics",
 			Code: rules.ErrorCodeEqualTo,
 		})
 	})
@@ -931,7 +929,7 @@ func TestSumoLogic_MetricsType_SingleQuery(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal.sumoLogic"),
+				Prop: "spec.objectives[0].countMetrics.goodTotal.sumoLogic",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)

--- a/manifest/v1alpha/slo/metrics_thousand_eyes_test.go
+++ b/manifest/v1alpha/slo/metrics_thousand_eyes_test.go
@@ -3,8 +3,6 @@ package slo
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	"github.com/nobl9/nobl9-go/internal/testutils"
@@ -22,11 +20,11 @@ func TestThousandEyes(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.total.thousandEyes"),
+				Prop: "spec.objectives[0].countMetrics.total.thousandEyes",
 				Code: rules.ErrorCodeForbidden,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].countMetrics.good.thousandEyes"),
+				Prop: "spec.objectives[0].countMetrics.good.thousandEyes",
 				Code: rules.ErrorCodeForbidden,
 			},
 		)
@@ -37,11 +35,11 @@ func TestThousandEyes(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.thousandEyes.testID"),
+				Prop: "spec.objectives[0].rawMetric.query.thousandEyes.testID",
 				Code: rules.ErrorCodeRequired,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.thousandEyes.testType"),
+				Prop: "spec.objectives[0].rawMetric.query.thousandEyes.testType",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -55,11 +53,11 @@ func TestThousandEyes(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.thousandEyes.testID"),
+				Prop: "spec.objectives[0].rawMetric.query.thousandEyes.testID",
 				Code: rules.ErrorCodeGreaterThanOrEqualTo,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.thousandEyes.testType"),
+				Prop: "spec.objectives[0].rawMetric.query.thousandEyes.testType",
 				Code: rules.ErrorCodeOneOf,
 			},
 		)
@@ -78,7 +76,7 @@ func TestThousandEyes(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query.thousandEyes.accountGroupID"),
+				Prop: "spec.objectives[0].rawMetric.query.thousandEyes.accountGroupID",
 				Code: rules.ErrorCodeGreaterThanOrEqualTo,
 			},
 		)

--- a/manifest/v1alpha/slo/validation_composite_test.go
+++ b/manifest/v1alpha/slo/validation_composite_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/rules"
 
 	validationV1Alpha "github.com/nobl9/nobl9-go/internal/manifest/v1alpha"
@@ -26,7 +24,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].name"),
+			Prop: "spec.objectives[0].name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -36,7 +34,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].displayName"),
+			Prop: "spec.objectives[0].displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		})
 	})
@@ -64,7 +62,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			slo.Spec.Indicator = &ind
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.indicator"),
+				Prop:    "spec.indicator",
 				Code:    rules.ErrorCodeForbidden,
 				Message: "property is forbidden; indicator section is forbidden when spec.objectives[0].composite is provided",
 			})
@@ -79,7 +77,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives"),
+				Prop:    "spec.objectives",
 				Code:    rules.ErrorCodeSliceLength,
 				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
@@ -100,7 +98,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.anomalyConfig"),
+				Prop:    "spec.anomalyConfig",
 				Code:    rules.ErrorCodeForbidden,
 				Message: "property is forbidden; anomalyConfig section is forbidden when spec.objectives[0].composite is provided",
 			},
@@ -113,7 +111,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].rawMetric"),
+				Prop:    "spec.objectives[0].rawMetric",
 				Code:    rules.ErrorCodeForbidden,
 				Message: "when defining composite objective, this property is forbidden",
 			},
@@ -130,7 +128,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+				Prop:    "spec.objectives[0].countMetrics",
 				Code:    rules.ErrorCodeForbidden,
 				Message: "when defining composite objective, this property is forbidden",
 			},
@@ -154,7 +152,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives"),
+				Prop:    "spec.objectives",
 				Code:    rules.ErrorCodeSliceLength,
 				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
@@ -182,7 +180,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives"),
+				Prop:    "spec.objectives",
 				Code:    rules.ErrorCodeSliceLength,
 				Message: "this SLO contains a composite objective. No more objectives can be added to it",
 			},
@@ -204,7 +202,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 			err := validate(slo)
 
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.composite"),
+				Prop: "spec.composite",
 				Code: rules.ErrorCodeForbidden,
 				Message: "property is forbidden; composite section is forbidden " +
 					"when spec.objectives[0].composite is provided",
@@ -225,7 +223,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].composite.maxDelay"),
+				Prop:    "spec.objectives[0].composite.maxDelay",
 				Code:    rules.ErrorCodeGreaterThanOrEqualTo,
 				Message: "must be greater than or equal to '1m0s'",
 			},
@@ -237,7 +235,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.maxDelay"),
+			Prop:    "spec.objectives[0].composite.maxDelay",
 			Code:    rules.ErrorCodeRequired,
 			Message: "property is required but was empty",
 		})
@@ -248,7 +246,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.maxDelay"),
+			Prop:    "spec.objectives[0].composite.maxDelay",
 			Code:    rules.ErrorCodeDurationPrecision,
 			Message: "duration must be defined with 1m0s precision",
 		})
@@ -259,7 +257,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].weight"),
+			Prop: "spec.objectives[0].composite.components.objectives[0].weight",
 			Code: rules.ErrorCodeGreaterThan,
 		})
 	})
@@ -269,7 +267,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.components.objectives[1].weight"),
+			Prop: "spec.objectives[0].composite.components.objectives[1].weight",
 			Code: rules.ErrorCodeGreaterThan,
 		})
 	})
@@ -280,7 +278,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("slo"),
+			Prop:    "slo",
 			Code:    rules.ErrorCodeForbidden,
 			Message: "composite SLO cannot have itself as one of its objectives",
 		})
@@ -291,7 +289,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].project"),
+			Prop: "spec.objectives[0].composite.components.objectives[0].project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -301,7 +299,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].slo"),
+			Prop: "spec.objectives[0].composite.components.objectives[0].slo",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -311,7 +309,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].objective"),
+			Prop: "spec.objectives[0].composite.components.objectives[0].objective",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -321,7 +319,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].weight"),
+			Prop:    "spec.objectives[0].composite.components.objectives[0].weight",
 			Code:    rules.ErrorCodeGreaterThan,
 			Message: "must be greater than '0'",
 		})
@@ -332,7 +330,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.components.objectives[0].whenDelayed"),
+			Prop:    "spec.objectives[0].composite.components.objectives[0].whenDelayed",
 			Code:    rules.ErrorCodeOneOf,
 			Message: "must be one of: CountAsGood, CountAsBad, Ignore",
 		})
@@ -354,7 +352,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.components.objectives[2]"),
+			Prop:    "spec.objectives[0].composite.components.objectives[2]",
 			Code:    rules.ErrorCodeForbidden,
 			Message: "composite SLO cannot have duplicated SLOs as its objectives",
 		})
@@ -366,7 +364,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].composite.components.objectives"),
+			Prop:    "spec.objectives[0].composite.components.objectives",
 			Code:    rules.ErrorCodeRequired,
 			Message: "property is required but was empty",
 		})
@@ -410,7 +408,7 @@ func TestValidate_CompositeSLO(t *testing.T) {
 		err := validate(slo)
 
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].composite.aggregation"),
+			Prop: "spec.objectives[0].composite.aggregation",
 			Code: rules.ErrorCodeOneOf,
 		})
 	})

--- a/manifest/v1alpha/slo/validation_test.go
+++ b/manifest/v1alpha/slo/validation_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/govy"
@@ -41,11 +39,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, slo, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -63,22 +61,22 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, slo, err, 3,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.displayName"),
+			Prop: "metadata.displayName",
 			Code: rules.ErrorCodeStringMaxLength,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.project"),
+			Prop: "metadata.project",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
 }
 
 func TestValidate_Metadata_Labels(t *testing.T) {
-	for name, test := range v1alphatest.GetLabelsTestCases[SLO](t, jsonpath.Parse("metadata.labels")) {
+	for name, test := range v1alphatest.GetLabelsTestCases[SLO](t, "metadata.labels") {
 		t.Run(name, func(t *testing.T) {
 			svc := validSLO()
 			svc.Metadata.Labels = test.Labels
@@ -88,7 +86,7 @@ func TestValidate_Metadata_Labels(t *testing.T) {
 }
 
 func TestValidate_Metadata_Annotations(t *testing.T) {
-	for name, test := range v1alphatest.GetMetadataAnnotationsTestCases[SLO](t, jsonpath.Parse("metadata.annotations")) {
+	for name, test := range v1alphatest.GetMetadataAnnotationsTestCases[SLO](t, "metadata.annotations") {
 		t.Run(name, func(t *testing.T) {
 			svc := validSLO()
 			svc.Metadata.Annotations = test.Annotations
@@ -102,7 +100,7 @@ func TestValidate_Spec_Description(t *testing.T) {
 	slo.Spec.Description = strings.Repeat("a", 2000)
 	err := validate(slo)
 	testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-		Prop: jsonpath.Parse("spec.description"),
+		Prop: "spec.description",
 		Code: validationV1Alpha.ErrorCodeStringDescription,
 	})
 }
@@ -121,7 +119,7 @@ func TestValidate_Spec_BudgetingMethod(t *testing.T) {
 		slo.Spec.BudgetingMethod = ""
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.budgetingMethod"),
+			Prop: "spec.budgetingMethod",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -130,7 +128,7 @@ func TestValidate_Spec_BudgetingMethod(t *testing.T) {
 		slo.Spec.BudgetingMethod = "invalid"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.budgetingMethod"),
+			Prop:    "spec.budgetingMethod",
 			Message: "'invalid' is not a valid budgeting method",
 		})
 	})
@@ -148,7 +146,7 @@ func TestValidate_Spec_Service(t *testing.T) {
 		slo.Spec.Service = "MY SERVICE"
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.service"),
+			Prop: "spec.service",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -166,7 +164,7 @@ func TestValidate_Spec_AlertPolicies(t *testing.T) {
 		slo.Spec.AlertPolicies = []string{"my-policy", "MY POLICY", "ok-policy"}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.alertPolicies[1]"),
+			Prop: "spec.alertPolicies[1]",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		})
 	})
@@ -194,7 +192,7 @@ func TestValidate_Spec_Attachments(t *testing.T) {
 		slo.Spec.Attachments = attachments
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.attachments"),
+			Prop: "spec.attachments",
 			Code: rules.ErrorCodeSliceLength,
 		})
 	})
@@ -208,15 +206,15 @@ func TestValidate_Spec_Attachments(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 3,
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.attachments[1].url"),
+				Prop: "spec.attachments[1].url",
 				Code: rules.ErrorCodeStringURL,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.attachments[2].displayName"),
+				Prop: "spec.attachments[2].displayName",
 				Code: rules.ErrorCodeStringLength,
 			},
 			testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.attachments[2].url"),
+				Prop: "spec.attachments[2].url",
 				Code: rules.ErrorCodeRequired,
 			},
 		)
@@ -253,7 +251,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 1000, Operator: "gt"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.target"),
+					Prop: "spec.composite.target",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -263,7 +261,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 1000, Operator: "gt"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.target"),
+					Prop: "spec.composite.target",
 					Code: rules.ErrorCodeGreaterThan,
 				},
 			},
@@ -273,7 +271,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 1000, Operator: "gt"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.target"),
+					Prop: "spec.composite.target",
 					Code: rules.ErrorCodeLessThan,
 				},
 			},
@@ -283,7 +281,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: -1, Operator: "gt"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.burnRateCondition.value"),
+					Prop: "spec.composite.burnRateCondition.value",
 					Code: rules.ErrorCodeGreaterThanOrEqualTo,
 				},
 			},
@@ -293,7 +291,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 1001, Operator: "gt"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.burnRateCondition.value"),
+					Prop: "spec.composite.burnRateCondition.value",
 					Code: rules.ErrorCodeLessThanOrEqualTo,
 				},
 			},
@@ -303,7 +301,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 10},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.burnRateCondition.op"),
+					Prop: "spec.composite.burnRateCondition.op",
 					Code: rules.ErrorCodeRequired,
 				},
 			},
@@ -313,7 +311,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 					BurnRateCondition: &CompositeBurnRateCondition{Value: 10, Operator: "lte"},
 				},
 				ExpectedError: testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.composite.burnRateCondition.op"),
+					Prop: "spec.composite.burnRateCondition.op",
 					Code: rules.ErrorCodeEqualTo,
 				},
 			},
@@ -335,7 +333,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.composite.burnRateCondition"),
+			Prop: "spec.composite.burnRateCondition",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -349,7 +347,7 @@ func TestValidate_Spec_Composite(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.composite.burnRateCondition"),
+			Prop: "spec.composite.burnRateCondition",
 			Code: rules.ErrorCodeForbidden,
 		})
 	})
@@ -389,7 +387,7 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods"),
+						Prop: "spec.anomalyConfig.noData.alertMethods",
 						Code: rules.ErrorCodeSliceMinLength,
 					},
 				},
@@ -411,19 +409,19 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				}}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods[0].name"),
+						Prop: "spec.anomalyConfig.noData.alertMethods[0].name",
 						Code: rules.ErrorCodeRequired,
 					},
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods[1].name"),
+						Prop: "spec.anomalyConfig.noData.alertMethods[1].name",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods[1].project"),
+						Prop: "spec.anomalyConfig.noData.alertMethods[1].project",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods[2].name"),
+						Prop: "spec.anomalyConfig.noData.alertMethods[2].name",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 				},
@@ -442,7 +440,7 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				}}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertMethods"),
+						Prop: "spec.anomalyConfig.noData.alertMethods",
 						Code: rules.ErrorCodeSliceUnique,
 					},
 				},
@@ -461,7 +459,7 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.anomalyConfig.noData.alertAfter"),
+						Prop:    "spec.anomalyConfig.noData.alertAfter",
 						Code:    rules.ErrorCodeGreaterThanOrEqualTo,
 						Message: `must be greater than or equal to '5m0s'`,
 					},
@@ -481,7 +479,7 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.anomalyConfig.noData.alertAfter"),
+						Prop: "spec.anomalyConfig.noData.alertAfter",
 						Code: rules.ErrorCodeLessThanOrEqualTo,
 					},
 				},
@@ -500,7 +498,7 @@ func TestValidate_Spec_AnomalyConfig(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.anomalyConfig.noData.alertAfter"),
+						Prop:    "spec.anomalyConfig.noData.alertAfter",
 						Code:    rules.ErrorCodeDurationPrecision,
 						Message: "duration must be defined with 1m0s precision",
 					},
@@ -553,7 +551,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				TimeWindows: []TimeWindow{},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows"),
+						Prop: "spec.timeWindows",
 						Code: rules.ErrorCodeSliceLength,
 					},
 				},
@@ -563,7 +561,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				TimeWindows: []TimeWindow{{}, {}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows"),
+						Prop: "spec.timeWindows",
 						Code: rules.ErrorCodeSliceLength,
 					},
 				},
@@ -577,11 +575,11 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0].unit"),
+						Prop: "spec.timeWindows[0].unit",
 						Code: rules.ErrorCodeRequired,
 					},
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0].count"),
+						Prop: "spec.timeWindows[0].count",
 						Code: rules.ErrorCodeGreaterThan,
 					},
 				},
@@ -594,7 +592,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0].unit"),
+						Prop: "spec.timeWindows[0].unit",
 						Code: rules.ErrorCodeOneOf,
 					},
 				},
@@ -608,11 +606,11 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0].calendar.startTime"),
+						Prop: "spec.timeWindows[0].calendar.startTime",
 						Code: rules.ErrorCodeRequired,
 					},
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0].calendar.timeZone"),
+						Prop: "spec.timeWindows[0].calendar.timeZone",
 						Code: rules.ErrorCodeRequired,
 					},
 				},
@@ -629,11 +627,11 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0].calendar.startTime"),
+						Prop:    "spec.timeWindows[0].calendar.startTime",
 						Message: `error parsing date: parsing time "asd" as "2006-01-02 15:04:05": cannot parse "asd" as "2006"`,
 					},
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0].calendar.timeZone"),
+						Prop:    "spec.timeWindows[0].calendar.timeZone",
 						Message: "not a valid time zone: unknown time zone asd",
 					},
 				},
@@ -651,7 +649,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0]"),
+						Prop:    "spec.timeWindows[0]",
 						Message: "if 'isRolling' property is true, 'calendar' property must be omitted",
 					},
 				},
@@ -665,7 +663,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0]"),
+						Prop:    "spec.timeWindows[0]",
 						Message: "if 'isRolling' property is false or not set, 'calendar' property must be provided",
 					},
 				},
@@ -679,7 +677,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0]"),
+						Prop:    "spec.timeWindows[0]",
 						Message: "invalid time window unit for Rolling window type: must be one of: Minute, Hour, Day",
 					},
 				},
@@ -697,7 +695,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop:    jsonpath.Parse("spec.timeWindows[0]"),
+						Prop:    "spec.timeWindows[0]",
 						Message: "invalid time window unit for Calendar window type: must be one of: Day, Week, Month, Quarter, Year",
 					},
 				},
@@ -711,7 +709,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0]"),
+						Prop: "spec.timeWindows[0]",
 						Message: fmt.Sprintf(
 							"rolling time window size must be greater than or equal to %s",
 							minimumRollingTimeWindowSize),
@@ -727,7 +725,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0]"),
+						Prop: "spec.timeWindows[0]",
 						Message: fmt.Sprintf(
 							"rolling time window size must be less than or equal to %s",
 							maximumRollingTimeWindowSize),
@@ -747,7 +745,7 @@ func TestValidate_Spec_TimeWindows(t *testing.T) {
 				}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.timeWindows[0]"),
+						Prop: "spec.timeWindows[0]",
 						Message: fmt.Sprintf(
 							"calendar time window size must be less than %s",
 							maximumCalendarTimeWindowSize),
@@ -803,7 +801,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				Indicator: nil,
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.indicator"),
+						Prop: "spec.indicator",
 						Code: rules.ErrorCodeRequired,
 					},
 				},
@@ -813,7 +811,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				Indicator: &Indicator{},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.indicator.metricSource.name"),
+						Prop: "spec.indicator.metricSource.name",
 						Code: rules.ErrorCodeRequired,
 					},
 				},
@@ -823,7 +821,7 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				Indicator: &Indicator{MetricSource: MetricSourceSpec{Name: "", Project: "default"}},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.indicator.metricSource.name"),
+						Prop: "spec.indicator.metricSource.name",
 						Code: rules.ErrorCodeRequired,
 					},
 				},
@@ -839,15 +837,15 @@ func TestValidate_Spec_Indicator(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.indicator.metricSource.name"),
+						Prop: "spec.indicator.metricSource.name",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 					{
-						Prop: jsonpath.Parse("spec.indicator.metricSource.project"),
+						Prop: "spec.indicator.metricSource.project",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 					{
-						Prop: jsonpath.Parse("spec.indicator.metricSource.kind"),
+						Prop: "spec.indicator.metricSource.kind",
 						Code: rules.ErrorCodeOneOf,
 					},
 				},
@@ -910,7 +908,7 @@ func TestValidate_Spec_Objectives(t *testing.T) {
 				Objectives: []Objective{},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.objectives"),
+						Prop: "spec.objectives",
 						Code: rules.ErrorCodeSliceMinLength,
 					},
 				},
@@ -942,27 +940,27 @@ func TestValidate_Spec_Objectives(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.objectives[0].displayName"),
+						Prop: "spec.objectives[0].displayName",
 						Code: rules.ErrorCodeStringMaxLength,
 					},
 					{
-						Prop: jsonpath.Parse("spec.objectives[0].name"),
+						Prop: "spec.objectives[0].name",
 						Code: validationV1Alpha.ErrorCodeStringName,
 					},
 					{
-						Prop: jsonpath.Parse("spec.objectives[0].target"),
+						Prop: "spec.objectives[0].target",
 						Code: rules.ErrorCodeLessThan,
 					},
 					{
-						Prop: jsonpath.Parse("spec.objectives[1].value"),
+						Prop: "spec.objectives[1].value",
 						Code: rules.ErrorCodeRequired,
 					},
 					{
-						Prop: jsonpath.Parse("spec.objectives[1].target"),
+						Prop: "spec.objectives[1].target",
 						Code: rules.ErrorCodeRequired,
 					},
 					{
-						Prop: jsonpath.Parse("spec.objectives[2].target"),
+						Prop: "spec.objectives[2].target",
 						Code: rules.ErrorCodeGreaterThanOrEqualTo,
 					},
 				},
@@ -984,7 +982,7 @@ func TestValidate_Spec_Objectives(t *testing.T) {
 					},
 				},
 				ExpectedErrors: []testutils.ExpectedError{{
-					Prop: jsonpath.Parse("spec.objectives"),
+					Prop: "spec.objectives",
 					Code: rules.ErrorCodeSliceUnique,
 				}},
 				ExpectedErrorsCount: 1,
@@ -997,7 +995,7 @@ func TestValidate_Spec_Objectives(t *testing.T) {
 					Operator:      ptr("invalid"),
 				}},
 				ExpectedErrors: []testutils.ExpectedError{{
-					Prop: jsonpath.Parse("spec.objectives[0].op"),
+					Prop: "spec.objectives[0].op",
 					Code: rules.ErrorCodeOneOf,
 				}},
 				ExpectedErrorsCount: 1,
@@ -1093,7 +1091,7 @@ func TestValidate_Spec_Objectives_Primary(t *testing.T) {
 				},
 				ExpectedErrors: []testutils.ExpectedError{
 					{
-						Prop: jsonpath.Parse("spec.objectives"),
+						Prop: "spec.objectives",
 						Code: rules.ErrorCodeForbidden,
 					},
 				},
@@ -1130,7 +1128,7 @@ func TestValidate_Spec_Objectives_RawMetric(t *testing.T) {
 			slo.Spec.Objectives[0].TimeSliceTarget = ptr(test.InputValue)
 			err := validate(slo)
 			testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-				Prop: jsonpath.Parse("spec.objectives[0].timeSliceTarget"),
+				Prop: "spec.objectives[0].timeSliceTarget",
 				Code: test.Code,
 			})
 		})
@@ -1151,7 +1149,7 @@ func TestValidate_Spec(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1,
 			testutils.ExpectedError{
-				Prop:    jsonpath.New().Name("spec"),
+				Prop:    "spec",
 				Message: "[countMetrics, rawMetrics] properties are mutually exclusive, provide only one of them",
 				Code:    rules.ErrorCodeMutuallyExclusive,
 			})
@@ -1162,7 +1160,7 @@ func TestValidate_Spec(t *testing.T) {
 		slo.Spec.Objectives[0].CountMetrics = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("spec"),
+			Prop:    "spec",
 			Message: "one of [composite, countMetrics, rawMetrics] properties must be set, none was provided",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1176,7 +1174,7 @@ func TestValidate_Spec(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop:    jsonpath.New().Name("spec"),
+				Prop:    "spec",
 				Message: "[countMetrics, rawMetrics] properties are mutually exclusive, provide only one of them",
 				Code:    rules.ErrorCodeMutuallyExclusive,
 			})
@@ -1191,7 +1189,7 @@ func TestValidate_Spec(t *testing.T) {
 		slo.Spec.Objectives[1].CountMetrics = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.New().Name("spec"),
+			Prop:    "spec",
 			Message: "one of [composite, countMetrics, rawMetrics] properties must be set, none was provided",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1201,7 +1199,7 @@ func TestValidate_Spec(t *testing.T) {
 		slo.Spec.BudgetingMethod = BudgetingMethodTimeslices.String()
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].timeSliceTarget"),
+			Prop: "spec.objectives[0].timeSliceTarget",
 			Code: joinErrorCodes(errCodeTimeSliceTarget, rules.ErrorCodeRequired),
 		})
 	})
@@ -1211,7 +1209,7 @@ func TestValidate_Spec(t *testing.T) {
 		slo.Spec.Objectives[0].TimeSliceTarget = ptr(0.1)
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].timeSliceTarget"),
+			Prop: "spec.objectives[0].timeSliceTarget",
 			Code: joinErrorCodes(errCodeTimeSliceTarget, rules.ErrorCodeForbidden),
 		})
 	})
@@ -1220,7 +1218,7 @@ func TestValidate_Spec(t *testing.T) {
 		slo.Spec.Objectives[0].Operator = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].op"),
+			Prop: "spec.objectives[0].op",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -1232,7 +1230,7 @@ func TestValidate_Spec_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery.Prometheus = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].rawMetric.query"),
+			Prop:    "spec.objectives[0].rawMetric.query",
 			Message: "exactly one valid metric spec has to be provided (e.g. 'prometheus')",
 		})
 	})
@@ -1262,7 +1260,7 @@ func TestValidate_Spec_RawMetrics(t *testing.T) {
 				}
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.New().Name("spec"),
+					Prop: "spec",
 					Code: errCodeExactlyOneMetricSpecType,
 				})
 			})
@@ -1273,7 +1271,7 @@ func TestValidate_Spec_RawMetrics(t *testing.T) {
 		slo.Spec.Objectives[0].RawMetric.MetricQuery = nil
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.objectives[0].rawMetric.query"),
+			Prop: "spec.objectives[0].rawMetric.query",
 			Code: rules.ErrorCodeRequired,
 		})
 	})
@@ -1287,11 +1285,11 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 2,
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.good"),
+				Prop:    "spec.objectives[0].countMetrics.good",
 				Message: "exactly one valid metric spec has to be provided (e.g. 'prometheus')",
 			},
 			testutils.ExpectedError{
-				Prop:    jsonpath.Parse("spec.objectives[0].countMetrics.total"),
+				Prop:    "spec.objectives[0].countMetrics.total",
 				Message: "exactly one valid metric spec has to be provided (e.g. 'prometheus')",
 			},
 		)
@@ -1324,7 +1322,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "[goodTotal, total] properties are mutually exclusive, provide only one of them",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1339,7 +1337,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "[bad, good] properties are mutually exclusive, provide only one of them",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1352,7 +1350,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "one of [goodTotal, total] properties must be set, none was provided",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1365,7 +1363,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "one of [goodTotal, total] properties must be set, none was provided",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1378,7 +1376,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 		}
 		err := validate(slo)
 		testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-			Prop:    jsonpath.Parse("spec.objectives[0].countMetrics"),
+			Prop:    "spec.objectives[0].countMetrics",
 			Message: "one of [bad, good] properties must be set, none was provided",
 			Code:    rules.ErrorCodeMutuallyExclusive,
 		})
@@ -1476,7 +1474,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 				}
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.New().Name("spec"),
+					Prop: "spec",
 					Code: errCodeExactlyOneMetricSpecType,
 				})
 			})
@@ -1500,7 +1498,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 				}
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].countMetrics.bad"),
+					Prop: "spec.objectives[0].countMetrics.bad",
 					Code: joinErrorCodes(errCodeBadOverTotalDisabled, rules.ErrorCodeOneOf),
 				})
 			})
@@ -1519,7 +1517,7 @@ func TestValidate_Spec_CountMetrics(t *testing.T) {
 				}
 				err := validate(slo)
 				testutils.AssertContainsErrors(t, slo, err, 1, testutils.ExpectedError{
-					Prop: jsonpath.Parse("spec.objectives[0].countMetrics.goodTotal"),
+					Prop: "spec.objectives[0].countMetrics.goodTotal",
 					Code: joinErrorCodes(errCodeSingleQueryGoodOverTotalDisabled, rules.ErrorCodeOneOf),
 				})
 			})

--- a/manifest/v1alpha/usergroup/validation_test.go
+++ b/manifest/v1alpha/usergroup/validation_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nobl9/govy/pkg/rules"
@@ -32,11 +30,11 @@ func TestValidate_VersionAndKind(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, group, err, 2,
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("apiVersion"),
+			Prop: "apiVersion",
 			Code: rules.ErrorCodeEqualTo,
 		},
 		testutils.ExpectedError{
-			Prop: jsonpath.New().Name("kind"),
+			Prop: "kind",
 			Code: rules.ErrorCodeEqualTo,
 		},
 	)
@@ -50,7 +48,7 @@ func TestValidate_Metadata(t *testing.T) {
 	assert.Regexp(t, validationMessageRegexp, err.Error())
 	testutils.AssertContainsErrors(t, group, err, 1,
 		testutils.ExpectedError{
-			Prop: jsonpath.Parse("metadata.name"),
+			Prop: "metadata.name",
 			Code: validationV1Alpha.ErrorCodeStringName,
 		},
 	)
@@ -62,7 +60,7 @@ func TestValidate_Spec(t *testing.T) {
 		group.Spec.DisplayName = strings.Repeat("MY GROUP", 32)
 		err := validate(group)
 		testutils.AssertContainsErrors(t, group, err, 1, testutils.ExpectedError{
-			Prop: jsonpath.Parse("spec.displayName"),
+			Prop: "spec.displayName",
 			Code: rules.ErrorCodeStringLength,
 		})
 	})

--- a/sdk/endpoints/objects/v1/budgetadjsustments_request_test.go
+++ b/sdk/endpoints/objects/v1/budgetadjsustments_request_test.go
@@ -3,8 +3,6 @@ package v1
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/govytest"
 )
 
@@ -44,7 +42,7 @@ func TestGetBudgetAdjustmentsInputValidation(t *testing.T) {
 			},
 			wantErr: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    jsonpath.New().Name("slo_project").String(),
+					PropertyPath:    "slo_project",
 					ContainsMessage: "Project is required when SLO is set",
 				},
 			},
@@ -56,7 +54,7 @@ func TestGetBudgetAdjustmentsInputValidation(t *testing.T) {
 			},
 			wantErr: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    jsonpath.New().Name("slo").String(),
+					PropertyPath:    "slo",
 					ContainsMessage: "SLO is required when Project is set",
 				},
 			},
@@ -70,19 +68,19 @@ func TestGetBudgetAdjustmentsInputValidation(t *testing.T) {
 			},
 			wantErr: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    jsonpath.New().Name("slo_project").String(),
+					PropertyPath:    "slo_project",
 					ContainsMessage: "must consist of lower case alphanumeric characters",
 				},
 				{
-					PropertyPath:    jsonpath.New().Name("slo").String(),
+					PropertyPath:    "slo",
 					ContainsMessage: "must consist of lower case alphanumeric characters",
 				},
 				{
-					PropertyPath:    jsonpath.Parse("name[0]").String(),
+					PropertyPath:    "name[0]",
 					ContainsMessage: "must consist of lower case alphanumeric characters",
 				},
 				{
-					PropertyPath:    jsonpath.Parse("name[1]").String(),
+					PropertyPath:    "name[1]",
 					ContainsMessage: "must consist of lower case alphanumeric characters",
 				},
 			},

--- a/sdk/endpoints/objects/v1/move_slo_request_test.go
+++ b/sdk/endpoints/objects/v1/move_slo_request_test.go
@@ -3,8 +3,6 @@ package v1
 import (
 	"testing"
 
-	"github.com/nobl9/govy/pkg/jsonpath"
-
 	"github.com/nobl9/govy/pkg/govytest"
 	"github.com/nobl9/govy/pkg/rules"
 
@@ -37,7 +35,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.New().Name("sloNames").String(),
+					PropertyPath:  "sloNames",
 					Code:          rules.ErrorCodeSliceMinLength,
 					ValidatorName: "Move SLOs request",
 				},
@@ -53,7 +51,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.New().Name("oldProject").String(),
+					PropertyPath:  "oldProject",
 					Code:          validationV1Alpha.ErrorCodeStringName,
 					ValidatorName: "Move SLOs request",
 				},
@@ -69,7 +67,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.New().Name("oldProject").String(),
+					PropertyPath:  "oldProject",
 					Code:          rules.ErrorCodeRequired,
 					ValidatorName: "Move SLOs request",
 				},
@@ -85,7 +83,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.New().Name("newProject").String(),
+					PropertyPath:  "newProject",
 					Code:          validationV1Alpha.ErrorCodeStringName,
 					ValidatorName: "Move SLOs request",
 				},
@@ -101,7 +99,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.New().Name("service").String(),
+					PropertyPath:  "service",
 					Code:          validationV1Alpha.ErrorCodeStringName,
 					ValidatorName: "Move SLOs request",
 				},
@@ -152,7 +150,7 @@ func TestMoveSLOsRequest_Validate_MoveToProject(t *testing.T) {
 			},
 			errChecks: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:  jsonpath.Parse("sloNames[1]").String(),
+					PropertyPath:  "sloNames[1]",
 					Code:          validationV1Alpha.ErrorCodeStringName,
 					ValidatorName: "Move SLOs request",
 				},


### PR DESCRIPTION
## Motivation

After recent migration to new govy version we also changed testutils contract to operate on `jsonpath.Path`.
In hindsight, the new API is cumbersome and I'd prefer it to operate on plain string paths, just like `govy/testutils` package does.
