### PR TITLE
feat: enable bad over total for Splunk Observability

### DIFF
--- a/internal/manifest/v1alpha/slo/slo.go
+++ b/internal/manifest/v1alpha/slo/slo.go
@@ -8,6 +8,7 @@ var BadOverTotalEnabledSources = []v1alpha.DataSourceType{
 	v1alpha.AzureMonitor,
 	v1alpha.LogicMonitor,
 	v1alpha.AzurePrometheus,
+	v1alpha.SplunkObservability,
 }
 
 var SingleQueryGoodOverTotalEnabledSources = []v1alpha.DataSourceType{

--- a/manifest/v1alpha/examples/slo.go
+++ b/manifest/v1alpha/examples/slo.go
@@ -12,7 +12,6 @@ var standardGoodOverTotalMetrics = []v1alpha.DataSourceType{
 	v1alpha.Prometheus,
 	v1alpha.Datadog,
 	v1alpha.NewRelic,
-	v1alpha.SplunkObservability,
 	v1alpha.Dynatrace,
 	v1alpha.Elasticsearch,
 	v1alpha.Graphite,
@@ -31,6 +30,7 @@ var standardBadOverTotalMetrics = []v1alpha.DataSourceType{
 	v1alpha.AppDynamics,
 	v1alpha.LogicMonitor,
 	v1alpha.AzurePrometheus,
+	v1alpha.SplunkObservability,
 }
 
 var customMetricExamples = map[v1alpha.DataSourceType]map[metricVariant][]metricSubVariant{

--- a/manifest/v1alpha/examples/slo_variants.go
+++ b/manifest/v1alpha/examples/slo_variants.go
@@ -383,6 +383,12 @@ func (s sloExample) generateMetricVariant(slo v1alphaSLO.SLO) v1alphaSLO.SLO {
 			}), newMetricSpec(v1alphaSLO.SplunkObservabilityMetric{
 				Program: ptr(`data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()`),
 			}))
+		case metricVariantBadRatio:
+			return setBadOverTotalMetric(slo, newMetricSpec(v1alphaSLO.SplunkObservabilityMetric{
+				Program: ptr(`data('demo.trans.count', filter=filter('api_server'), rollup='rate').count(filter=filter('error', 'true')).publish()`),
+			}), newMetricSpec(v1alphaSLO.SplunkObservabilityMetric{
+				Program: ptr(`data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()`),
+			}))
 		}
 	case v1alpha.Dynatrace:
 		switch s.MetricVariant {

--- a/manifest/v1alpha/slo/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/slo/examples/splunk-observability.yaml
@@ -1,3 +1,271 @@
+# Metric type: bad over total
+# Budgeting method: Occurrences
+# Time window type: Calendar
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability SLO
+    indicator:
+      metricSource:
+        name: splunk-observability
+        project: default
+        kind: Agent
+    budgetingMethod: Occurrences
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      countMetrics:
+        incremental: true
+        bad:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').count(filter=filter('error', 'true')).publish()
+        total:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Month
+      count: 1
+      isRolling: false
+      calendar:
+        startTime: "2022-12-01 00:00:00"
+        timeZone: UTC
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: bad over total
+# Budgeting method: Occurrences
+# Time window type: Rolling
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability SLO
+    indicator:
+      metricSource:
+        name: splunk-observability
+        project: default
+        kind: Agent
+    budgetingMethod: Occurrences
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      countMetrics:
+        incremental: true
+        bad:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').count(filter=filter('error', 'true')).publish()
+        total:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Hour
+      count: 1
+      isRolling: true
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: bad over total
+# Budgeting method: Timeslices
+# Time window type: Calendar
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability SLO
+    indicator:
+      metricSource:
+        name: splunk-observability
+        project: default
+        kind: Agent
+    budgetingMethod: Timeslices
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      timeSliceTarget: 0.9
+      countMetrics:
+        incremental: true
+        bad:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').count(filter=filter('error', 'true')).publish()
+        total:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Month
+      count: 1
+      isRolling: false
+      calendar:
+        startTime: "2022-12-01 00:00:00"
+        timeZone: UTC
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
+# Metric type: bad over total
+# Budgeting method: Timeslices
+# Time window type: Rolling
+- apiVersion: n9/v1alpha
+  kind: SLO
+  metadata:
+    name: api-server-slo
+    displayName: API Server SLO
+    project: default
+    labels:
+      area:
+      - latency
+      - slow-check
+      env:
+      - prod
+      - dev
+      region:
+      - us
+      - eu
+      team:
+      - green
+      - sales
+    annotations:
+      area: latency
+      env: prod
+      region: us
+      team: sales
+  spec:
+    description: Example Splunk Observability SLO
+    indicator:
+      metricSource:
+        name: splunk-observability
+        project: default
+        kind: Agent
+    budgetingMethod: Timeslices
+    objectives:
+    - displayName: Good response (200)
+      value: 1.0
+      name: ok
+      target: 0.95
+      timeSliceTarget: 0.9
+      countMetrics:
+        incremental: true
+        bad:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').count(filter=filter('error', 'true')).publish()
+        total:
+          splunkObservability:
+            program: data('demo.trans.count', filter=filter('api_server'), rollup='rate').mean().publish()
+      primary: true
+    service: api-server
+    timeWindows:
+    - unit: Hour
+      count: 1
+      isRolling: true
+    alertPolicies:
+    - fast-burn-5x-for-last-10m
+    attachments:
+    - url: https://docs.nobl9.com
+      displayName: Nobl9 Documentation
+    anomalyConfig:
+      noData:
+        alertMethods:
+        - name: slack-notification
+          project: default
+        alertAfter: 1h
 # Metric type: good over total
 # Budgeting method: Occurrences
 # Time window type: Calendar


### PR DESCRIPTION
## Motivation

Splunk Observability ratio SLOs currently accept only good-over-total count metrics; `countMetrics.bad` is rejected at validation. This enables bad-over-total for Splunk Observability, in line with sources such as Azure Monitor, LogicMonitor, and Azure Prometheus.

## Summary

- Add `SplunkObservability` to `BadOverTotalEnabledSources` so SLO validation accepts `countMetrics.bad` for this source.
- Move Splunk Observability from the good-over-total example set to the bad-over-total set and add the bad-ratio metric variant.
- Regenerate SLO examples (`manifest/v1alpha/slo/examples/splunk-observability.yaml`).

| SLO countMetrics shape | Before | After |
|---|---|---|
| good + total | accepted | accepted (unchanged) |
| bad + total | validation error | accepted |
| other data sources | unchanged | unchanged |

## Related changes

- #925 — same release train; both PRs should be merged before the next release is tagged.

## Testing

- `go build ./...`
- `go test ./manifest/... ./internal/...`
- `make generate` produces no diff (regenerated examples are committed).
- Manual: apply a Splunk Observability SLO with `countMetrics.bad` + `countMetrics.total` and verify it passes validation.

## Release Notes

Splunk Observability SLOs now support bad-over-total count metrics (`countMetrics.bad`).
