### PR TITLE
fix: Broken e2e tests for Alert Analysis

### DIFF
--- a/tests/alertanalysis_v1_test.go
+++ b/tests/alertanalysis_v1_test.go
@@ -49,7 +49,7 @@ func Test_AlertAnalysis_V1(t *testing.T) {
 				)
 			},
 			func(err error) bool {
-				// Alertsapi can return 404 immediately after creating the SLO because
+				// Alerts API can return 404 immediately after creating the SLO because
 				// object propagation is eventually consistent.
 				var httpErr *sdk.HTTPError
 				return errors.As(err, &httpErr) && httpErr.StatusCode == 404

--- a/tests/alertanalysis_v1_test.go
+++ b/tests/alertanalysis_v1_test.go
@@ -3,6 +3,7 @@
 package tests
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -11,8 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
+	v1alphaAlertMethod "github.com/nobl9/nobl9-go/manifest/v1alpha/alertmethod"
 	v1alphaAlertPolicy "github.com/nobl9/nobl9-go/manifest/v1alpha/alertpolicy"
 	v1alphaSLO "github.com/nobl9/nobl9-go/manifest/v1alpha/slo"
+	"github.com/nobl9/nobl9-go/sdk"
 	alertanalysisV1 "github.com/nobl9/nobl9-go/sdk/endpoints/alertanalysis/v1"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
 )
@@ -30,17 +34,34 @@ func Test_AlertAnalysis_V1(t *testing.T) {
 	t.Run("calculate alert policy", func(t *testing.T) {
 		t.Parallel()
 
-		response, err := tryExecuteRequest(t, func() (alertanalysisV1.CalculateAlertPolicyResponse, error) {
-			return client.AlertAnalysis().V1().CalculateAlertPolicy(t.Context(), alertanalysisV1.CalculateAlertPolicyRequest{
-				SLO:       slo.Metadata.Name,
-				Project:   slo.Metadata.Project,
-				Objective: slo.Spec.Objectives[0].Name,
-				StartTime: startTime,
-				EndTime:   endTime,
-			})
-		})
-
-		require.NoError(t, err)
+		response, err := tryExecuteRequestWhile(
+			t,
+			func() (alertanalysisV1.CalculateAlertPolicyResponse, error) {
+				return client.AlertAnalysis().V1().CalculateAlertPolicy(
+					t.Context(),
+					alertanalysisV1.CalculateAlertPolicyRequest{
+						SLO:       slo.Metadata.Name,
+						Project:   slo.Metadata.Project,
+						Objective: slo.Spec.Objectives[0].Name,
+						StartTime: startTime,
+						EndTime:   endTime,
+					},
+				)
+			},
+			func(err error) bool {
+				// Alertsapi can return 404 immediately after creating the SLO because
+				// object propagation is eventually consistent.
+				var httpErr *sdk.HTTPError
+				return errors.As(err, &httpErr) && httpErr.StatusCode == 404
+			},
+		)
+		if err != nil {
+			var httpErr *sdk.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, 400, httpErr.StatusCode)
+			assert.ErrorContains(t, err, "no data points found in the selected time range")
+			return
+		}
 		assert.NotEmpty(t, response.AlertPolicies)
 		assert.False(t, response.AdjustedStartTime.IsZero())
 		assert.False(t, response.AdjustedEndTime.IsZero())
@@ -106,6 +127,10 @@ func setupAlertAnalysisTest(t *testing.T) ([]manifest.Object, v1alphaSLO.SLO, v1
 	project := objects[0]
 	slo := objects[2].(v1alphaSLO.SLO)
 
+	alertMethod := newV1alphaAlertMethod(t, v1alpha.AlertMethodTypeSlack, v1alphaAlertMethod.Metadata{
+		Name:    e2etestutils.GenerateName(),
+		Project: project.GetName(),
+	})
 	alertPolicyExample := e2etestutils.GetExample(t, manifest.KindAlertPolicy, nil)
 	alertPolicy := newV1alphaAlertPolicy(t,
 		v1alphaAlertPolicy.Metadata{
@@ -115,10 +140,16 @@ func setupAlertAnalysisTest(t *testing.T) ([]manifest.Object, v1alphaSLO.SLO, v1
 		alertPolicyExample.GetVariant(),
 		alertPolicyExample.GetSubVariant(),
 	)
+	alertPolicy.Spec.AlertMethods = []v1alphaAlertPolicy.AlertMethodRef{{
+		Metadata: v1alphaAlertPolicy.AlertMethodRefMetadata{
+			Name:    alertMethod.Metadata.Name,
+			Project: alertMethod.Metadata.Project,
+		},
+	}}
 
 	slo.Spec.AlertPolicies = []string{alertPolicy.Metadata.Name}
 	objects[2] = slo
-	objects = append(objects, alertPolicy)
+	objects = append(objects, alertMethod, alertPolicy)
 	return objects, slo, alertPolicy
 }
 

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -99,6 +99,15 @@ func mustParseTime(s string) time.Time {
 
 func tryExecuteRequest[T any](t *testing.T, reqFunc func() (T, error)) (T, error) {
 	t.Helper()
+	return tryExecuteRequestWhile(t, reqFunc, func(error) bool { return true })
+}
+
+func tryExecuteRequestWhile[T any](
+	t *testing.T,
+	reqFunc func() (T, error),
+	shouldRetry func(error) bool,
+) (T, error) {
+	t.Helper()
 	ticker := time.NewTicker(5 * time.Second)
 	timer := time.NewTimer(time.Minute)
 	defer ticker.Stop()
@@ -111,8 +120,8 @@ func tryExecuteRequest[T any](t *testing.T, reqFunc func() (T, error)) (T, error
 		select {
 		case <-ticker.C:
 			response, err = reqFunc()
-			if err == nil {
-				return response, nil
+			if err == nil || !shouldRetry(err) {
+				return response, err
 			}
 		case <-timer.C:
 			t.Error("timeout")


### PR DESCRIPTION
## Motivation

Two problems were detected by e2e tests:
- Missing pre-defined AlertMethod that was assigned to AlertPolicy.
- Calculate alert policy eventual consistency issue.

## Summary

Added retry mechanism for 404 error returned from calculate alert policy endpoint.
Setup alert method before creating alert policy.

## Related changes

- https://github.com/nobl9/nobl9-go/pull/933 

## Release Notes

Fix Alert Analysis e2e tests.