### PR TITLE
feat: add GoodOverTotalAnomaly annotation category

### DIFF
--- a/manifest/v1alpha/annotation/category.go
+++ b/manifest/v1alpha/annotation/category.go
@@ -15,6 +15,7 @@ NoDataAnomaly
 IncrementalMismatchAnomaly
 NoBurnAnomaly
 ConstantBurnAnomaly
+GoodOverTotalAnomaly
 )*/
 type Category string
 
@@ -26,6 +27,7 @@ var systemCategories = []Category{
 	CategoryIncrementalMismatchAnomaly,
 	CategoryNoBurnAnomaly,
 	CategoryConstantBurnAnomaly,
+	CategoryGoodOverTotalAnomaly,
 }
 
 var userCategories = []Category{

--- a/manifest/v1alpha/annotation/category_enum.go
+++ b/manifest/v1alpha/annotation/category_enum.go
@@ -21,6 +21,7 @@ const (
 	CategoryIncrementalMismatchAnomaly Category = "IncrementalMismatchAnomaly"
 	CategoryNoBurnAnomaly              Category = "NoBurnAnomaly"
 	CategoryConstantBurnAnomaly        Category = "ConstantBurnAnomaly"
+	CategoryGoodOverTotalAnomaly       Category = "GoodOverTotalAnomaly"
 )
 
 var ErrInvalidCategory = errors.New("not a valid Category")
@@ -37,6 +38,7 @@ func CategoryValues() []Category {
 		CategoryIncrementalMismatchAnomaly,
 		CategoryNoBurnAnomaly,
 		CategoryConstantBurnAnomaly,
+		CategoryGoodOverTotalAnomaly,
 	}
 }
 
@@ -62,6 +64,7 @@ var _CategoryValue = map[string]Category{
 	"IncrementalMismatchAnomaly": CategoryIncrementalMismatchAnomaly,
 	"NoBurnAnomaly":              CategoryNoBurnAnomaly,
 	"ConstantBurnAnomaly":        CategoryConstantBurnAnomaly,
+	"GoodOverTotalAnomaly":       CategoryGoodOverTotalAnomaly,
 }
 
 // ParseCategory attempts to convert a string to a Category.

--- a/manifest/v1alpha/annotation/category_test.go
+++ b/manifest/v1alpha/annotation/category_test.go
@@ -1,0 +1,17 @@
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCategory_GoodOverTotalAnomaly(t *testing.T) {
+	category, err := ParseCategory("GoodOverTotalAnomaly")
+	require.NoError(t, err)
+	assert.Equal(t, CategoryGoodOverTotalAnomaly, category)
+	assert.True(t, CategoryGoodOverTotalAnomaly.IsValid())
+	assert.Contains(t, GetSystemCategories(), CategoryGoodOverTotalAnomaly)
+	assert.NotContains(t, GetUserCategories(), CategoryGoodOverTotalAnomaly)
+}


### PR DESCRIPTION
## Motivation

The platform now emits system annotations for the Good over total anomaly type. The SDK needs to recognize the `GoodOverTotalAnomaly` category so downstream code can parse manifests and API responses without local compatibility workarounds.

## Summary

- Add `GoodOverTotalAnomaly` to the annotation category enum source and generated enum output.
- Include `CategoryGoodOverTotalAnomaly` in system annotation categories.
- Keep `CategoryGoodOverTotalAnomaly` out of user-created annotation categories.
- Add focused coverage for parsing, validity, and system/user category membership.

## Release Notes

Add SDK manifest support for the `GoodOverTotalAnomaly` system annotation category.