### PR TITLE
feat: add sampling rate anomaly categories

### DIFF
--- a/manifest/v1alpha/annotation/category.go
+++ b/manifest/v1alpha/annotation/category.go
@@ -16,6 +16,9 @@ IncrementalMismatchAnomaly
 NoBurnAnomaly
 ConstantBurnAnomaly
 GoodOverTotalAnomaly
+MissingPairAnomaly
+DensityMismatchAnomaly
+DensityChangeAnomaly
 )*/
 type Category string
 
@@ -28,6 +31,9 @@ var systemCategories = []Category{
 	CategoryNoBurnAnomaly,
 	CategoryConstantBurnAnomaly,
 	CategoryGoodOverTotalAnomaly,
+	CategoryMissingPairAnomaly,
+	CategoryDensityMismatchAnomaly,
+	CategoryDensityChangeAnomaly,
 }
 
 var userCategories = []Category{

--- a/manifest/v1alpha/annotation/category.go
+++ b/manifest/v1alpha/annotation/category.go
@@ -16,7 +16,6 @@ IncrementalMismatchAnomaly
 NoBurnAnomaly
 ConstantBurnAnomaly
 GoodOverTotalAnomaly
-MissingPairAnomaly
 DensityMismatchAnomaly
 DensityChangeAnomaly
 )*/
@@ -31,7 +30,6 @@ var systemCategories = []Category{
 	CategoryNoBurnAnomaly,
 	CategoryConstantBurnAnomaly,
 	CategoryGoodOverTotalAnomaly,
-	CategoryMissingPairAnomaly,
 	CategoryDensityMismatchAnomaly,
 	CategoryDensityChangeAnomaly,
 }

--- a/manifest/v1alpha/annotation/category.go
+++ b/manifest/v1alpha/annotation/category.go
@@ -16,8 +16,8 @@ IncrementalMismatchAnomaly
 NoBurnAnomaly
 ConstantBurnAnomaly
 GoodOverTotalAnomaly
-DensityMismatchAnomaly
-DensityChangeAnomaly
+SamplingRateMismatchAnomaly
+SamplingRateChangeAnomaly
 )*/
 type Category string
 
@@ -30,8 +30,8 @@ var systemCategories = []Category{
 	CategoryNoBurnAnomaly,
 	CategoryConstantBurnAnomaly,
 	CategoryGoodOverTotalAnomaly,
-	CategoryDensityMismatchAnomaly,
-	CategoryDensityChangeAnomaly,
+	CategorySamplingRateMismatchAnomaly,
+	CategorySamplingRateChangeAnomaly,
 }
 
 var userCategories = []Category{

--- a/manifest/v1alpha/annotation/category_enum.go
+++ b/manifest/v1alpha/annotation/category_enum.go
@@ -22,6 +22,9 @@ const (
 	CategoryNoBurnAnomaly              Category = "NoBurnAnomaly"
 	CategoryConstantBurnAnomaly        Category = "ConstantBurnAnomaly"
 	CategoryGoodOverTotalAnomaly       Category = "GoodOverTotalAnomaly"
+	CategoryMissingPairAnomaly         Category = "MissingPairAnomaly"
+	CategoryDensityMismatchAnomaly     Category = "DensityMismatchAnomaly"
+	CategoryDensityChangeAnomaly       Category = "DensityChangeAnomaly"
 )
 
 var ErrInvalidCategory = errors.New("not a valid Category")
@@ -39,6 +42,9 @@ func CategoryValues() []Category {
 		CategoryNoBurnAnomaly,
 		CategoryConstantBurnAnomaly,
 		CategoryGoodOverTotalAnomaly,
+		CategoryMissingPairAnomaly,
+		CategoryDensityMismatchAnomaly,
+		CategoryDensityChangeAnomaly,
 	}
 }
 
@@ -65,6 +71,9 @@ var _CategoryValue = map[string]Category{
 	"NoBurnAnomaly":              CategoryNoBurnAnomaly,
 	"ConstantBurnAnomaly":        CategoryConstantBurnAnomaly,
 	"GoodOverTotalAnomaly":       CategoryGoodOverTotalAnomaly,
+	"MissingPairAnomaly":         CategoryMissingPairAnomaly,
+	"DensityMismatchAnomaly":     CategoryDensityMismatchAnomaly,
+	"DensityChangeAnomaly":       CategoryDensityChangeAnomaly,
 }
 
 // ParseCategory attempts to convert a string to a Category.

--- a/manifest/v1alpha/annotation/category_enum.go
+++ b/manifest/v1alpha/annotation/category_enum.go
@@ -12,18 +12,18 @@ import (
 )
 
 const (
-	CategoryComment                    Category = "Comment"
-	CategoryReviewNote                 Category = "ReviewNote"
-	CategorySloEdit                    Category = "SloEdit"
-	CategoryAlert                      Category = "Alert"
-	CategoryAdjustment                 Category = "Adjustment"
-	CategoryNoDataAnomaly              Category = "NoDataAnomaly"
-	CategoryIncrementalMismatchAnomaly Category = "IncrementalMismatchAnomaly"
-	CategoryNoBurnAnomaly              Category = "NoBurnAnomaly"
-	CategoryConstantBurnAnomaly        Category = "ConstantBurnAnomaly"
-	CategoryGoodOverTotalAnomaly       Category = "GoodOverTotalAnomaly"
-	CategoryDensityMismatchAnomaly     Category = "DensityMismatchAnomaly"
-	CategoryDensityChangeAnomaly       Category = "DensityChangeAnomaly"
+	CategoryComment                     Category = "Comment"
+	CategoryReviewNote                  Category = "ReviewNote"
+	CategorySloEdit                     Category = "SloEdit"
+	CategoryAlert                       Category = "Alert"
+	CategoryAdjustment                  Category = "Adjustment"
+	CategoryNoDataAnomaly               Category = "NoDataAnomaly"
+	CategoryIncrementalMismatchAnomaly  Category = "IncrementalMismatchAnomaly"
+	CategoryNoBurnAnomaly               Category = "NoBurnAnomaly"
+	CategoryConstantBurnAnomaly         Category = "ConstantBurnAnomaly"
+	CategoryGoodOverTotalAnomaly        Category = "GoodOverTotalAnomaly"
+	CategorySamplingRateMismatchAnomaly Category = "SamplingRateMismatchAnomaly"
+	CategorySamplingRateChangeAnomaly   Category = "SamplingRateChangeAnomaly"
 )
 
 var ErrInvalidCategory = errors.New("not a valid Category")
@@ -41,8 +41,8 @@ func CategoryValues() []Category {
 		CategoryNoBurnAnomaly,
 		CategoryConstantBurnAnomaly,
 		CategoryGoodOverTotalAnomaly,
-		CategoryDensityMismatchAnomaly,
-		CategoryDensityChangeAnomaly,
+		CategorySamplingRateMismatchAnomaly,
+		CategorySamplingRateChangeAnomaly,
 	}
 }
 
@@ -59,18 +59,18 @@ func (x Category) IsValid() bool {
 }
 
 var _CategoryValue = map[string]Category{
-	"Comment":                    CategoryComment,
-	"ReviewNote":                 CategoryReviewNote,
-	"SloEdit":                    CategorySloEdit,
-	"Alert":                      CategoryAlert,
-	"Adjustment":                 CategoryAdjustment,
-	"NoDataAnomaly":              CategoryNoDataAnomaly,
-	"IncrementalMismatchAnomaly": CategoryIncrementalMismatchAnomaly,
-	"NoBurnAnomaly":              CategoryNoBurnAnomaly,
-	"ConstantBurnAnomaly":        CategoryConstantBurnAnomaly,
-	"GoodOverTotalAnomaly":       CategoryGoodOverTotalAnomaly,
-	"DensityMismatchAnomaly":     CategoryDensityMismatchAnomaly,
-	"DensityChangeAnomaly":       CategoryDensityChangeAnomaly,
+	"Comment":                     CategoryComment,
+	"ReviewNote":                  CategoryReviewNote,
+	"SloEdit":                     CategorySloEdit,
+	"Alert":                       CategoryAlert,
+	"Adjustment":                  CategoryAdjustment,
+	"NoDataAnomaly":               CategoryNoDataAnomaly,
+	"IncrementalMismatchAnomaly":  CategoryIncrementalMismatchAnomaly,
+	"NoBurnAnomaly":               CategoryNoBurnAnomaly,
+	"ConstantBurnAnomaly":         CategoryConstantBurnAnomaly,
+	"GoodOverTotalAnomaly":        CategoryGoodOverTotalAnomaly,
+	"SamplingRateMismatchAnomaly": CategorySamplingRateMismatchAnomaly,
+	"SamplingRateChangeAnomaly":   CategorySamplingRateChangeAnomaly,
 }
 
 // ParseCategory attempts to convert a string to a Category.

--- a/manifest/v1alpha/annotation/category_enum.go
+++ b/manifest/v1alpha/annotation/category_enum.go
@@ -22,7 +22,6 @@ const (
 	CategoryNoBurnAnomaly              Category = "NoBurnAnomaly"
 	CategoryConstantBurnAnomaly        Category = "ConstantBurnAnomaly"
 	CategoryGoodOverTotalAnomaly       Category = "GoodOverTotalAnomaly"
-	CategoryMissingPairAnomaly         Category = "MissingPairAnomaly"
 	CategoryDensityMismatchAnomaly     Category = "DensityMismatchAnomaly"
 	CategoryDensityChangeAnomaly       Category = "DensityChangeAnomaly"
 )
@@ -42,7 +41,6 @@ func CategoryValues() []Category {
 		CategoryNoBurnAnomaly,
 		CategoryConstantBurnAnomaly,
 		CategoryGoodOverTotalAnomaly,
-		CategoryMissingPairAnomaly,
 		CategoryDensityMismatchAnomaly,
 		CategoryDensityChangeAnomaly,
 	}
@@ -71,7 +69,6 @@ var _CategoryValue = map[string]Category{
 	"NoBurnAnomaly":              CategoryNoBurnAnomaly,
 	"ConstantBurnAnomaly":        CategoryConstantBurnAnomaly,
 	"GoodOverTotalAnomaly":       CategoryGoodOverTotalAnomaly,
-	"MissingPairAnomaly":         CategoryMissingPairAnomaly,
 	"DensityMismatchAnomaly":     CategoryDensityMismatchAnomaly,
 	"DensityChangeAnomaly":       CategoryDensityChangeAnomaly,
 }

--- a/manifest/v1alpha/annotation/category_test.go
+++ b/manifest/v1alpha/annotation/category_test.go
@@ -15,3 +15,18 @@ func TestCategory_GoodOverTotalAnomaly(t *testing.T) {
 	assert.Contains(t, GetSystemCategories(), CategoryGoodOverTotalAnomaly)
 	assert.NotContains(t, GetUserCategories(), CategoryGoodOverTotalAnomaly)
 }
+
+func TestCategory_SLIDensityAnomalies(t *testing.T) {
+	for _, expected := range []Category{
+		CategoryMissingPairAnomaly,
+		CategoryDensityMismatchAnomaly,
+		CategoryDensityChangeAnomaly,
+	} {
+		actual, err := ParseCategory(expected.String())
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+		assert.True(t, expected.IsValid())
+		assert.Contains(t, GetSystemCategories(), expected)
+		assert.NotContains(t, GetUserCategories(), expected)
+	}
+}

--- a/manifest/v1alpha/annotation/category_test.go
+++ b/manifest/v1alpha/annotation/category_test.go
@@ -16,10 +16,10 @@ func TestCategory_GoodOverTotalAnomaly(t *testing.T) {
 	assert.NotContains(t, GetUserCategories(), CategoryGoodOverTotalAnomaly)
 }
 
-func TestCategory_SLIDensityAnomalies(t *testing.T) {
+func TestCategory_SLISamplingRateAnomalies(t *testing.T) {
 	for _, expected := range []Category{
-		CategoryDensityMismatchAnomaly,
-		CategoryDensityChangeAnomaly,
+		CategorySamplingRateMismatchAnomaly,
+		CategorySamplingRateChangeAnomaly,
 	} {
 		actual, err := ParseCategory(expected.String())
 		require.NoError(t, err)

--- a/manifest/v1alpha/annotation/category_test.go
+++ b/manifest/v1alpha/annotation/category_test.go
@@ -18,7 +18,6 @@ func TestCategory_GoodOverTotalAnomaly(t *testing.T) {
 
 func TestCategory_SLIDensityAnomalies(t *testing.T) {
 	for _, expected := range []Category{
-		CategoryMissingPairAnomaly,
 		CategoryDensityMismatchAnomaly,
 		CategoryDensityChangeAnomaly,
 	} {


### PR DESCRIPTION
Add `SamplingRateMismatchAnomaly` and `SamplingRateChangeAnomaly` as typed system annotation categories. Code, generated enums, and tests use the same sampling rate terminology as the API and UI.

Annotation tests and `make check/generate` pass. Platform-backed e2e tests were not run.

## Release Notes

Adds typed SDK categories for Sampling rate mismatch and Sampling rate change annotations.

