### PR TITLE
test: fix Prometheus labels and alert policy comparisons

### DIFF
--- a/tests/prometheus_v1_test.go
+++ b/tests/prometheus_v1_test.go
@@ -187,7 +187,11 @@ func Test_Prometheus_V1_LabelNames(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Empty(t, warnings)
-			assert.Equal(t, tt.expected, labelNames)
+			expectedLabelNames := make(model.LabelNames, 0, len(tt.expected))
+			for _, name := range tt.expected {
+				expectedLabelNames = append(expectedLabelNames, model.LabelName(name))
+			}
+			assert.Equal(t, expectedLabelNames, labelNames)
 		})
 	}
 }

--- a/tests/v1alpha_alertpolicy_test.go
+++ b/tests/v1alpha_alertpolicy_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -145,6 +146,7 @@ func newV1alphaAlertPolicy(
 
 func assertV1alphaAlertPoliciesAreEqual(t *testing.T, expected, actual v1alphaAlertPolicy.AlertPolicy) {
 	t.Helper()
+	expected.Spec.Conditions = slices.Clone(expected.Spec.Conditions)
 	for i := range expected.Spec.Conditions {
 		if expected.Spec.Conditions[i].AlertingWindow == "" && expected.Spec.Conditions[i].LastsForDuration == "" {
 			expected.Spec.Conditions[i].LastsForDuration = "0m"


### PR DESCRIPTION
## Motivation

With the updated contract for new Prometheus library version the e2e tests started failing.
There was also a race condition for Alert Policies I encountered.
