### PR TITLE
fix: remove limit from prometheus v1 query requests

### DIFF
--- a/sdk/endpoints/prometheus/v1/endpoints.go
+++ b/sdk/endpoints/prometheus/v1/endpoints.go
@@ -126,7 +126,6 @@ func (e endpoints) api(ctx context.Context) (API, error) {
 
 func queryOptions(request QueryRequest) []promv1.Option {
 	opts := make([]promv1.Option, 0, 3)
-	opts = appendLimitOption(opts, request.Limit)
 	opts = appendLookbackDeltaOption(opts, request.LookbackDelta)
 	opts = appendTimeoutOption(opts, request.Timeout)
 	return opts
@@ -134,7 +133,6 @@ func queryOptions(request QueryRequest) []promv1.Option {
 
 func queryRangeOptions(request QueryRangeRequest) []promv1.Option {
 	opts := make([]promv1.Option, 0, 3)
-	opts = appendLimitOption(opts, request.Limit)
 	opts = appendLookbackDeltaOption(opts, request.LookbackDelta)
 	opts = appendTimeoutOption(opts, request.Timeout)
 	return opts

--- a/sdk/endpoints/prometheus/v1/request.go
+++ b/sdk/endpoints/prometheus/v1/request.go
@@ -8,7 +8,6 @@ import (
 type QueryRequest struct {
 	Query         string
 	Time          time.Time
-	Limit         uint64
 	LookbackDelta time.Duration
 	Timeout       time.Duration
 }
@@ -19,7 +18,6 @@ type QueryRangeRequest struct {
 	Start         time.Time
 	End           time.Time
 	Step          time.Duration
-	Limit         uint64
 	LookbackDelta time.Duration
 	Timeout       time.Duration
 }

--- a/tests/prometheus_v1_test.go
+++ b/tests/prometheus_v1_test.go
@@ -49,15 +49,42 @@ var allPrometheusMetricNames = []string{
 	"time_slice_status",
 }
 
-func Test_Prometheus_V1_Buildinfo(t *testing.T) {
+func Test_Prometheus_V1_Query(t *testing.T) {
 	t.Parallel()
 
-	buildInfo, err := client.Prometheus().V1().Buildinfo(t.Context())
+	value, warnings, err := client.Prometheus().V1().Query(
+		t.Context(),
+		prometheusV1.QueryRequest{
+			Query: "unknown_metric",
+		},
+	)
 	require.NoError(t, err)
-	assert.NotEmpty(t, buildInfo.Version)
-	assert.NotEmpty(t, buildInfo.Revision)
-	assert.NotEmpty(t, buildInfo.Branch)
-	assert.NotEmpty(t, buildInfo.GoVersion)
+	require.Empty(t, warnings)
+
+	vector, ok := value.(model.Vector)
+	require.True(t, ok)
+	assert.Empty(t, vector)
+}
+
+func Test_Prometheus_V1_QueryRange(t *testing.T) {
+	t.Parallel()
+
+	end := time.Now()
+	value, warnings, err := client.Prometheus().V1().QueryRange(
+		t.Context(),
+		prometheusV1.QueryRangeRequest{
+			Query: "unknown_metric",
+			Start: end.Add(-time.Minute),
+			End:   end,
+			Step:  time.Minute,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	matrix, ok := value.(model.Matrix)
+	require.True(t, ok)
+	assert.Empty(t, matrix)
 }
 
 func Test_Prometheus_V1_LabelNames(t *testing.T) {
@@ -575,6 +602,17 @@ func Test_Prometheus_V1_Metadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Prometheus_V1_Buildinfo(t *testing.T) {
+	t.Parallel()
+
+	buildInfo, err := client.Prometheus().V1().Buildinfo(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, buildInfo.Version)
+	assert.NotEmpty(t, buildInfo.Revision)
+	assert.NotEmpty(t, buildInfo.Branch)
+	assert.NotEmpty(t, buildInfo.GoVersion)
 }
 
 type prometheusLabelValuesObjects struct {


### PR DESCRIPTION
## Summary

Drop the unsupported `Limit` field from instant and range query requests so the SDK no longer sends it as an option. Add coverage for `Query` and `QueryRange` responses while keeping the existing build info test.

## Breaking Changes

Removed `limit` from `sdk.Client.Prometheus.V1.Query` and `sdk.Client.Prometheus.V1.QueryRange`.
The parameter is not currently supported and was not working to begin with.
