### PR TITLE
fix: update Splunk Observability agent fixture

### DIFF
--- a/manifest/v1alpha/agent/examples/splunk-observability.yaml
+++ b/manifest/v1alpha/agent/examples/splunk-observability.yaml
@@ -1,46 +1,26 @@
-- apiVersion: n9/v1alpha
-  kind: Agent
-  metadata:
-    name: splunk-observability
-    displayName: Splunk Observability Agent
-    project: default
-    annotations:
-      area: latency
-      env: prod
-      region: us
-      team: sales
-  spec:
-    description: Example Splunk Observability Agent
-    releaseChannel: beta
-    splunkObservability:
-      realm: us1
-    queryDelay:
-      value: 6
-      unit: Minute
-# replay
-- apiVersion: n9/v1alpha
-  kind: Agent
-  metadata:
-    name: splunk-observability
-    displayName: Splunk Observability Agent
-    project: default
-    annotations:
-      area: latency
-      env: prod
-      region: us
-      team: sales
-  spec:
-    description: Example Splunk Observability Agent
-    releaseChannel: beta
-    splunkObservability:
-      realm: us1
-    historicalDataRetrieval:
-      maxDuration:
-        value: 30
-        unit: Day
-      defaultDuration:
-        value: 15
-        unit: Day
-    queryDelay:
-      value: 6
-      unit: Minute
+apiVersion: n9/v1alpha
+kind: Agent
+metadata:
+  name: splunk-observability
+  displayName: Splunk Observability Agent
+  project: default
+  annotations:
+    area: latency
+    env: prod
+    region: us
+    team: sales
+spec:
+  description: Example Splunk Observability Agent
+  releaseChannel: beta
+  splunkObservability:
+    realm: us1
+  historicalDataRetrieval:
+    maxDuration:
+      value: 30
+      unit: Day
+    defaultDuration:
+      value: 15
+      unit: Day
+  queryDelay:
+    value: 6
+    unit: Minute

--- a/manifest/v1alpha/examples/agent.go
+++ b/manifest/v1alpha/examples/agent.go
@@ -12,8 +12,7 @@ import (
 
 type agentExample struct {
 	standardExample
-	typ           v1alpha.DataSourceType
-	replayEnabled bool
+	typ v1alpha.DataSourceType
 }
 
 func (a agentExample) GetDataSourceType() v1alpha.DataSourceType {
@@ -22,29 +21,18 @@ func (a agentExample) GetDataSourceType() v1alpha.DataSourceType {
 
 func Agent() []Example {
 	types := v1alpha.DataSourceTypeValues()
-	examples := make([]Example, 0, len(types)+1)
+	examples := make([]Example, 0, len(types))
 	for _, typ := range types {
-		variant := toKebabCase(typ.String())
-		if typ == v1alpha.SplunkObservability {
-			examples = append(examples,
-				newAgentExample(typ, variant, "", false),
-				newAgentExample(typ, variant, "replay", true),
-			)
-			continue
+		example := agentExample{
+			standardExample: standardExample{
+				Variant: toKebabCase(typ.String()),
+			},
+			typ: typ,
 		}
-		examples = append(examples, newAgentExample(typ, variant, "", true))
+		example.Object = example.Generate()
+		examples = append(examples, example)
 	}
 	return examples
-}
-
-func newAgentExample(typ v1alpha.DataSourceType, variant, subVariant string, replayEnabled bool) agentExample {
-	example := agentExample{
-		standardExample: standardExample{Variant: variant, SubVariant: subVariant},
-		typ:             typ,
-		replayEnabled:   replayEnabled,
-	}
-	example.Object = example.Generate()
-	return example
 }
 
 var betaChannelAgents = []v1alpha.DataSourceType{
@@ -80,16 +68,14 @@ func (a agentExample) Generate() v1alphaAgent.Agent {
 	)
 	agent = a.generateVariant(agent)
 	typ, _ := agent.Spec.GetType()
-	if a.replayEnabled {
-		if maxDuration, err := v1alpha.GetDataRetrievalMaxDuration(manifest.KindAgent, typ); err == nil {
-			defaultDuration := v1alpha.HistoricalRetrievalDuration{
-				Value: ptr(*maxDuration.Value / 2),
-				Unit:  maxDuration.Unit,
-			}
-			agent.Spec.HistoricalDataRetrieval = &v1alpha.HistoricalDataRetrieval{
-				MaxDuration:     maxDuration,
-				DefaultDuration: defaultDuration,
-			}
+	if maxDuration, err := v1alpha.GetDataRetrievalMaxDuration(manifest.KindAgent, typ); err == nil {
+		defaultDuration := v1alpha.HistoricalRetrievalDuration{
+			Value: ptr(*maxDuration.Value / 2),
+			Unit:  maxDuration.Unit,
+		}
+		agent.Spec.HistoricalDataRetrieval = &v1alpha.HistoricalDataRetrieval{
+			MaxDuration:     maxDuration,
+			DefaultDuration: defaultDuration,
 		}
 	}
 	defaultQueryDelay := v1alpha.GetQueryDelayDefaults()[typ]


### PR DESCRIPTION
## Release Notes


## Motivation

Splunk Observability is beta-only. Keeping a separate non-replay Agent example left SDK e2e expecting a fixture shape that no longer matches the API response.

## Summary

Generate one Splunk Observability Agent fixture through the standard Agent example path and remove the stale replay-variant scaffolding. Update the generated YAML fixture to match the API response.

## Related Changes

None.