### PR TITLE
feat: add project scope setting to report filters

### DIFF
--- a/manifest/v1alpha/examples/report.go
+++ b/manifest/v1alpha/examples/report.go
@@ -200,7 +200,8 @@ func Report() []Example {
 			),
 		},
 		{
-			Variant: "Error Budget Status",
+			Variant:    "Error Budget Status",
+			SubVariant: "selected projects",
 			Object: report.New(
 				report.Metadata{
 					Name:        "ebs-report",
@@ -213,6 +214,23 @@ func Report() []Example {
 							"project-1",
 							"project-2",
 						},
+					},
+					ErrorBudgetStatus: &report.ErrorBudgetStatusConfig{},
+				},
+			),
+		},
+		{
+			Variant:    "Error Budget Status",
+			SubVariant: "all projects",
+			Object: report.New(
+				report.Metadata{
+					Name:        "ebs-report",
+					DisplayName: "Error Budget Status",
+				},
+				report.Spec{
+					Shared: true,
+					Filters: &report.Filters{
+						ProjectScope: report.ProjectScopeAll,
 					},
 					ErrorBudgetStatus: &report.ErrorBudgetStatusConfig{},
 				},

--- a/manifest/v1alpha/report/examples/error-budget-status.yaml
+++ b/manifest/v1alpha/report/examples/error-budget-status.yaml
@@ -1,12 +1,24 @@
-apiVersion: n9/v1alpha
-kind: Report
-metadata:
-  name: ebs-report
-  displayName: Error Budget Status
-spec:
-  shared: true
-  filters:
-    projects:
-    - project-1
-    - project-2
-  errorBudgetStatus: {}
+# all projects
+- apiVersion: n9/v1alpha
+  kind: Report
+  metadata:
+    name: ebs-report
+    displayName: Error Budget Status
+  spec:
+    shared: true
+    filters:
+      projectScope: all
+    errorBudgetStatus: {}
+# selected projects
+- apiVersion: n9/v1alpha
+  kind: Report
+  metadata:
+    name: ebs-report
+    displayName: Error Budget Status
+  spec:
+    shared: true
+    filters:
+      projects:
+      - project-1
+      - project-2
+    errorBudgetStatus: {}

--- a/manifest/v1alpha/report/report.go
+++ b/manifest/v1alpha/report/report.go
@@ -63,11 +63,19 @@ type CustomPeriod struct {
 	EndDate   string `json:"endDate,omitempty"`
 }
 
+type ProjectScope string
+
+const (
+	ProjectScopeSelected ProjectScope = "selected"
+	ProjectScopeAll      ProjectScope = "all"
+)
+
 type Filters struct {
-	Projects []string       `json:"projects,omitempty"`
-	Services Services       `json:"services,omitempty"`
-	SLOs     SLOs           `json:"slos,omitempty"`
-	Labels   v1alpha.Labels `json:"labels,omitempty"`
+	ProjectScope ProjectScope   `json:"projectScope,omitempty"`
+	Projects     []string       `json:"projects,omitempty"`
+	Services     Services       `json:"services,omitempty"`
+	SLOs         SLOs           `json:"slos,omitempty"`
+	Labels       v1alpha.Labels `json:"labels,omitempty"`
 }
 
 type (

--- a/manifest/v1alpha/report/validation.go
+++ b/manifest/v1alpha/report/validation.go
@@ -93,12 +93,34 @@ var specValidation = govy.New[Spec](
 
 var filtersValidation = govy.New[Filters](
 	govy.For(govy.GetSelf[Filters]()).
+		When(
+			func(f Filters) bool { return f.ProjectScope == ProjectScopeAll },
+			govy.WhenDescription("projectScope is set to all"),
+		).
 		Rules(govy.NewRule(func(f Filters) error {
-			if len(f.Projects) == 0 && len(f.Services) == 0 && len(f.SLOs) == 0 {
-				return errors.New("at least one of the following fields is required: projects, services, slos")
+			if len(f.Projects) > 0 || len(f.Services) > 0 || len(f.SLOs) > 0 {
+				return errors.New("projectScope=all cannot be combined with projects, services, or slos")
 			}
 			return nil
 		})),
+	govy.For(govy.GetSelf[Filters]()).
+		When(
+			func(f Filters) bool { return f.ProjectScope == ProjectScopeSelected || f.ProjectScope == "" },
+			govy.WhenDescription("projectScope is selected or unspecified"),
+		).
+		Rules(govy.NewRule(func(f Filters) error {
+			if len(f.Projects) == 0 && len(f.Services) == 0 && len(f.SLOs) == 0 {
+				return errors.New("at least one of the following fields is required: projectScope=all, projects, services, slos")
+			}
+			return nil
+		})),
+	govy.For(func(f Filters) ProjectScope { return f.ProjectScope }).
+		WithName("projectScope").
+		When(
+			func(f Filters) bool { return f.ProjectScope != "" },
+			govy.WhenDescription("projectScope is set"),
+		).
+		Rules(rules.OneOf(ProjectScopeSelected, ProjectScopeAll)),
 	govy.ForSlice(func(f Filters) []string { return f.Projects }).
 		WithName("projects").
 		RulesForEach(

--- a/manifest/v1alpha/report/validation.go
+++ b/manifest/v1alpha/report/validation.go
@@ -116,10 +116,7 @@ var filtersValidation = govy.New[Filters](
 		})),
 	govy.For(func(f Filters) ProjectScope { return f.ProjectScope }).
 		WithName("projectScope").
-		When(
-			func(f Filters) bool { return f.ProjectScope != "" },
-			govy.WhenDescription("projectScope is set"),
-		).
+		OmitEmpty().
 		Rules(rules.OneOf(ProjectScopeSelected, ProjectScopeAll)),
 	govy.ForSlice(func(f Filters) []string { return f.Projects }).
 		WithName("projects").

--- a/manifest/v1alpha/report/validation_test.go
+++ b/manifest/v1alpha/report/validation_test.go
@@ -120,6 +120,13 @@ func TestValidate_Spec_Filters(t *testing.T) {
 		"passes with valid projects": {
 			Projects: []string{"project1", "project2"},
 		},
+		"passes with selected project scope and valid projects": {
+			ProjectScope: ProjectScopeSelected,
+			Projects:     []string{"project1", "project2"},
+		},
+		"passes with all project scope": {
+			ProjectScope: ProjectScopeAll,
+		},
 		"passes with valid services": {
 			Services: Services{
 				Service{
@@ -172,13 +179,50 @@ func TestValidate_Spec_Filters(t *testing.T) {
 			ExpectedErrors: []testutils.ExpectedError{
 				{
 					Prop:    "spec.filters",
-					Message: "at least one of the following fields is required: projects, services, slos",
+					Message: "at least one of the following fields is required: projectScope=all, projects, services, slos",
 				},
 			},
 			Filters: &Filters{
 				Labels: v1alpha.Labels{
 					"key1": {"value1"},
 				},
+			},
+		},
+		"fails with selected project scope and nothing selected": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop:    "spec.filters",
+					Message: "at least one of the following fields is required: projectScope=all, projects, services, slos",
+				},
+			},
+			Filters: &Filters{
+				ProjectScope: ProjectScopeSelected,
+			},
+		},
+		"fails with invalid project scope": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop: "spec.filters.projectScope",
+					Code: rules.ErrorCodeOneOf,
+				},
+			},
+			Filters: &Filters{
+				ProjectScope: ProjectScope("invalid"),
+			},
+		},
+		"fails with all project scope and explicit projects": {
+			ExpectedErrorsCount: 1,
+			ExpectedErrors: []testutils.ExpectedError{
+				{
+					Prop:    "spec.filters",
+					Message: "projectScope=all cannot be combined with projects, services, or slos",
+				},
+			},
+			Filters: &Filters{
+				ProjectScope: ProjectScopeAll,
+				Projects:     []string{"project"},
 			},
 		},
 		"fails with invalid project names": {


### PR DESCRIPTION
## Motivation

PC-19834 adds report project scope to Nobl9 Report manifests, so SDK users can represent reports that cover all current and future projects without enumerating project names.

## Summary

Added `ProjectScope` constants and `projectScope` JSON support to Report filters. `projectScope: all` now satisfies Report filter validation on its own, while unknown values and `all` combined with explicit projects, services, or SLOs are rejected.

Preserved backward compatibility for existing Report manifests that omit `projectScope`: they still validate with explicit resources and marshal without emitting the new field unless it is set.

## Testing

Added manifest validation coverage for `projectScope: all`, invalid project scope values, and invalid combinations with explicit resources. Added JSON round-trip coverage for new all-project filters and legacy filters that omit `projectScope`.

E2E tests were not added because this change is limited to manifest encoding and validation, not SDK client behavior against the Nobl9 platform API.

## Release Notes

Added `projectScope` to Report manifest filters.
