### PR TITLE
feat: add get users endpoint

### DIFF
--- a/sdk/endpoints/users/v2/endpoints.go
+++ b/sdk/endpoints/users/v2/endpoints.go
@@ -37,7 +37,7 @@ func (e endpoints) GetUser(ctx context.Context, id string) (*User, error) {
 	}
 	switch len(users) {
 	case 1:
-		return users[0], nil
+		return &users[0], nil
 	case 0:
 		return nil, nil
 	default:
@@ -46,12 +46,12 @@ func (e endpoints) GetUser(ctx context.Context, id string) (*User, error) {
 }
 
 // GetUsers fetches users filtered by the provided request.
-func (e endpoints) GetUsers(ctx context.Context, params GetUsersRequest) ([]*User, error) {
+func (e endpoints) GetUsers(ctx context.Context, params GetUsersRequest) ([]User, error) {
 	return e.getUsers(ctx, getUsersRequest{IDs: params.IDs})
 }
 
 // getUsers fetches a list of [User] filtered by the provided parameters.
-func (e endpoints) getUsers(ctx context.Context, params getUsersRequest) ([]*User, error) {
+func (e endpoints) getUsers(ctx context.Context, params getUsersRequest) ([]User, error) {
 	q := make(url.Values)
 	if params.Phrase != "" {
 		q["phrase"] = []string{params.Phrase}
@@ -69,7 +69,7 @@ func (e endpoints) getUsers(ctx context.Context, params getUsersRequest) ([]*Use
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var users struct {
-		Users []*User `json:"users"`
+		Users []User `json:"users"`
 	}
 	if err = json.NewDecoder(resp.Body).Decode(&users); err != nil {
 		return nil, err

--- a/sdk/endpoints/users/v2/endpoints.go
+++ b/sdk/endpoints/users/v2/endpoints.go
@@ -45,9 +45,20 @@ func (e endpoints) GetUser(ctx context.Context, id string) (*User, error) {
 	}
 }
 
-// getUsers fetches a list of [User] filtered by the provided search phrase.
+// GetUsers fetches users filtered by the provided request.
+func (e endpoints) GetUsers(ctx context.Context, params GetUsersRequest) ([]*User, error) {
+	return e.getUsers(ctx, getUsersRequest{IDs: params.IDs})
+}
+
+// getUsers fetches a list of [User] filtered by the provided parameters.
 func (e endpoints) getUsers(ctx context.Context, params getUsersRequest) ([]*User, error) {
-	q := url.Values{"phrase": []string{params.Phrase}}
+	q := make(url.Values)
+	if params.Phrase != "" {
+		q["phrase"] = []string{params.Phrase}
+	}
+	if len(params.IDs) > 0 {
+		q["id"] = params.IDs
+	}
 	req, err := e.client.CreateRequest(ctx, http.MethodGet, baseAPIPath, nil, q, nil)
 	if err != nil {
 		return nil, err

--- a/sdk/endpoints/users/v2/endpoints_interface.go
+++ b/sdk/endpoints/users/v2/endpoints_interface.go
@@ -14,5 +14,5 @@ type Endpoints interface {
 	// It returns nil if the user was not found.
 	GetUser(ctx context.Context, id string) (*User, error)
 	// GetUsers fetches users filtered by the provided request.
-	GetUsers(ctx context.Context, params GetUsersRequest) ([]*User, error)
+	GetUsers(ctx context.Context, params GetUsersRequest) ([]User, error)
 }

--- a/sdk/endpoints/users/v2/endpoints_interface.go
+++ b/sdk/endpoints/users/v2/endpoints_interface.go
@@ -13,4 +13,6 @@ type Endpoints interface {
 	//
 	// It returns nil if the user was not found.
 	GetUser(ctx context.Context, id string) (*User, error)
+	// GetUsers fetches users filtered by the provided request.
+	GetUsers(ctx context.Context, params GetUsersRequest) ([]*User, error)
 }

--- a/sdk/endpoints/users/v2/request.go
+++ b/sdk/endpoints/users/v2/request.go
@@ -1,5 +1,11 @@
 package v2
 
+// GetUsersRequest defines filters for fetching users.
+type GetUsersRequest struct {
+	IDs []string
+}
+
 type getUsersRequest struct {
 	Phrase string
+	IDs    []string
 }

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	usersV2 "github.com/nobl9/nobl9-go/sdk/endpoints/users/v2"
 )
 
 func Test_Users_V2_GetUser(t *testing.T) {
@@ -21,4 +23,21 @@ func Test_Users_V2_GetUser(t *testing.T) {
 	assert.NotEmpty(t, user.FirstName)
 	assert.NotEmpty(t, user.LastName)
 	assert.Equal(t, userID, user.UserID)
+}
+
+func Test_Users_V2_GetUsers(t *testing.T) {
+	t.Parallel()
+
+	userID, err := client.GetUserID(t.Context())
+	require.NoError(t, err)
+
+	users, err := client.Users().V2().GetUsers(t.Context(), usersV2.GetUsersRequest{
+		IDs: []string{userID},
+	})
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	assert.NotEmpty(t, users[0].Email)
+	assert.NotEmpty(t, users[0].FirstName)
+	assert.NotEmpty(t, users[0].LastName)
+	assert.Equal(t, userID, users[0].UserID)
 }


### PR DESCRIPTION
## Motivation

The underlying API already allows fetching multiple users. To make fetching multiple users easier and faster for SDK callers, this PR adds a dedicated method for that API capability.

## Summary

- Added `GetUsers(ctx, GetUsersRequest)` to the users v2 endpoint and generated interface, returning `[]User`.
- Added `IDs []string` request filtering while keeping `GetUser` on the existing phrase lookup path.
- Extended e2e coverage for fetching the current user through the ID-list lookup.

## Related Changes

https://github.com/nobl9/sloctl/pull/483

## Testing

- Added `Test_Users_V2_GetUsers` e2e coverage for fetching the current user by ID list.
- Verified the new e2e test against the configured Nobl9 environment.

## Release Notes

Added `GetUsers` to the Go SDK users v2 endpoint for fetching users by ID list.
