### PR TITLE
test: fix Dynatrace Direct e2e test

### DIFF
--- a/tests/v1alpha_direct_test.go
+++ b/tests/v1alpha_direct_test.go
@@ -127,6 +127,7 @@ func assertV1alphaDirectsAreEqual(t *testing.T, expected, actual v1alphaDirect.D
 		expected.Spec.Datadog.ApplicationKey = "[hidden]"
 	case v1alpha.Dynatrace:
 		expected.Spec.Dynatrace.DynatraceToken = "[hidden]"
+		expected.Spec.Dynatrace.PlatformToken = "[hidden]"
 	case v1alpha.GCM:
 		expected.Spec.GCM.ServiceAccountKey = "[hidden]"
 	case v1alpha.Honeycomb:


### PR DESCRIPTION
## Motivation

Add Dynatrace Platform token to expected fields in e2e tests.
<img width="885" height="160" alt="image" src="https://github.com/user-attachments/assets/98180172-3335-4091-8b1d-f5e37d554326" />


## Release Notes