### PR TITLE
feat: wrap Prometheus API errors in  sdk.HTTPError

### DIFF
--- a/sdk/prometheus.go
+++ b/sdk/prometheus.go
@@ -35,8 +35,8 @@ func (c *Client) newPrometheusAPI(ctx context.Context) (prometheusEndpointsV1.AP
 }
 
 type prometheusAPIStore struct {
-	mu  sync.Mutex
 	api prometheusEndpointsV1.API
+	mu  sync.Mutex
 }
 
 func (c *Client) createPrometheusAPI(ctx context.Context) (prometheusEndpointsV1.API, error) {

--- a/sdk/prometheus.go
+++ b/sdk/prometheus.go
@@ -2,7 +2,9 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 
 	promapi "github.com/prometheus/client_golang/api"
@@ -49,7 +51,7 @@ func (c *Client) createPrometheusAPI(ctx context.Context) (prometheusEndpointsV1
 	if err != nil {
 		return nil, err
 	}
-	return promv1.NewAPI(client), nil
+	return promv1.NewAPI(prometheusAPIClient{Client: client}), nil
 }
 
 func (c *Client) newPrometheusHTTPClient() *http.Client {
@@ -84,4 +86,64 @@ func (r prometheusRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		return http.DefaultTransport.RoundTrip(req)
 	}
 	return r.next.RoundTrip(req)
+}
+
+type prometheusAPIClient struct {
+	promapi.Client
+}
+
+func (c prometheusAPIClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	resp, body, err := c.Client.Do(ctx, req)
+	if err != nil || resp == nil || resp.StatusCode < 300 {
+		return resp, body, err
+	}
+	return resp, body, newPrometheusHTTPError(resp, body)
+}
+
+type prometheusAPIResponse struct {
+	Status    string           `json:"status"`
+	ErrorType promv1.ErrorType `json:"errorType"`
+	Error     string           `json:"error"`
+	Data      json.RawMessage  `json:"data,omitempty"`
+	Warnings  []string         `json:"warnings,omitempty"`
+}
+
+func newPrometheusHTTPError(resp *http.Response, body []byte) error {
+	apiErrors := prometheusAPIErrors(resp, body)
+	httpErr := HTTPError{
+		StatusCode: resp.StatusCode,
+		TraceID:    resp.Header.Get(HeaderTraceID),
+		APIErrors:  apiErrors,
+	}
+	if resp.Request != nil {
+		if resp.Request.URL != nil {
+			httpErr.URL = resp.Request.URL.String()
+		}
+		httpErr.Method = resp.Request.Method
+	}
+	return &httpErr
+}
+
+func prometheusAPIErrors(resp *http.Response, body []byte) APIErrors {
+	if len(body) == 0 {
+		return APIErrors{Errors: []APIError{{Title: "unknown error"}}}
+	}
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
+		var response prometheusAPIResponse
+		if err := json.Unmarshal(body, &response); err == nil && response.Status == "error" && response.Error != "" {
+			return APIErrors{Errors: []APIError{{Title: prometheusErrorTitle(response)}}}
+		}
+	}
+	apiErrors, err := newGenericAPIErrors(body)
+	if err != nil {
+		return APIErrors{Errors: []APIError{{Title: "unknown error"}}}
+	}
+	return apiErrors
+}
+
+func prometheusErrorTitle(response prometheusAPIResponse) string {
+	if response.ErrorType == "" {
+		return response.Error
+	}
+	return string(response.ErrorType) + ": " + response.Error
 }

--- a/tests/prometheus_v1_test.go
+++ b/tests/prometheus_v1_test.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"fmt"
 	"maps"
+	"net/http"
 	"slices"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ import (
 	v1alphaProject "github.com/nobl9/nobl9-go/manifest/v1alpha/project"
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 	v1alphaSLO "github.com/nobl9/nobl9-go/manifest/v1alpha/slo"
+	"github.com/nobl9/nobl9-go/sdk"
 	prometheusV1 "github.com/nobl9/nobl9-go/sdk/endpoints/prometheus/v1"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
 )
@@ -52,18 +54,47 @@ var allPrometheusMetricNames = []string{
 func Test_Prometheus_V1_Query(t *testing.T) {
 	t.Parallel()
 
-	value, warnings, err := client.Prometheus().V1().Query(
-		t.Context(),
-		prometheusV1.QueryRequest{
-			Query: "unknown_metric",
-		},
-	)
-	require.NoError(t, err)
-	require.Empty(t, warnings)
+	t.Run("non-existent metric", func(t *testing.T) {
+		t.Parallel()
 
-	vector, ok := value.(model.Vector)
-	require.True(t, ok)
-	assert.Empty(t, vector)
+		value, warnings, err := client.Prometheus().V1().Query(
+			t.Context(),
+			prometheusV1.QueryRequest{
+				Query: "unknown_metric",
+			},
+		)
+		require.NoError(t, err)
+		require.Empty(t, warnings)
+
+		vector, ok := value.(model.Vector)
+		require.True(t, ok)
+		assert.Empty(t, vector)
+	})
+
+	t.Run("bad response error", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := client.Prometheus().V1().Query(
+			t.Context(),
+			prometheusV1.QueryRequest{
+				Query: "sum(rate(",
+			},
+		)
+
+		require.Error(t, err)
+		var httpErr *sdk.HTTPError
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+		assert.Equal(t, http.MethodPost, httpErr.Method)
+		assert.Contains(t, httpErr.URL, "/api/prometheus/v1/api/v1/query")
+		assert.NotEmpty(t, httpErr.TraceID)
+		require.Len(t, httpErr.Errors, 1)
+		assert.Equal(
+			t,
+			"bad_data: Field Namespace:query ERROR:1 error occurred:\n\t* line 1:9 no viable alternative at input 'sum(rate('",
+			httpErr.Errors[0].Title,
+		)
+	})
 }
 
 func Test_Prometheus_V1_QueryRange(t *testing.T) {


### PR DESCRIPTION
## Motivation

Currently the Prometheus client we use under the hood is creating `promv1.Error` which obfuscates the real problems encountered, for instance, it will say `server_error: server error: 500`, omitting the important details.
Furthermore, it breaks away from the standard `sdk.HTTPError` contract we've established for API functions.

## Summary

Converted non-2xx Prometheus API responses into `sdk.HTTPError` values so callers receive status, trace ID, request metadata, and parsed API error details.

## Release Notes

Prometheus API for SLOs errors now are of type `sdk.HTTPError` and convey more details then the prior errors.

